### PR TITLE
Add addresses and shipments support for orders

### DIFF
--- a/app/Enums/ShipmentStatus.php
+++ b/app/Enums/ShipmentStatus.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Enums;
+
+enum ShipmentStatus: string
+{
+    case Pending = 'pending';
+    case Processing = 'processing';
+    case Shipped = 'shipped';
+    case Delivered = 'delivered';
+    case Cancelled = 'cancelled';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Pending => 'Pending',
+            self::Processing => 'Processing',
+            self::Shipped => 'Shipped',
+            self::Delivered => 'Delivered',
+            self::Cancelled => 'Cancelled',
+        };
+    }
+
+    public function badgeColor(): string
+    {
+        return match ($this) {
+            self::Pending => 'gray',
+            self::Processing => 'warning',
+            self::Shipped => 'info',
+            self::Delivered => 'success',
+            self::Cancelled => 'danger',
+        };
+    }
+}

--- a/app/Filament/Mine/Resources/Orders/Pages/CreateOrder.php
+++ b/app/Filament/Mine/Resources/Orders/Pages/CreateOrder.php
@@ -2,18 +2,24 @@
 
 namespace App\Filament\Mine\Resources\Orders\Pages;
 
+use App\Enums\ShipmentStatus;
 use App\Filament\Mine\Resources\Orders\OrderResource;
+use App\Models\Address;
 use App\Models\Order;
