### PR TITLE
Add product reviews API and moderation

### DIFF
--- a/app/Filament/Mine/Resources/Reviews/Pages/EditReview.php
+++ b/app/Filament/Mine/Resources/Reviews/Pages/EditReview.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Reviews\Pages;
+
+use App\Filament\Mine\Resources\Reviews\ReviewResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditReview extends EditRecord
+{
+    protected static string $resource = ReviewResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Mine/Resources/Reviews/Pages/ListReviews.php
+++ b/app/Filament/Mine/Resources/Reviews/Pages/ListReviews.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Reviews\Pages;
+
+use App\Filament\Mine\Resources\Reviews\ReviewResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListReviews extends ListRecords
+{
+    protected static string $resource = ReviewResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Mine/Resources/Reviews/ReviewResource.php
+++ b/app/Filament/Mine/Resources/Reviews/ReviewResource.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Reviews;
+
+use App\Filament\Mine\Resources\Reviews\Pages\EditReview;
+use App\Filament\Mine\Resources\Reviews\Pages\ListReviews;
+use App\Filament\Mine\Resources\Reviews\Schemas\ReviewForm;
+use App\Filament\Mine\Resources\Reviews\Tables\ReviewsTable;
+use App\Models\Review;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Table;
+
+class ReviewResource extends Resource
+{
+    protected static ?string $model = Review::class;
+
+    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-chat-bubble-left-right';
+
+    protected static ?string $recordTitleAttribute = 'id';
+
+    protected static string|null|\UnitEnum $navigationGroup = 'Content';
+    protected static bool $shouldRegisterNavigation = true;
+
+    public static function form(Schema $schema): Schema
+    {
+        return ReviewForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return ReviewsTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListReviews::route('/'),
+            'edit' => EditReview::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        $pending = Review::query()
+            ->where('status', Review::STATUS_PENDING)
+            ->count();
+
+        return $pending > 0 ? (string) $pending : null;
+    }
+}

--- a/app/Filament/Mine/Resources/Reviews/Schemas/ReviewForm.php
+++ b/app/Filament/Mine/Resources/Reviews/Schemas/ReviewForm.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Reviews\Schemas;
+
+use App\Models\Review;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Schema;
+
+class ReviewForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Select::make('product_id')
+                    ->label('Product')
+                    ->relationship('product', 'name')
+                    ->searchable()
+                    ->preload()
+                    ->disabled()
+                    ->dehydrated(false),
+
+                Select::make('user_id')
+                    ->label('User')
+                    ->relationship('user', 'email')
+                    ->searchable()
+                    ->preload()
+                    ->disabled()
+                    ->dehydrated(false),
+
+                TextInput::make('rating')
+                    ->label('Rating')
+                    ->numeric()
+                    ->disabled()
+                    ->dehydrated(false),
+
+                Select::make('status')
+                    ->label('Status')
+                    ->options([
+                        Review::STATUS_PENDING => 'Pending',
+                        Review::STATUS_APPROVED => 'Approved',
+                        Review::STATUS_REJECTED => 'Rejected',
+                    ])
+                    ->required(),
+
+                Textarea::make('text')
+                    ->label('Review text')
+                    ->rows(6)
+                    ->columnSpanFull(),
+            ])
+            ->columns(2);
+    }
+}

