### PR TITLE
Add coupons and loyalty points support

### DIFF
--- a/app/Data/CartTotals.php
+++ b/app/Data/CartTotals.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\Coupon;
+
+class CartTotals
+{
+    public function __construct(
+        public float $subtotal,
+        public float $couponDiscount,
+        public ?Coupon $coupon,
+        public ?string $couponCode,
+        public int $pointsUsed,
+        public float $pointsValue,
+        public float $total,
+        public int $availablePoints,
+        public int $maxRedeemablePoints,
+    ) {
+    }
+
+    public function discountTotal(): float
+    {
+        return round($this->couponDiscount + $this->pointsValue, 2);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'subtotal' => $this->subtotal,
+            'coupon_discount' => $this->couponDiscount,
+            'coupon_code' => $this->couponCode,
+            'loyalty_points_used' => $this->pointsUsed,
+            'loyalty_points_value' => $this->pointsValue,
+            'discount_total' => $this->discountTotal(),
+            'total' => $this->total,
+            'available_points' => $this->availablePoints,
+            'max_redeemable_points' => $this->maxRedeemablePoints,
+        ];
+    }
+}

--- a/app/Filament/Mine/Resources/Coupons/CouponResource.php
+++ b/app/Filament/Mine/Resources/Coupons/CouponResource.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Coupons;
+
+use App\Filament\Mine\Resources\Coupons\Pages\CreateCoupon;
+use App\Filament\Mine\Resources\Coupons\Pages\EditCoupon;
+use App\Filament\Mine\Resources\Coupons\Pages\ListCoupons;
+use App\Filament\Mine\Resources\Coupons\Schemas\CouponForm;
+use App\Filament\Mine\Resources\Coupons\Tables\CouponsTable;
+use App\Models\Coupon;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class CouponResource extends Resource
+{
+    protected static ?string $model = Coupon::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedTicket;
+    protected static string|null|\UnitEnum $navigationGroup = 'Marketing';
+    protected static ?string $recordTitleAttribute = 'code';
+    protected static bool $shouldRegisterNavigation = true;
+
+    public static function form(Schema $schema): Schema
+    {
+        return CouponForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return CouponsTable::configure($table);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListCoupons::route('/'),
+            'create' => CreateCoupon::route('/create'),
+            'edit' => EditCoupon::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) Coupon::count();
+    }
+}

--- a/app/Filament/Mine/Resources/Coupons/Pages/CreateCoupon.php
+++ b/app/Filament/Mine/Resources/Coupons/Pages/CreateCoupon.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Coupons\Pages;
+
+use App\Filament\Mine\Resources\Coupons\CouponResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateCoupon extends CreateRecord
+{
+    protected static string $resource = CouponResource::class;
+}

--- a/app/Filament/Mine/Resources/Coupons/Pages/EditCoupon.php
+++ b/app/Filament/Mine/Resources/Coupons/Pages/EditCoupon.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Coupons\Pages;
+
+use App\Filament\Mine\Resources\Coupons\CouponResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditCoupon extends EditRecord
+{
+    protected static string $resource = CouponResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Mine/Resources/Coupons/Pages/ListCoupons.php
+++ b/app/Filament/Mine/Resources/Coupons/Pages/ListCoupons.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Coupons\Pages;
+
+use App\Filament\Mine\Resources\Coupons\CouponResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListCoupons extends ListRecords
+{
+    protected static string $resource = CouponResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Mine/Resources/Coupons/Schemas/CouponForm.php
+++ b/app/Filament/Mine/Resources/Coupons/Schemas/CouponForm.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Coupons\Schemas;
+
+use App\Models\Coupon;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Components\Select;
+use Filament\Schemas\Schema;
+
+class CouponForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema->components([
+            TextInput::make('code')
+                ->required()
+                ->unique(ignoreRecord: true)
+                ->maxLength(64)
+                ->helperText('Unique coupon code customers will enter.'),
+            TextInput::make('name')
+                ->maxLength(255),
+            Textarea::make('description')
+                ->rows(3)
+                ->columnSpanFull(),
+            Select::make('type')
+                ->required()
+                ->options([
+                    Coupon::TYPE_FIXED => 'Fixed amount',
+                    Coupon::TYPE_PERCENT => 'Percentage',
+                ])
+                ->native(false),
+            TextInput::make('value')
+                ->required()
+                ->numeric()
+                ->prefix(fn ($state, callable $get) => $get('type') === Coupon::TYPE_PERCENT ? '%' : '₴'),
+            TextInput::make('min_cart_total')
+                ->numeric()
+                ->default(0)
+                ->prefix('₴'),
+            TextInput::make('max_discount')
+                ->numeric()
+                ->prefix('₴'),
+            TextInput::make('usage_limit')
+                ->numeric()
+                ->minValue(0)
+                ->label('Total usage limit'),
+            TextInput::make('per_user_limit')
+                ->numeric()
+                ->minValue(0)
+                ->label('Per user limit'),
+            DateTimePicker::make('starts_at')
+                ->seconds(false)
+                ->label('Starts at'),
+            DateTimePicker::make('expires_at')
+                ->seconds(false)
+                ->label('Expires at'),
+            Toggle::make('is_active')
+                ->default(true)
+                ->label('Active'),
+        ])->columns(2);
+    }
+}

