### PR TITLE
Add warehouse-aware inventory management

### DIFF
--- a/app/Filament/Mine/Resources/Inventory/InventoryResource.php
+++ b/app/Filament/Mine/Resources/Inventory/InventoryResource.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Inventory;
+
+use App\Filament\Mine\Resources\Inventory\Pages\CreateInventory;
+use App\Filament\Mine\Resources\Inventory\Pages\EditInventory;
+use App\Filament\Mine\Resources\Inventory\Pages\ListInventory;
+use App\Models\ProductStock;
+use BackedEnum;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class InventoryResource extends Resource
+{
+    protected static ?string $model = ProductStock::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCube;
+
+    protected static string|null|\UnitEnum $navigationGroup = 'Inventory';
+
+    protected static ?string $recordTitleAttribute = 'id';
+
+    protected static bool $shouldRegisterNavigation = true;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Select::make('product_id')
+                ->relationship('product', 'name')
+                ->searchable()
+                ->preload()
+                ->native(false)
+                ->required()
+                ->disabledOn('edit'),
+            Select::make('warehouse_id')
+                ->relationship('warehouse', 'name')
+                ->searchable()
+                ->preload()
+                ->native(false)
+                ->required()
+                ->disabledOn('edit'),
+            TextInput::make('qty')
+                ->label('Quantity')
+                ->numeric()
+                ->required()
+                ->minValue(0),
+            TextInput::make('reserved')
+                ->numeric()
+                ->required()
+                ->minValue(0),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('product.name')
+                    ->label('Product')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('product.sku')
+                    ->label('SKU')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('warehouse.name')
+                    ->label('Warehouse')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('qty')
+                    ->label('Qty')
+                    ->numeric()
+                    ->sortable(),
+                TextColumn::make('reserved')
+                    ->numeric()
+                    ->sortable(),
+                TextColumn::make('available')
+                    ->label('Available')
+                    ->numeric()
+                    ->sortable(),
+                TextColumn::make('updated_at')
+                    ->label('Updated')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('warehouse_id')
+                    ->relationship('warehouse', 'name')
+                    ->label('Warehouse'),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListInventory::route('/'),
+            'create' => CreateInventory::route('/create'),
+            'edit' => EditInventory::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) ProductStock::count();
+    }
+}

--- a/app/Filament/Mine/Resources/Inventory/Pages/CreateInventory.php
+++ b/app/Filament/Mine/Resources/Inventory/Pages/CreateInventory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Inventory\Pages;
+
+use App\Filament\Mine\Resources\Inventory\InventoryResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateInventory extends CreateRecord
+{
+    protected static string $resource = InventoryResource::class;
+}

--- a/app/Filament/Mine/Resources/Inventory/Pages/EditInventory.php
+++ b/app/Filament/Mine/Resources/Inventory/Pages/EditInventory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Inventory\Pages;
+
+use App\Filament\Mine\Resources\Inventory\InventoryResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditInventory extends EditRecord
+{
+    protected static string $resource = InventoryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Mine/Resources/Inventory/Pages/ListInventory.php
+++ b/app/Filament/Mine/Resources/Inventory/Pages/ListInventory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Inventory\Pages;
+
+use App\Filament\Mine\Resources\Inventory\InventoryResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListInventory extends ListRecords
+{
+    protected static string $resource = InventoryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Models/Warehouse.php
+++ b/app/Models/Warehouse.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Warehouse extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'code',
+        'name',
+        'description',
+    ];
+
+    public function stocks(): HasMany
+    {
+        return $this->hasMany(ProductStock::class);
+    }
+
+    public static function getDefault(): self
+    {
+        return static::query()->orderBy('id')->first()
+            ?? static::create([
+                'code' => 'MAIN',
+                'name' => 'Main Warehouse',
+            ]);
+    }
+}

--- a/app/Services/Orders/OrderStateService.php
+++ b/app/Services/Orders/OrderStateService.php
@@ -16,6 +16,7 @@ class OrderStateService
         }
 
         DB::transaction(function () use ($order) {
+            $order->reserveInventory();
             $order->update(['status' => OrderStatus::Paid]);
         });
     }
@@ -27,6 +28,7 @@ class OrderStateService
         }
 
         DB::transaction(function () use ($order) {
+            $order->commitReservedInventory();
             $order->update(['status' => OrderStatus::Shipped]);
         });
     }