--- a/app/Filament/Mine/Resources/Reviews/Tables/ReviewsTable.php
+++ b/app/Filament/Mine/Resources/Reviews/Tables/ReviewsTable.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Reviews\Tables;
+
+use App\Models\Review;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class ReviewsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->query(fn (): Builder => Review::query()->with(['product', 'user']))
+            ->columns([
+                TextColumn::make('product.name')
+                    ->label('Product')
+                    ->sortable()
+                    ->searchable(),
+
+                TextColumn::make('user.email')
+                    ->label('User')
+                    ->sortable()
+                    ->searchable()
+                    ->formatStateUsing(fn (?string $state) => $state ?? '—'),
+
+                TextColumn::make('rating')
+                    ->label('Rating')
+                    ->numeric()
+                    ->sortable(),
+
+                TextColumn::make('status')
+                    ->label('Status')
+                    ->badge()
+                    ->sortable()
+                    ->formatStateUsing(fn (string $state) => ucfirst($state))
+                    ->color(fn (Review $record) => match ($record->status) {
+                        Review::STATUS_APPROVED => 'success',
+                        Review::STATUS_REJECTED => 'danger',
+                        default => 'warning',
+                    }),
+
+                TextColumn::make('created_at')
+                    ->label('Created')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->label('Status')
+                    ->options([
+                        Review::STATUS_PENDING => 'Pending',
+                        Review::STATUS_APPROVED => 'Approved',
+                        Review::STATUS_REJECTED => 'Rejected',
+                    ]),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+}

--- a/app/Http/Controllers/Api/ReviewController.php
+++ b/app/Http/Controllers/Api/ReviewController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Product;
+use App\Models\Review;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ReviewController extends Controller
+{
+    public function index(int $id): JsonResponse
+    {
+        $product = Product::query()->findOrFail($id);
+
+        $reviews = $product->reviews()
+            ->approved()
+            ->with(['user:id,name'])
+            ->orderByDesc('created_at')
+            ->get();
+
+        return response()->json([
+            'data' => $reviews,
+            'average_rating' => $product->rating,
+            'reviews_count' => $product->reviews_count,
+        ]);
+    }
+
+    public function store(Request $request, int $id): JsonResponse
+    {
+        $product = Product::query()->findOrFail($id);
+
+        $user = $request->user();
+
+        abort_if($user === null, 401);
+
+        $validated = $request->validate([
+            'rating' => ['required', 'integer', 'min:1', 'max:5'],
+            'text' => ['nullable', 'string', 'max:2000'],
+        ]);
+
+        $review = $product->reviews()->create([
+            'user_id' => $user->id,
+            'rating' => $validated['rating'],
+            'text' => $validated['text'] ?? null,
+            'status' => Review::STATUS_PENDING,
+        ]);
+
+        return response()->json([
+            'data' => $review->load('user:id,name'),
+            'message' => 'Review submitted for moderation.',
+        ], 201);
+    }
+}

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Review extends Model
+{
+    use HasFactory;
+
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_APPROVED = 'approved';
+    public const STATUS_REJECTED = 'rejected';
+
+    protected $fillable = [
+        'product_id',
+        'user_id',
+        'rating',
+        'text',
+        'status',
+    ];
+
+    protected $casts = [
+        'rating' => 'integer',
+    ];
+
+    protected static function booted(): void
+    {
+        $syncProductRating = function (Review $review): void {
+            if ($product = $review->product) {
+                $product->refreshRating();
+            }
+        };
+
+        static::saved($syncProductRating);
+        static::deleted($syncProductRating);
+    }
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function scopeApproved(Builder $query): Builder
+    {
+        return $query->where('status', self::STATUS_APPROVED);
+    }
+}

--- a/database/migrations/2025_10_01_120000_create_reviews_table.php
+++ b/database/migrations/2025_10_01_120000_create_reviews_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('reviews', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->unsignedTinyInteger('rating');
+            $table->text('text')->nullable();
+            $table->string('status', 32)->default('pending');
+            $table->timestamps();
+
+            $table->index(['product_id', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('reviews');
+    }
+};

--- a/database/migrations/2025_10_01_121000_add_rating_columns_to_products_table.php
+++ b/database/migrations/2025_10_01_121000_add_rating_columns_to_products_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->unsignedInteger('reviews_count')->default(0)->after('is_active');
+            $table->decimal('rating', 3, 2)->nullable()->after('reviews_count');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn(['reviews_count', 'rating']);
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\{CategoryController,
     ProductController,
     CartController,
     OrderController,
+    ReviewController,
     WishlistController};
 
 //Categories
@@ -15,6 +16,8 @@ Route::get('categories', [CategoryController::class,'index']);
 Route::get('products', [ProductController::class, 'index']);
 Route::get('products/facets', [ProductController::class, 'facets']);
 Route::get('products/{slug}', [ProductController::class, 'show']);
+Route::get('products/{id}/reviews', [ReviewController::class, 'index']);
+Route::middleware('auth:sanctum')->post('products/{id}/reviews', [ReviewController::class, 'store']);
 
 // Cart
 Route::get('cart', [CartController::class, 'getOrCreate']);


### PR DESCRIPTION
## Summary
- add database support and model for product reviews with rating sync on products
- expose product review API endpoints for reading and submitting reviews
- add a Filament moderation resource to manage review statuses

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68c9068b7f548331b639ee3a9f9717b0