--- a/app/Filament/Mine/Resources/Coupons/Tables/CouponsTable.php
+++ b/app/Filament/Mine/Resources/Coupons/Tables/CouponsTable.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Coupons\Tables;
+
+use App\Models\Coupon;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\TernaryFilter;
+use Filament\Tables\Table;
+
+class CouponsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->defaultSort('created_at', 'desc')
+            ->columns([
+                TextColumn::make('code')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('type')
+                    ->label('Type')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state) => ucfirst($state))
+                    ->sortable(),
+                TextColumn::make('value')
+                    ->label('Value')
+                    ->state(function (Coupon $record) {
+                        return $record->type === Coupon::TYPE_PERCENT
+                            ? number_format((float) $record->value, 2) . '%'
+                            : '₴ ' . number_format((float) $record->value, 2);
+                    }),
+                TextColumn::make('min_cart_total')
+                    ->label('Min cart')
+                    ->state(fn (Coupon $record) => '₴ ' . number_format((float) $record->min_cart_total, 2))
+                    ->toggleable(),
+                TextColumn::make('usage_limit')
+                    ->label('Usage')
+                    ->state(fn (Coupon $record) => $record->usage_limit
+                        ? sprintf('%d / %d', $record->used, $record->usage_limit)
+                        : (string) $record->used)
+                    ->toggleable(),
+                IconColumn::make('is_active')
+                    ->label('Active')
+                    ->boolean(),
+                TextColumn::make('starts_at')
+                    ->dateTime()
+                    ->toggleable(),
+                TextColumn::make('expires_at')
+                    ->dateTime()
+                    ->toggleable(),
+                TextColumn::make('updated_at')
+                    ->since()
+                    ->toggleable(),
+            ])
+            ->filters([
+                TernaryFilter::make('is_active')
+                    ->label('Active')
+                    ->true(fn ($query) => $query->where('is_active', true))
+                    ->false(fn ($query) => $query->where('is_active', false)),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ]);
+    }
+}

--- a/app/Filament/Mine/Resources/Users/Pages/ListUsers.php
+++ b/app/Filament/Mine/Resources/Users/Pages/ListUsers.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Users\Pages;
+
+use App\Filament\Mine\Resources\Users\UserResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListUsers extends ListRecords
+{
+    protected static string $resource = UserResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Mine/Resources/Users/Pages/ViewUser.php
+++ b/app/Filament/Mine/Resources/Users/Pages/ViewUser.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Users\Pages;
+
+use App\Filament\Mine\Resources\Users\UserResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewUser extends ViewRecord
+{
+    protected static string $resource = UserResource::class;
+}

--- a/app/Filament/Mine/Resources/Users/RelationManagers/LoyaltyPointTransactionsRelationManager.php
+++ b/app/Filament/Mine/Resources/Users/RelationManagers/LoyaltyPointTransactionsRelationManager.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Users\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class LoyaltyPointTransactionsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'loyaltyPointTransactions';
+    protected static ?string $recordTitleAttribute = 'description';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('created_at', 'desc')
+            ->columns([
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable(),
+                TextColumn::make('type')
+                    ->label('Type')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state) => ucfirst($state)),
+                TextColumn::make('points')
+                    ->label('Points')
+                    ->state(fn ($record) => (int) $record->points),
+                TextColumn::make('amount')
+                    ->label('Amount')
+                    ->state(fn ($record) => '₴ ' . number_format((float) $record->amount, 2))
+                    ->toggleable(),
+                TextColumn::make('description')
+                    ->wrap()
+                    ->toggleable(),
+            ])
+            ->headerActions([])
+            ->actions([])
+            ->bulkActions([]);
+    }
+
+    protected function canCreate(): bool
+    {
+        return false;
+    }
+
+    protected function canEdit(mixed $record): bool
+    {
+        return false;
+    }
+
+    protected function canDelete(mixed $record): bool
+    {
+        return false;
+    }
+}