@@ -38,10 +40,7 @@ class OrderStateService
         }
 
         DB::transaction(function () use ($order) {
-            // Якщо списуєте склад при створенні або при "paid", тут відкотити залишки:
-            // foreach ($order->items as $item) {
-            //     $item->product()->increment('stock', $item->qty);
-            // }
+            $order->releaseInventory();
 
             $order->update(['status' => OrderStatus::Cancelled]);
         });

--- a/database/factories/OrderItemFactory.php
+++ b/database/factories/OrderItemFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Models\Order;
 use App\Models\OrderItem;
 use App\Models\Product;
+use App\Models\Warehouse;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class OrderItemFactory extends Factory
@@ -16,6 +17,7 @@ class OrderItemFactory extends Factory
         return [
             'order_id'   => Order::factory(),
             'product_id' => Product::factory(),
+            'warehouse_id' => fn () => Warehouse::getDefault()->id,
             'qty'        => $this->faker->numberBetween(1, 3),
             'price'      => $this->faker->randomFloat(2, 10, 500),
         ];

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Product;
+use App\Models\Warehouse;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 use App\Models\Category;
@@ -12,6 +13,23 @@ use App\Models\Category;
  */
 class ProductFactory extends Factory
 {
+    public function configure(): static
+    {
+        return $this->afterCreating(function (Product $product) {
+            $warehouse = Warehouse::getDefault();
+
+            $product->stocks()->updateOrCreate(
+                ['warehouse_id' => $warehouse->id],
+                [
+                    'qty' => (int) $product->stock,
+                    'reserved' => 0,
+                ]
+            );
+
+            $product->syncAvailableStock();
+        });
+    }
+
     /**
      * Define the model's default state.
      *

--- a/database/factories/WarehouseFactory.php
+++ b/database/factories/WarehouseFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Warehouse;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class WarehouseFactory extends Factory
+{
+    protected $model = Warehouse::class;
+
+    public function definition(): array
+    {
+        return [
+            'code' => Str::upper('WH-' . $this->faker->unique()->lexify('????')),
+            'name' => $this->faker->unique()->company . ' Warehouse',
+            'description' => $this->faker->optional()->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2025_10_05_000000_create_warehouses_table.php
+++ b/database/migrations/2025_10_05_000000_create_warehouses_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('warehouses', function (Blueprint $table) {
+            $table->id();
+            $table->string('code')->unique();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+
+        DB::table('warehouses')->insert([
+            'code' => 'MAIN',
+            'name' => 'Main Warehouse',
+            'description' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('warehouses');
+    }
+};

--- a/database/migrations/2025_10_05_000100_create_product_stock_table.php
+++ b/database/migrations/2025_10_05_000100_create_product_stock_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product_stocks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('warehouse_id')->constrained('warehouses')->cascadeOnDelete();
+            $table->integer('qty')->default(0);
+            $table->integer('reserved')->default(0);
+            $table->timestamps();
+            $table->unique(['product_id', 'warehouse_id']);
+        });
+
+        $warehouseId = DB::table('warehouses')->where('code', 'MAIN')->value('id');
+
+        if ($warehouseId) {
+            $products = DB::table('products')->select('id', 'stock')->get();
+
+            foreach ($products as $product) {
+                DB::table('product_stocks')->insert([
+                    'product_id' => $product->id,
+                    'warehouse_id' => $warehouseId,
+                    'qty' => (int) ($product->stock ?? 0),
+                    'reserved' => 0,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('product_stocks');
+    }
+};

--- a/database/migrations/2025_10_05_000200_add_warehouse_id_to_order_items_table.php
+++ b/database/migrations/2025_10_05_000200_add_warehouse_id_to_order_items_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            if (! Schema::hasColumn('order_items', 'warehouse_id')) {
+                $table->foreignId('warehouse_id')
+                    ->nullable()
+                    ->after('product_id')
+                    ->constrained('warehouses')
+                    ->nullOnDelete();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            if (Schema::hasColumn('order_items', 'warehouse_id')) {
+                $table->dropForeign(['warehouse_id']);
+                $table->dropColumn('warehouse_id');
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- introduce warehouses and product stock tables with models and factory support
- update product stock handling and order workflows to reserve, release, and ship from specific warehouses
- add a Filament Inventory resource to review and edit warehouse quantities

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68c932134de48331bb28105ab5ec433b