-use App\Models\User;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateOrder extends CreateRecord
 {
     protected static string $resource = OrderResource::class;
 
+    protected array $shipmentFormData = [];
+
     protected function mutateFormDataBeforeCreate(array $data): array
     {
+        $this->shipmentFormData = $this->extractShipmentFormData($data);
 
+        $data['shipping_address_id'] = $this->createShippingAddress($data);
+        $data['shipping_address'] = $this->normalizeAddressPayload($data['shipping_address'] ?? []);
         $data['total']  = $data['total'] ?? 0;
         $data['number'] = $data['number'] ?? app(Order::class)->makeOrderNumber();
 
@@ -28,5 +34,74 @@ class CreateOrder extends CreateRecord
     protected function afterCreate(): void
     {
         $this->record->recalculateTotal();
+
+        $this->record->shipment()->updateOrCreate([], $this->buildShipmentPayload());
+    }
+
+    protected function extractShipmentFormData(array &$data): array
+    {
+        $shipment = [
+            'tracking_number' => $data['shipment_tracking_number'] ?? null,
+            'status' => $data['shipment_status'] ?? ShipmentStatus::Pending->value,
+        ];
+
+        unset($data['shipment_tracking_number'], $data['shipment_status']);
+
+        return $shipment;
+    }
+
+    protected function createShippingAddress(array $data): ?int
+    {
+        $payload = $this->normalizeAddressPayload($data['shipping_address'] ?? []);
+
+        if (empty(array_filter($payload, fn ($value) => !is_null($value) && $value !== ''))) {
+            return null;
+        }
+
+        $address = Address::create(array_merge([
+            'user_id' => $data['user_id'] ?? null,
+        ], $payload));
+
+        return $address->id;
+    }
+
+    protected function normalizeAddressPayload(array $address): array
+    {
+        return [
+            'name' => $address['name'] ?? null,
+            'city' => $address['city'] ?? null,
+            'addr' => $address['addr'] ?? null,
+            'postal_code' => $address['postal_code'] ?? null,
+            'phone' => $address['phone'] ?? null,
+        ];
+    }
+
+    protected function buildShipmentPayload(): array
+    {
+        $statusValue = $this->shipmentFormData['status'] ?? ShipmentStatus::Pending->value;
+        $status = $statusValue instanceof ShipmentStatus
+            ? $statusValue
+            : ShipmentStatus::from($statusValue);
+
+        $payload = [
+            'address_id' => $this->record->shipping_address_id,
+            'tracking_number' => $this->shipmentFormData['tracking_number'] ?? null,
+            'status' => $status,
+        ];
+
+        return match ($status) {
+            ShipmentStatus::Shipped => $payload + [
+                'shipped_at' => now(),
+                'delivered_at' => null,
+            ],
+            ShipmentStatus::Delivered => $payload + [
+                'shipped_at' => now(),
+                'delivered_at' => now(),
+            ],
+            default => $payload + [
+                'shipped_at' => null,
+                'delivered_at' => null,
+            ],
+        };
     }
 }

--- a/app/Filament/Mine/Resources/Orders/Pages/EditOrder.php
+++ b/app/Filament/Mine/Resources/Orders/Pages/EditOrder.php
@@ -2,7 +2,10 @@
 
 namespace App\Filament\Mine\Resources\Orders\Pages;
 
+use App\Enums\ShipmentStatus;
 use App\Filament\Mine\Resources\Orders\OrderResource;
+use App\Models\Address;
+use App\Models\Shipment;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
 use Livewire\Attributes\On;
@@ -12,6 +15,38 @@ use Filament\Actions;
 class EditOrder extends EditRecord
 {
     protected static string $resource = OrderResource::class;
+
+    protected array $shipmentFormData = [];
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $this->shipmentFormData = $this->extractShipmentFormData($data);
+
+        $payload = $this->normalizeAddressPayload($data['shipping_address'] ?? []);
+        $addressId = $this->record->shipping_address_id;
+
+        if ($addressId && $this->record->shippingAddress) {
+            $address = $this->record->shippingAddress;
+            $address->fill($payload);
+            if (array_key_exists('user_id', $data)) {
+                $address->user_id = $data['user_id'];
+            }
+            $address->save();
+            $addressId = $address->id;
+        } elseif (empty(array_filter($payload, fn ($value) => !is_null($value) && $value !== ''))) {
+            $addressId = null;
+        } else {
+            $address = Address::create(array_merge([
+                'user_id' => $data['user_id'] ?? null,
+            ], $payload));
+            $addressId = $address->id;
+        }
+
+        $data['shipping_address_id'] = $addressId;
+        $data['shipping_address'] = $payload;
+
+        return $data;
+    }
 
     protected function getHeaderActions(): array
     {
@@ -58,6 +93,7 @@ class EditOrder extends EditRecord
     protected function afterSave(): void
     {
         $this->record->recalculateTotal();
+        $this->record->shipment()->updateOrCreate([], $this->buildShipmentPayload($this->record->shipment));
         $this->record->refresh();
         $this->data['total'] = (string) $this->record->total;
     }
@@ -67,5 +103,63 @@ class EditOrder extends EditRecord
     {
         $this->record->refresh();
         $this->data['total'] = (string) ($total ?? $this->record->total);
+    }
+
+    protected function extractShipmentFormData(array &$data): array
+    {
+        $shipment = [
+            'tracking_number' => $data['shipment_tracking_number'] ?? null,
+            'status' => $data['shipment_status'] ?? null,
+        ];
+
+        unset($data['shipment_tracking_number'], $data['shipment_status']);
+
+        return $shipment;
+    }
+
+    protected function normalizeAddressPayload(array $address): array
+    {
+        return [
+            'name' => $address['name'] ?? null,
+            'city' => $address['city'] ?? null,
+            'addr' => $address['addr'] ?? null,
+            'postal_code' => $address['postal_code'] ?? null,
+            'phone' => $address['phone'] ?? null,
+        ];
+    }
+
+    protected function buildShipmentPayload(?Shipment $shipment = null): array
+    {
+        $shipment ??= $this->record->shipment;
+        $statusValue = $this->shipmentFormData['status']
+            ?? ($shipment?->status instanceof ShipmentStatus ? $shipment->status->value : ($shipment?->status ?? ShipmentStatus::Pending->value));
+
+        $status = $statusValue instanceof ShipmentStatus
+            ? $statusValue
+            : ShipmentStatus::from($statusValue);
+
+        $payload = [
+            'address_id' => $this->record->shipping_address_id,
+            'tracking_number' => $this->shipmentFormData['tracking_number'] ?? $shipment?->tracking_number,
+            'status' => $status,
+        ];
+
+        $shippedAt = $shipment?->shipped_at;
+        $deliveredAt = $shipment?->delivered_at;
+
+        return match ($status) {
+            ShipmentStatus::Shipped => $payload + [
+                'shipped_at' => $shippedAt ?? now(),
+                'delivered_at' => null,
+            ],
+            ShipmentStatus::Delivered => $payload + [
+                'shipped_at' => $shippedAt ?? now(),
+                'delivered_at' => $deliveredAt ?? now(),
+            ],
+            default => $payload + [
+                'shipped_at' => null,
+                'delivered_at' => null,
+            ],
+        };
     }
 }

--- a/app/Filament/Mine/Resources/Orders/Schemas/OrderForm.php
+++ b/app/Filament/Mine/Resources/Orders/Schemas/OrderForm.php
@@ -3,6 +3,8 @@
 namespace App\Filament\Mine\Resources\Orders\Schemas;
 
 use App\Enums\OrderStatus;
+use App\Enums\ShipmentStatus;
+use App\Models\Order;
 use App\Models\User;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
@@ -69,16 +71,41 @@ class OrderForm
                         TextInput::make('shipping_address.name')->label('Name'),
                         TextInput::make('shipping_address.city')->label('City'),
                         TextInput::make('shipping_address.addr')->label('Address'),
-                    ])->columns(3),
+                        TextInput::make('shipping_address.postal_code')->label('Postal code'),
+                        TextInput::make('shipping_address.phone')->label('Phone')->tel(),
+                    ])->columns(2),
 
                     Fieldset::make('Billing address')->schema([
                         TextInput::make('billing_address.name')->label('Name'),
                         TextInput::make('billing_address.city')->label('City'),
                         TextInput::make('billing_address.addr')->label('Address'),
-                    ])->columns(3),
+                        TextInput::make('billing_address.postal_code')->label('Postal code'),
+                        TextInput::make('billing_address.phone')->label('Phone')->tel(),
+                    ])->columns(2),
                 ])->columns(1),
 
                 TextInput::make('note')->label('Note')->columnSpanFull(),
