### PR TITLE
Add wishlist API and sync frontend hook

### DIFF
--- a/app/Http/Controllers/Api/WishlistController.php
+++ b/app/Http/Controllers/Api/WishlistController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Product;
+use App\Models\Wishlist;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class WishlistController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth:sanctum');
+    }
+
+    public function index(Request $request): JsonResponse
+    {
+        $items = Wishlist::query()
+            ->where('user_id', $request->user()->id)
+            ->with('product')
+            ->orderByDesc('wishlists.created_at')
+            ->get()
+            ->map(fn (Wishlist $wishlist) => $this->presentProduct($wishlist->product))
+            ->filter()
+            ->values();
+
+        return response()->json($items);
+    }
+
+    public function store(Request $request, Product $product): JsonResponse
+    {
+        Wishlist::query()->upsert([
+            [
+                'user_id' => $request->user()->id,
+                'product_id' => $product->id,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ], ['user_id', 'product_id'], ['updated_at']);
+
+        return response()->json($this->presentProduct($product));
+    }
+
+    public function destroy(Request $request, Product $product): JsonResponse
+    {
+        Wishlist::query()
+            ->where('user_id', $request->user()->id)
+            ->where('product_id', $product->id)
+            ->delete();
+
+        return response()->noContent();
+    }
+
+    private function presentProduct(?Product $product): ?array
+    {
+        if (!$product) {
+            return null;
+        }
+
+        return [
+            'id' => $product->id,
+            'slug' => $product->slug,
+            'name' => $product->name,
+            'price' => $product->price,
+            'preview_url' => $product->preview_url,
+        ];
+    }
+}

--- a/app/Models/Wishlist.php
+++ b/app/Models/Wishlist.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Wishlist extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['user_id', 'product_id'];
+
+    protected $casts = [
+        'user_id' => 'integer',
+        'product_id' => 'integer',
+    ];
+
+    public $incrementing = false;
+
+    protected $primaryKey = null;
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/database/migrations/2025_09_20_000000_create_wishlists_table.php
+++ b/database/migrations/2025_09_20_000000_create_wishlists_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('wishlists', function (Blueprint $table) {
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+            $table->unique(['user_id', 'product_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('wishlists');
+    }
+};

--- a/resources/js/shop/api.tsx
+++ b/resources/js/shop/api.tsx
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { normalizeLang } from './i18n/config';
+import type { WishItem } from './ui/wishlist';
 
 const API_BASE =
     (import.meta as any).env?.VITE_API_URL ||
@@ -172,6 +173,22 @@ export async function fetchRelatedProducts(
 export async function fetchCategories(): Promise<Category[]> {
     return CategoriesApi.list()
 }
+
+/* ==================== WISHLIST ==================== */
+
+export const WishlistApi = {
+    async list(): Promise<WishItem[]> {
+        const { data } = await api.get<WishItem[]>('/profile/wishlist');
+        return data;
+    },
+    async add(productId: number): Promise<WishItem> {
+        const { data } = await api.post<WishItem>(`/profile/wishlist/${encodeURIComponent(productId)}`);
+        return data;
+    },
+    async remove(productId: number): Promise<void> {
+        await api.delete(`/profile/wishlist/${encodeURIComponent(productId)}`);
+    },
+};
 
 /* ==================== CART ==================== */
 let activeCartId: string | null = null

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,7 +5,8 @@ use App\Http\Controllers\Api\{CategoryController,
     PaymentController,
     ProductController,
     CartController,
-    OrderController};
+    OrderController,
+    WishlistController};
 
 //Categories
 Route::get('categories', [CategoryController::class,'index']);
@@ -28,3 +29,9 @@ Route::get('/orders/{number}', [OrderController::class, 'show']);
 
 Route::post('/payments/intent', [PaymentController::class, 'intent']);
 Route::post('/payment/refresh/{number}', [PaymentController::class, 'refreshStatus']);
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::get('profile/wishlist', [WishlistController::class, 'index']);
+    Route::post('profile/wishlist/{product}', [WishlistController::class, 'store']);
+    Route::delete('profile/wishlist/{product}', [WishlistController::class, 'destroy']);
+});


### PR DESCRIPTION
## Summary
- add a wishlists table and Eloquent model
- expose Sanctum-protected profile wishlist API endpoints
- sync the shop wishlist hook with the backend API

## Testing
- php artisan test *(warnings: missing .env for some feature tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c902b7b2808331a01974f6d43089c4