--- a/app/Filament/Mine/Resources/Users/Tables/UsersTable.php
+++ b/app/Filament/Mine/Resources/Users/Tables/UsersTable.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Users\Tables;
+
+use App\Models\User;
+use Filament\Tables\Actions\ViewAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class UsersTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->defaultSort('created_at', 'desc')
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('email')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('loyalty_points_balance')
+                    ->label('Points balance')
+                    ->state(fn (User $record) => (int) ($record->loyalty_points_balance ?? 0))
+                    ->sortable(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->recordActions([
+                ViewAction::make(),
+            ]);
+    }
+}

--- a/app/Filament/Mine/Resources/Users/UserResource.php
+++ b/app/Filament/Mine/Resources/Users/UserResource.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Users;
+
+use App\Filament\Mine\Resources\Users\Pages\ListUsers;
+use App\Filament\Mine\Resources\Users\Pages\ViewUser;
+use App\Filament\Mine\Resources\Users\RelationManagers\LoyaltyPointTransactionsRelationManager;
+use App\Filament\Mine\Resources\Users\Tables\UsersTable;
+use App\Models\User;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class UserResource extends Resource
+{
+    protected static ?string $model = User::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedUsers;
+    protected static string|null|\UnitEnum $navigationGroup = 'Customers';
+    protected static ?string $recordTitleAttribute = 'name';
+    protected static bool $shouldRegisterNavigation = true;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema;
+    }
+
+    public static function table(Table $table): Table
+    {
+        return UsersTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            LoyaltyPointTransactionsRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListUsers::route('/'),
+            'view' => ViewUser::route('/{record}'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withSum('loyaltyPointTransactions as loyalty_points_balance', 'points');
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) User::count();
+    }
+}

--- a/app/Models/Cart.php
+++ b/app/Models/Cart.php
@@ -5,7 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Cart extends Model
@@ -15,8 +15,12 @@ class Cart extends Model
     public $incrementing = false;
     protected $keyType = 'string';
 
-    protected $fillable = ['user_id', 'status'];
-    protected $attributes = ['status' => 'active'];
+    protected $fillable = ['user_id', 'status', 'coupon_id', 'coupon_code', 'loyalty_points_used'];
+    protected $attributes = ['status' => 'active', 'loyalty_points_used' => 0];
+
+    protected $casts = [
+        'loyalty_points_used' => 'integer',
+    ];
 
 //    protected static function booted(): void
 //    {
@@ -27,6 +31,16 @@ class Cart extends Model
 //            $m->status ??= 'active';
 //        });
 //    }