+
+                Section::make('Shipment')->schema([
+                    TextInput::make('shipment_tracking_number')
+                        ->label('Tracking number')
+                        ->maxLength(255)
+                        ->afterStateHydrated(function (TextInput $component, ?Order $record) {
+                            $component->state($record?->shipment?->tracking_number);
+                        })
+                        ->dehydrateStateUsing(fn ($state) => blank($state) ? null : $state),
+
+                    Select::make('shipment_status')
+                        ->label('Shipment status')
+                        ->options(collect(ShipmentStatus::cases())->mapWithKeys(fn (ShipmentStatus $case) => [$case->value => $case->label()])->all())
+                        ->default(ShipmentStatus::Pending->value)
+                        ->native(false)
+                        ->afterStateHydrated(function (Select $component, ?Order $record) {
+                            $status = $record?->shipment?->status;
+                            $component->state($status instanceof ShipmentStatus ? $status->value : ($status ?: ShipmentStatus::Pending->value));
+                        })
+                        ->dehydrateStateUsing(fn ($state) => $state ?? ShipmentStatus::Pending->value),
+                ])->columns(2),
 
                 Section::make('Summary')
                     ->collapsible()

--- a/app/Http/Controllers/Api/AddressController.php
+++ b/app/Http/Controllers/Api/AddressController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Address;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AddressController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $addresses = $request->user()
+            ->addresses()
+            ->latest('id')
+            ->get();
+
+        return response()->json($addresses);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $data = $this->validateData($request);
+
+        $address = $request->user()->addresses()->create($data);
+
+        return response()->json($address, 201);
+    }
+
+    public function show(Request $request, Address $address): JsonResponse
+    {
+        $address = $this->resolveAddress($request, $address);
+
+        return response()->json($address);
+    }
+
+    public function update(Request $request, Address $address): JsonResponse
+    {
+        $address = $this->resolveAddress($request, $address);
+
+        $data = $this->validateData($request, partial: true);
+
+        if (empty($data)) {
+            return response()->json($address);
+        }
+
+        $address->update($data);
+
+        return response()->json($address);
+    }
+
+    public function destroy(Request $request, Address $address): JsonResponse
+    {
+        $address = $this->resolveAddress($request, $address);
+
+        $address->delete();
+
+        return response()->json(null, 204);
+    }
+
+    protected function resolveAddress(Request $request, Address $address): Address
+    {
+        if ($address->user_id !== $request->user()->id) {
+            abort(404);
+        }
+
+        return $address;
+    }
+
+    protected function validateData(Request $request, bool $partial = false): array
+    {
+        $rules = [
+            'name' => [$partial ? 'sometimes' : 'required', 'string', 'max:255'],
+            'city' => [$partial ? 'sometimes' : 'required', 'string', 'max:255'],
+            'addr' => [$partial ? 'sometimes' : 'required', 'string', 'max:500'],
+            'postal_code' => ['sometimes', 'nullable', 'string', 'max:32'],
+            'phone' => ['sometimes', 'nullable', 'string', 'max:32'],
+        ];
+
+        $data = $request->validate($rules);
+
+        if ($partial) {
+            $data = array_filter($data, fn ($value) => $value !== null);
+        }
+
+        return $data;
+    }
+}

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Address extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'name',
+        'city',
+        'addr',
+        'postal_code',
+        'phone',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function orders(): HasMany
+    {
+        return $this->hasMany(Order::class, 'shipping_address_id');
+    }
+
+    public function shipments(): HasMany
+    {
+        return $this->hasMany(Shipment::class);
+    }
+}

--- a/app/Models/Shipment.php
+++ b/app/Models/Shipment.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ShipmentStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Shipment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'order_id',
+        'address_id',
+        'status',
+        'tracking_number',
+        'shipped_at',
+        'delivered_at',
+    ];
+
+    protected $casts = [
+        'status' => ShipmentStatus::class,
+        'shipped_at' => 'datetime',
+        'delivered_at' => 'datetime',
+    ];
+
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    public function address(): BelongsTo
+    {
+        return $this->belongsTo(Address::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class User extends Authenticatable implements FilamentUser
 {
@@ -52,5 +53,10 @@ class User extends Authenticatable implements FilamentUser
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function addresses(): HasMany
+    {
+        return $this->hasMany(Address::class);
     }
 }

--- a/database/factories/AddressFactory.php
+++ b/database/factories/AddressFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Address;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class AddressFactory extends Factory
+{
+    protected $model = Address::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'name' => $this->faker->name(),
+            'city' => $this->faker->city(),
+            'addr' => $this->faker->streetAddress(),
+            'postal_code' => $this->faker->postcode(),
+            'phone' => $this->faker->phoneNumber(),
+        ];
+    }
+}

--- a/database/factories/OrderFactory.php
+++ b/database/factories/OrderFactory.php
@@ -3,6 +3,8 @@
 namespace Database\Factories;
 
 use App\Enums\OrderStatus;
+use App\Enums\ShipmentStatus;
+use App\Models\Address;
 use App\Models\Order;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
@@ -13,16 +15,30 @@ class OrderFactory extends Factory
 
     public function definition(): array
     {
+        $shipping = [
+            'name' => $this->faker->firstName(),
+            'city' => $this->faker->city(),
+            'addr' => $this->faker->streetAddress(),
+            'postal_code' => $this->faker->postcode(),
+            'phone' => $this->faker->phoneNumber(),
+        ];
+
         return [
             'user_id' => null, // за замовчуванням — гість
             'email'   => $this->faker->safeEmail(),
             'status'  => OrderStatus::New,            // enum каст у моделі
             'total'   => 0,
-            'shipping_address' => [
-                'name' => $this->faker->firstName(),
-                'city' => $this->faker->city(),
-                'addr' => $this->faker->streetAddress(),
-            ],
+            'shipping_address' => $shipping,
+            'shipping_address_id' => Address::factory()->state(function () use ($shipping) {
+                return [
+                    'user_id' => null,
+                    'name' => $shipping['name'],
+                    'city' => $shipping['city'],
+                    'addr' => $shipping['addr'],
+                    'postal_code' => $shipping['postal_code'],
+                    'phone' => $shipping['phone'],
+                ];
+            }),
             'billing_address' => null,
             'note'    => null,
             'number'  => 'ORD-'.now()->format('Ymd').'-'.Str::upper(Str::random(16)),
@@ -32,5 +48,17 @@ class OrderFactory extends Factory
     public function paid(): static
     {
         return $this->state(fn () => ['status' => OrderStatus::Paid]);
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (Order $order) {
+            if (! $order->shipment()->exists()) {
+                $order->shipment()->create([
+                    'address_id' => $order->shipping_address_id,
+                    'status' => ShipmentStatus::Pending,
+                ]);
+            }
+        });
     }
 }