+
+    public function coupon(): BelongsTo
+    {
+        return $this->belongsTo(Coupon::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
 
     public function items(): HasMany
     {

--- a/app/Models/Coupon.php
+++ b/app/Models/Coupon.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\OrderStatus;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+
+class Coupon extends Model
+{
+    use HasFactory;
+
+    public const TYPE_FIXED = 'fixed';
+    public const TYPE_PERCENT = 'percent';
+
+    protected $fillable = [
+        'code',
+        'name',
+        'description',
+        'type',
+        'value',
+        'min_cart_total',
+        'max_discount',
+        'usage_limit',
+        'per_user_limit',
+        'used',
+        'starts_at',
+        'expires_at',
+        'is_active',
+        'meta',
+    ];
+
+    protected $casts = [
+        'value' => 'decimal:2',
+        'min_cart_total' => 'decimal:2',
+        'max_discount' => 'decimal:2',
+        'usage_limit' => 'integer',
+        'per_user_limit' => 'integer',
+        'used' => 'integer',
+        'starts_at' => 'datetime',
+        'expires_at' => 'datetime',
+        'is_active' => 'boolean',
+        'meta' => 'array',
+    ];
+
+    public function scopeActive(Builder $builder): Builder
+    {
+        $now = Carbon::now();
+
+        return $builder
+            ->where('is_active', true)
+            ->where(function (Builder $query) use ($now) {
+                $query->whereNull('starts_at')->orWhere('starts_at', '<=', $now);
+            })
+            ->where(function (Builder $query) use ($now) {
+                $query->whereNull('expires_at')->orWhere('expires_at', '>=', $now);
+            });
+    }
+
+    public function orders(): HasMany
+    {
+        return $this->hasMany(Order::class);
+    }
+
+    public function isCurrentlyActive(): bool
+    {
+        if (!$this->is_active) {
+            return false;
+        }
+
+        $now = Carbon::now();
+
+        if ($this->starts_at && $now->lt($this->starts_at)) {
+            return false;
+        }
+
+        if ($this->expires_at && $now->gt($this->expires_at)) {
+            return false;
+        }
+
+        if ($this->usage_limit !== null && $this->used >= $this->usage_limit) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function calculateDiscount(float $subtotal): float
+    {
+        $subtotal = max($subtotal, 0);
+
+        $discount = match ($this->type) {
+            self::TYPE_PERCENT => $subtotal * ((float) $this->value / 100),
+            default => (float) $this->value,
+        };
+
+        if ($this->max_discount !== null) {
+            $discount = min($discount, (float) $this->max_discount);
+        }
+
+        return min($discount, $subtotal);
+    }
+
+    public function remainingUses(): ?int
+    {
+        if ($this->usage_limit === null) {
+            return null;
+        }
+
+        return max(0, $this->usage_limit - $this->used);
+    }
+
+    public function usageCountForUser(?User $user): int
+    {
+        if (!$user) {
+            return 0;
+        }
+
+        return (int) $this->orders()
+            ->where('user_id', $user->id)
+            ->where('status', '!=', OrderStatus::Cancelled->value)
+            ->count();
+    }
+}

--- a/app/Models/LoyaltyPointTransaction.php
+++ b/app/Models/LoyaltyPointTransaction.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class LoyaltyPointTransaction extends Model
+{
+    use HasFactory;
+
+    public const TYPE_EARN = 'earn';
+    public const TYPE_REDEEM = 'redeem';
+    public const TYPE_ADJUST = 'adjustment';
+
+    protected $fillable = [
+        'user_id',
+        'order_id',
+        'type',
+        'points',
+        'amount',
+        'description',
+        'meta',
+    ];
+
+    protected $casts = [
+        'points' => 'integer',
+        'amount' => 'decimal:2',
+        'meta' => 'array',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -55,6 +55,30 @@ class User extends Authenticatable implements FilamentUser
         ];
     }
 
+    public function loyaltyPointTransactions(): HasMany
+    {
+        return $this->hasMany(LoyaltyPointTransaction::class);
+    }
+
+    public function loyaltyPointsBalance(): int
+    {
+        return (int) $this->loyalty_points_balance;
+    }
+
+    public function getLoyaltyPointsBalanceAttribute(): int
+    {
+        if (array_key_exists('loyalty_points_balance', $this->attributes)) {
+            return (int) $this->attributes['loyalty_points_balance'];
+        }
+
+        if ($this->relationLoaded('loyaltyPointTransactions')) {
+            return (int) $this->loyaltyPointTransactions->sum('points');
+        }
+
+        return (int) $this->loyaltyPointTransactions()->sum('points');
+    }
+
+
     public function addresses(): HasMany
     {
         return $this->hasMany(Address::class);

--- a/app/Services/Carts/CartPricingService.php
+++ b/app/Services/Carts/CartPricingService.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Services\Carts;
+
+use App\Data\CartTotals;
+use App\Models\Cart;
+use App\Models\CartItem;
+use App\Models\Coupon;
+use App\Models\User;
+
+class CartPricingService
+{
+    public static function calculate(Cart $cart, ?int $overridePoints = null, ?Coupon $couponOverride = null): CartTotals
+    {
+        $cart->loadMissing('items.product', 'coupon', 'user');
+
+        $subtotal = (float) $cart->items->sum(fn (CartItem $item) => (float) $item->price * (int) $item->qty);
+
+        $coupon = $couponOverride ?? $cart->coupon;
+        $couponCode = $coupon?->code ?? $cart->coupon_code;
+        $couponDiscount = 0.0;
+
+        if ($coupon) {
+            if (! self::couponIsApplicable($coupon, $cart, $subtotal)) {
+                $coupon = null;
+                $couponCode = null;
+            } else {
+                $couponDiscount = $coupon->calculateDiscount($subtotal);
+            }
+        }
+
+        $user = $cart->user instanceof User ? $cart->user : null;
+        $availablePoints = $user?->loyaltyPointsBalance() ?? 0;
+
+        $pointsUsed = $overridePoints ?? (int) $cart->loyalty_points_used;
+        $pointsUsed = max(0, (int) $pointsUsed);
+
+        $redeemValue = (float) config('shop.loyalty.redeem_value', 0.1);
+        $redeemValue = $redeemValue > 0 ? $redeemValue : 0.0;
+
+        $maxPercent = (float) config('shop.loyalty.max_redeem_percent', 0.5);
+        $maxPercent = min(max($maxPercent, 0.0), 1.0);
+
+        $amountEligible = max(0.0, $subtotal - $couponDiscount);
+        $maxRedeemablePoints = 0;
+
+        if ($redeemValue > 0) {
+            $maxByPercent = (int) floor(($amountEligible * $maxPercent) / $redeemValue + 1e-9);
+            $maxByAmount = (int) floor($amountEligible / $redeemValue + 1e-9);
+            $maxRedeemablePoints = max(0, min($maxByPercent, $maxByAmount));
+        }
+
+        $pointsUsed = min($pointsUsed, $availablePoints, $maxRedeemablePoints);
+
+        $pointsValue = round($pointsUsed * $redeemValue, 2);
+
+        if ($pointsValue > $amountEligible) {
+            $pointsValue = round($amountEligible, 2);
+            $pointsUsed = $redeemValue > 0 ? (int) floor($pointsValue / $redeemValue + 1e-9) : 0;
+        }
+
+        $couponDiscount = round(min($couponDiscount, $subtotal), 2);
+        $subtotal = round($subtotal, 2);
+        $total = max(0, round($subtotal - $couponDiscount - $pointsValue, 2));
+
+        return new CartTotals(
+            subtotal: $subtotal,
+            couponDiscount: $couponDiscount,
+            coupon: $coupon,
+            couponCode: $couponCode,
+            pointsUsed: $pointsUsed,
+            pointsValue: $pointsValue,
+            total: $total,
+            availablePoints: (int) $availablePoints,
+            maxRedeemablePoints: $maxRedeemablePoints,
+        );
+    }
+
+    public static function couponIsApplicable(Coupon $coupon, Cart $cart, float $subtotal): bool
+    {
+        if (! $coupon->isCurrentlyActive()) {
+            return false;
+        }
+
+        if ($subtotal < (float) $coupon->min_cart_total) {
+            return false;
+        }
+
+        if ($coupon->per_user_limit !== null) {
+            $user = $cart->user;
+            if ($user instanceof User) {
+                if ($coupon->usageCountForUser($user) >= $coupon->per_user_limit) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public static function syncCartAdjustments(Cart $cart, CartTotals $totals): void
+    {
+        $updated = false;
+
+        if ($totals->coupon) {
+            if ($cart->coupon_id !== $totals->coupon->id) {
+                $cart->coupon()->associate($totals->coupon);
+                $updated = true;
+            }
+        } elseif ($cart->coupon_id !== null) {
+            $cart->coupon()->dissociate();
+            $updated = true;
+        }
+
+        if ($cart->coupon_code !== $totals->couponCode) {
+            $cart->coupon_code = $totals->couponCode;
+            $updated = true;
+        }
+
+        if ($cart->loyalty_points_used !== $totals->pointsUsed) {
+            $cart->loyalty_points_used = $totals->pointsUsed;
+            $updated = true;
+        }
+
+        if ($updated) {
+            $cart->save();
+            $cart->setRelation('coupon', $totals->coupon);
+        }
+    }
+}

--- a/config/shop.php
+++ b/config/shop.php
@@ -1,4 +1,10 @@
 <?php
+
 return [
     'admin_email' => env('SHOP_ADMIN_EMAIL'), // опціонально
+    'loyalty' => [
+        'earn_rate' => (float) env('SHOP_LOYALTY_EARN_RATE', 1),
+        'redeem_value' => (float) env('SHOP_LOYALTY_REDEEM_VALUE', 0.1),
+        'max_redeem_percent' => (float) env('SHOP_LOYALTY_MAX_REDEEM_PERCENT', 0.5),
+    ],
 ];

--- a/database/migrations/2025_10_02_000000_create_coupons_table.php
+++ b/database/migrations/2025_10_02_000000_create_coupons_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('coupons', function (Blueprint $table) {
+            $table->id();
+            $table->string('code')->unique();
+            $table->string('name')->nullable();
+            $table->text('description')->nullable();
+            $table->string('type', 32); // fixed|percent
+            $table->decimal('value', 12, 2);
+            $table->decimal('min_cart_total', 12, 2)->default(0);
+            $table->decimal('max_discount', 12, 2)->nullable();
+            $table->unsignedInteger('usage_limit')->nullable();
+            $table->unsignedInteger('per_user_limit')->nullable();
+            $table->unsignedInteger('used')->default(0);
+            $table->timestamp('starts_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->json('meta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('coupons');
+    }
+};

--- a/database/migrations/2025_10_02_000100_create_loyalty_point_transactions_table.php
+++ b/database/migrations/2025_10_02_000100_create_loyalty_point_transactions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('loyalty_point_transactions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('order_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('type', 32);
+            $table->integer('points');
+            $table->decimal('amount', 12, 2)->default(0);
+            $table->string('description')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('loyalty_point_transactions');
+    }
+};

--- a/database/migrations/2025_10_02_000200_add_discounts_to_carts_table.php
+++ b/database/migrations/2025_10_02_000200_add_discounts_to_carts_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('carts', function (Blueprint $table) {
+            $table->foreignId('coupon_id')->nullable()->constrained('coupons')->nullOnDelete();
+            $table->string('coupon_code')->nullable();
+            $table->integer('loyalty_points_used')->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('carts', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('coupon_id');
+            $table->dropColumn(['coupon_code', 'loyalty_points_used']);
+        });
+    }
+};

--- a/database/migrations/2025_10_02_000300_add_discounts_to_orders_table.php
+++ b/database/migrations/2025_10_02_000300_add_discounts_to_orders_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->decimal('subtotal', 12, 2)->default(0);
+            $table->decimal('discount_total', 12, 2)->default(0);
+            $table->foreignId('coupon_id')->nullable()->constrained('coupons')->nullOnDelete();
+            $table->string('coupon_code')->nullable();
+            $table->decimal('coupon_discount', 12, 2)->default(0);
+            $table->integer('loyalty_points_used')->default(0);
+            $table->decimal('loyalty_points_value', 12, 2)->default(0);
+            $table->integer('loyalty_points_earned')->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropColumn([
+                'subtotal',
+                'discount_total',
+                'coupon_code',
+                'coupon_discount',
+                'loyalty_points_used',
+                'loyalty_points_value',
+                'loyalty_points_earned',
+            ]);
+            $table->dropConstrainedForeignId('coupon_id');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,6 +26,9 @@ Route::get('cart/{id}', [CartController::class, 'show']);
 Route::post('cart/{id}/items', [CartController::class, 'addItem']);
 Route::patch('cart/{id}/items/{item}', [CartController::class, 'updateItem']);
 Route::delete('cart/{id}/items/{item}', [CartController::class, 'removeItem']);
+Route::post('cart/apply-coupon', [CartController::class, 'applyCoupon']);
+Route::post('cart/apply-points', [CartController::class, 'applyPoints']);
+
 
 // Checkout
 Route::post('orders', [OrderController::class, 'store']);


### PR DESCRIPTION
## Summary
- create coupon and loyalty point transaction persistence, update cart/order totals to honor discounts
- add API endpoints to apply coupons and loyalty points with shared cart pricing service
- expose Filament resources for coupon management and user loyalty balances

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68c92843346c833195d29bb5a6375523