--- a/database/migrations/2025_09_16_070141_create_addresses_table.php
+++ b/database/migrations/2025_09_16_070141_create_addresses_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('addresses', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('name');
+            $table->string('city');
+            $table->string('addr');
+            $table->string('postal_code')->nullable();
+            $table->string('phone')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('addresses');
+    }
+};

--- a/database/migrations/2025_09_16_070144_create_shipments_table.php
+++ b/database/migrations/2025_09_16_070144_create_shipments_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('shipments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('address_id')->nullable()->constrained('addresses')->nullOnDelete();
+            $table->string('status')->default('pending');
+            $table->string('tracking_number')->nullable();
+            $table->timestamp('shipped_at')->nullable();
+            $table->timestamp('delivered_at')->nullable();
+            $table->timestamps();
+
+            $table->unique('order_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('shipments');
+    }
+};

--- a/database/migrations/2025_09_16_070146_add_shipping_address_id_to_orders_table.php
+++ b/database/migrations/2025_09_16_070146_add_shipping_address_id_to_orders_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            if (! Schema::hasColumn('orders', 'shipping_address_id')) {
+                $table->foreignId('shipping_address_id')
+                    ->nullable()
+                    ->after('total')
+                    ->constrained('addresses')
+                    ->nullOnDelete();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            if (Schema::hasColumn('orders', 'shipping_address_id')) {
+                $table->dropConstrainedForeignId('shipping_address_id');
+            }
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,7 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\Api\{CategoryController,
+use App\Http\Controllers\Api\{AddressController,
+    CategoryController,
     PaymentController,
     ProductController,
     CartController,
@@ -34,6 +35,7 @@ Route::post('/payments/intent', [PaymentController::class, 'intent']);
 Route::post('/payment/refresh/{number}', [PaymentController::class, 'refreshStatus']);
 
 Route::middleware('auth:sanctum')->group(function () {
+    Route::apiResource('profile/addresses', AddressController::class);
     Route::get('profile/wishlist', [WishlistController::class, 'index']);
     Route::post('profile/wishlist/{product}', [WishlistController::class, 'store']);
     Route::delete('profile/wishlist/{product}', [WishlistController::class, 'destroy']);

--- a/tests/Feature/OrderFlowTest.php
+++ b/tests/Feature/OrderFlowTest.php
@@ -1,8 +1,7 @@
 <?php
 
-use App\Models\Cart;
-use App\Models\CartItem;
-use App\Models\Product;
+use App\Enums\ShipmentStatus;
+use App\Models\{Address, Cart, CartItem, Order, Product, Shipment};
 
 it('creates order from cart', function () {
 
@@ -26,5 +25,18 @@ it('creates order from cart', function () {
         'shipping_address' => ['name' => 'John', 'city' => 'Kyiv', 'addr' => 'Street 1'],
     ];
 
-    $this->postJson('/api/orders', $payload)->assertCreated();
+    $response = $this->postJson('/api/orders', $payload)->assertCreated();
+
+    $order = Order::with(['shipment', 'shippingAddress'])->first();
+
+    expect($order)->not->toBeNull();
+    expect($order->shipping_address_id)->not->toBeNull();
+    expect($order->shipment)->not->toBeNull();
+    expect($order->shipment->status)->toBeInstanceOf(ShipmentStatus::class);
+    expect($order->shipment->status->value)->toBe(ShipmentStatus::Pending->value);
+
+    expect(Address::count())->toBe(1);
+    expect(Shipment::count())->toBe(1);
+
+    $response->assertJsonPath('shipment.status', 'pending');
 });

--- a/tests/Feature/ProductsApiTest.php
+++ b/tests/Feature/ProductsApiTest.php
@@ -42,5 +42,6 @@ it('creates order from cart flow (smoke)', function () {
 
     $this->postJson('/api/orders', $payload)
         ->assertCreated()
-        ->assertJsonPath('items.0.product_id', $product->id);
+        ->assertJsonPath('items.0.product_id', $product->id)
+        ->assertJsonPath('shipment.status', 'pending');
 });

--- a/tests/Feature/ProfileAddressesTest.php
+++ b/tests/Feature/ProfileAddressesTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Models\Address;
+use App\Models\User;
+
+beforeEach(function () {
+    config(['auth.guards.sanctum' => [
+        'driver' => 'session',
+        'provider' => 'users',
+    ]]);
+});
+
+it('lists only current user addresses', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    Address::factory()->count(2)->create(['user_id' => $user->id]);
+    Address::factory()->create(['user_id' => $other->id]);
+
+    $this->actingAs($user, 'sanctum');
+
+    $response = $this->getJson('/api/profile/addresses')
+        ->assertOk()
+        ->json();
+
+    expect($response)->toHaveCount(2);
+    expect(collect($response)->pluck('user_id')->unique()->all())->toBe([$user->id]);
+});
+
+it('creates a new address', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user, 'sanctum');
+
+    $payload = [
+        'name' => 'John Doe',
+        'city' => 'Kyiv',
+        'addr' => 'Street 1',
+        'postal_code' => '01001',
+        'phone' => '+3801234567',
+    ];
+
+    $response = $this->postJson('/api/profile/addresses', $payload)
+        ->assertCreated();
+
+    $response->assertJsonFragment(['name' => 'John Doe']);
+    expect(Address::where('user_id', $user->id)->count())->toBe(1);
+});
+
+it('updates an address', function () {
+    $user = User::factory()->create();
+    $address = Address::factory()->create(['user_id' => $user->id, 'city' => 'Kyiv']);
+
+    $this->actingAs($user, 'sanctum');
+
+    $this->patchJson("/api/profile/addresses/{$address->id}", [
+        'city' => 'Lviv',
+    ])->assertOk()
+      ->assertJsonFragment(['city' => 'Lviv']);
+
+    expect($address->refresh()->city)->toBe('Lviv');
+});
+
+it('deletes an address', function () {
+    $user = User::factory()->create();
+    $address = Address::factory()->create(['user_id' => $user->id]);
+
+    $this->actingAs($user, 'sanctum');
+
+    $this->deleteJson("/api/profile/addresses/{$address->id}")
+        ->assertNoContent();
+
+    expect(Address::whereKey($address->id)->exists())->toBeFalse();
+});
+
+it('does not allow managing addresses of other users', function () {
+    $user = User::factory()->create();
+    $other = Address::factory()->create();
+
+    $this->actingAs($user, 'sanctum');
+
+    $this->getJson("/api/profile/addresses/{$other->id}")->assertNotFound();
+    $this->patchJson("/api/profile/addresses/{$other->id}", ['city' => 'Dnipro'])->assertNotFound();
+    $this->deleteJson("/api/profile/addresses/{$other->id}")->assertNotFound();
+});


### PR DESCRIPTION
## Summary
- Introduced address and shipment persistence with dedicated models, factories, enum, and schema updates. 【F:app/Models/Address.php†L1-L36】【F:app/Models/Shipment.php†L1-L38】【F:app/Enums/ShipmentStatus.php†L5-L34】【F:database/migrations/2025_09_16_070141_create_addresses_table.php†L12-L23】【F:database/migrations/2025_09_16_070144_create_shipments_table.php†L12-L25】【F:database/migrations/2025_09_16_070146_add_shipping_address_id_to_orders_table.php†L12-L35】
- Updated order flows to save shipping addresses, create shipments, and exposed profile address CRUD endpoints. 【F:app/Http/Controllers/Api/OrderController.php†L15-L99】【F:app/Http/Controllers/Api/AddressController.php†L10-L88】【F:routes/api.php†L4-L41】【F:app/Models/Order.php†L20-L252】【F:app/Models/User.php†L58-L61】
- Enhanced Filament order management with shipment fields, address syncing, and tracking controls. 【F:app/Filament/Mine/Resources/Orders/Schemas/OrderForm.php†L22-L118】【F:app/Filament/Mine/Resources/Orders/Pages/CreateOrder.php†L11-L106】【F:app/Filament/Mine/Resources/Orders/Pages/EditOrder.php†L15-L165】
- Added automated coverage for shipment handling and profile address APIs. 【F:tests/Feature/OrderFlowTest.php†L1-L42】【F:tests/Feature/ProductsApiTest.php†L22-L46】【F:tests/Feature/ProfileAddressesTest.php†L6-L84】

## Testing
- php artisan test 【2bb49c†L1-L24】

------
https://chatgpt.com/codex/tasks/task_e_68c90a2365648331bd67e303d3de88df