### PR TITLE
Add vendor support with messaging

### DIFF
--- a/app/Filament/Mine/Resources/Orders/OrderResource.php
+++ b/app/Filament/Mine/Resources/Orders/OrderResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Mine\Resources\Orders;
 use App\Filament\Mine\Resources\Orders\Pages\CreateOrder;
 use App\Filament\Mine\Resources\Orders\Pages\EditOrder;
 use App\Filament\Mine\Resources\Orders\Pages\ListOrders;
+use App\Filament\Mine\Resources\Orders\Pages\OrderMessages;
 use App\Filament\Mine\Resources\Orders\Schemas\OrderForm;
 use App\Filament\Mine\Resources\Orders\Tables\OrdersTable;
 use App\Models\Order;
@@ -13,6 +14,8 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
 
 class OrderResource extends Resource
 {
@@ -38,6 +41,19 @@ class OrderResource extends Resource
         return OrdersTable::configure($table);
     }
 
+    public static function getEloquentQuery(): Builder
+    {
+        $query = parent::getEloquentQuery();
+
+        $user = Auth::user();
+
+        if ($user?->vendor) {
+            $query->whereHas('items.product', fn ($builder) => $builder->where('vendor_id', $user->vendor->id));
+        }
+
+        return $query->with(['items.product.vendor']);
+    }
+
     public static function getRelations(): array
     {
         return [
@@ -52,6 +68,7 @@ class OrderResource extends Resource
             'index' => ListOrders::route('/'),
             'create' => CreateOrder::route('/create'),
             'edit' => EditOrder::route('/{record}/edit'),
+            'messages' => OrderMessages::route('/{record}/messages'),
         ];
     }
 

--- a/app/Filament/Mine/Resources/Orders/Pages/OrderMessages.php
+++ b/app/Filament/Mine/Resources/Orders/Pages/OrderMessages.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Orders\Pages;
+
+use App\Filament\Mine\Resources\Orders\OrderResource;
+use App\Models\Message;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\Concerns\InteractsWithRecord;
+use Filament\Resources\Pages\Page;
+use Illuminate\Support\Facades\Auth;
+
+class OrderMessages extends Page implements HasForms
+{
+    use InteractsWithForms;
+    use InteractsWithRecord;
+
+    protected static string $resource = OrderResource::class;
+
+    protected string $view = 'filament.mine.resources.orders.pages.messages';
+
+    public array $data = [];
+
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    public array $messages = [];
+
+    public function mount(int|string $record): void
+    {
+        $this->record = $this->resolveRecord($record);
+
+        $this->authorize('view', $this->record);
+
+        $this->loadMessages();
+
+        $this->form->fill(['body' => '']);
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Textarea::make('body')
+                    ->label('Message')
+                    ->rows(4)
+                    ->required()
+                    ->maxLength(2000),
+            ])
+            ->statePath('data');
+    }
+
+    public function send(): void
+    {
+        $this->authorize('createMessage', $this->record);
+
+        $data = $this->form->getState();
+
+        $this->record->messages()->create([
+            'user_id' => Auth::id(),
+            'body' => $data['body'],
+        ]);
+
+        $this->form->fill(['body' => '']);
+        $this->loadMessages();
+
+        Notification::make()
+            ->title(__('Message sent'))
+            ->success()
+            ->send();
+    }
+
+    protected function loadMessages(): void
+    {
+        $currentUserId = Auth::id();
+
+        $this->messages = $this->record->messages()
+            ->with('user:id,name')
+            ->oldest('created_at')
+            ->get()
+            ->map(fn (Message $message) => [
+                'id' => $message->id,
+                'body' => $message->body,
+                'created_at' => $message->created_at,
+                'user' => $message->user,
+                'is_author' => $message->user_id === $currentUserId,
+            ])
+            ->all();
+    }
+
+    protected function getViewData(): array
+    {
+        return [
+            'order' => $this->record,
+        ];
+    }
+}

--- a/app/Filament/Mine/Resources/Orders/Tables/OrdersTable.php
+++ b/app/Filament/Mine/Resources/Orders/Tables/OrdersTable.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Mine\Resources\Orders\Tables;
 
 use App\Enums\OrderStatus;
+use App\Filament\Mine\Resources\Orders\OrderResource;
 use App\Models\Order;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
@@ -68,6 +69,12 @@ class OrdersTable
             ])
             ->recordActions([
                 EditAction::make(),
+                Action::make('messages')
+                    ->label('Messages')
+                    ->icon('heroicon-o-chat-bubble-left-right')
+                    ->color('gray')
+                    ->url(fn (Order $record) => OrderResource::getUrl('messages', ['record' => $record]))
+                    ->visible(fn (Order $record) => auth()->user()?->can('view', $record)),
                 Action::make('markPaid')
                     ->label('Mark paid')
                     ->icon('heroicon-o-banknotes')

--- a/app/Filament/Mine/Resources/Products/Pages/CreateProduct.php
+++ b/app/Filament/Mine/Resources/Products/Pages/CreateProduct.php
@@ -4,8 +4,18 @@ namespace App\Filament\Mine\Resources\Products\Pages;
 
 use App\Filament\Mine\Resources\Products\ProductResource;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Support\Facades\Auth;
 
 class CreateProduct extends CreateRecord
 {
     protected static string $resource = ProductResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        if ($vendor = Auth::user()?->vendor) {
+            $data['vendor_id'] = $vendor->id;
+        }
+
+        return $data;
+    }
 }

--- a/app/Filament/Mine/Resources/Products/Pages/EditProduct.php
+++ b/app/Filament/Mine/Resources/Products/Pages/EditProduct.php
@@ -5,6 +5,7 @@ namespace App\Filament\Mine\Resources\Products\Pages;
 use App\Filament\Mine\Resources\Products\ProductResource;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Support\Facades\Auth;
 
 class EditProduct extends EditRecord
 {
@@ -15,5 +16,14 @@ class EditProduct extends EditRecord
         return [
             DeleteAction::make(),
         ];
+    }
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        if ($vendor = Auth::user()?->vendor) {
+            $data['vendor_id'] = $this->record->vendor_id ?? $vendor->id;
+        }
+
+        return $data;
     }
 }

--- a/app/Filament/Mine/Resources/Products/ProductResource.php
+++ b/app/Filament/Mine/Resources/Products/ProductResource.php
@@ -15,6 +15,7 @@ use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Filament\Forms;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
 
 
 class ProductResource extends Resource
@@ -42,12 +43,20 @@ class ProductResource extends Resource
 
     public static function getEloquentQuery(): Builder
     {
-        return parent::getEloquentQuery()
+        $query = parent::getEloquentQuery()
             ->with(['images' => fn($q) => $q
                 ->select('id','product_id','path','disk','is_primary','sort')
                 ->orderByDesc('is_primary')
                 ->orderBy('sort')
             ]);
+
+        $user = Auth::user();
+
+        if ($user?->vendor) {
+            $query->where('vendor_id', $user->vendor->id);
+        }
+
+        return $query;
     }
 
     public static function getPages(): array

--- a/app/Filament/Mine/Resources/Products/Tables/ProductsTable.php
+++ b/app/Filament/Mine/Resources/Products/Tables/ProductsTable.php
@@ -15,13 +15,22 @@ use Filament\Tables\Table;
 use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Filters\TernaryFilter;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
 
 class ProductsTable
 {
     public static function configure(Table $table): Table
     {
         return $table
-            ->query(fn (): Builder => Product::query()->with(['images', 'category']))
+            ->query(function (): Builder {
+                $query = Product::query()->with(['images', 'category']);
+
+                if ($vendor = Auth::user()?->vendor) {
+                    $query->where('vendor_id', $vendor->id);
+                }
+
+                return $query;
+            })
             ->columns([
                 ImageColumn::make('preview')
                     ->label('Preview')

--- a/app/Filament/Mine/Resources/Vendors/Pages/CreateVendor.php
+++ b/app/Filament/Mine/Resources/Vendors/Pages/CreateVendor.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Vendors\Pages;
+
+use App\Filament\Mine\Resources\Vendors\VendorResource;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Support\Facades\Auth;
+
+class CreateVendor extends CreateRecord
+{
+    protected static string $resource = VendorResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $user = Auth::user();
+
+        if ($user?->vendor) {
+            $data['user_id'] = $user->id;
+        } elseif (! array_key_exists('user_id', $data) || ! $data['user_id']) {
+            $data['user_id'] = $user?->id;
+        }
+
+        return $data;
+    }
+}

--- a/app/Filament/Mine/Resources/Vendors/Pages/EditVendor.php
+++ b/app/Filament/Mine/Resources/Vendors/Pages/EditVendor.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Vendors\Pages;
+
+use App\Filament\Mine\Resources\Vendors\VendorResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Illuminate\Support\Facades\Auth;
+
+class EditVendor extends EditRecord
+{
+    protected static string $resource = VendorResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make()
+                ->visible(fn () => ! auth()->user()?->vendor),
+        ];
+    }
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        if ($user = Auth::user()) {
+            if ($user->vendor && $this->record->user_id === $user->vendor->user_id) {
+                $data['user_id'] = $user->id;
+            }
+        }
+
+        return $data;
+    }
+}

--- a/app/Filament/Mine/Resources/Vendors/Pages/ListVendors.php
+++ b/app/Filament/Mine/Resources/Vendors/Pages/ListVendors.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Vendors\Pages;
+
+use App\Filament\Mine\Resources\Vendors\VendorResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListVendors extends ListRecords
+{
+    protected static string $resource = VendorResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make()
+                ->visible(fn () => ! auth()->user()?->vendor),
+        ];
+    }
+}

--- a/app/Filament/Mine/Resources/Vendors/Schemas/VendorForm.php
+++ b/app/Filament/Mine/Resources/Vendors/Schemas/VendorForm.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Vendors\Schemas;
+
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Facades\Auth;
+
+class VendorForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        $user = Auth::user();
+
+        return $schema
+            ->components([
+                Select::make('user_id')
+                    ->label(__('Owner'))
+                    ->relationship('user', 'name')
+                    ->searchable()
+                    ->preload()
+                    ->required()
+                    ->unique(ignoreRecord: true)
+                    ->disabled(fn () => (bool) $user?->vendor),
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255),
+                TextInput::make('slug')
+                    ->required()
+                    ->maxLength(255)
+                    ->unique(ignoreRecord: true),
+                TextInput::make('contact_email')
+                    ->email()
+                    ->maxLength(255),
+                TextInput::make('contact_phone')
+                    ->maxLength(255),
+                Textarea::make('description')
+                    ->rows(4)
+                    ->columnSpanFull(),
+            ])
+            ->columns(2);
+    }
+}

--- a/app/Filament/Mine/Resources/Vendors/Tables/VendorsTable.php
+++ b/app/Filament/Mine/Resources/Vendors/Tables/VendorsTable.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Vendors\Tables;
+
+use App\Models\Vendor;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+
+class VendorsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->query(function (): Builder {
+                $query = Vendor::query()->with('user');
+
+                if ($vendor = Auth::user()?->vendor) {
+                    $query->whereKey($vendor->id);
+                }
+
+                return $query;
+            })
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('slug')
+                    ->searchable()
+                    ->toggleable(),
+                TextColumn::make('user.name')
+                    ->label(__('Owner'))
+                    ->sortable(),
+                TextColumn::make('contact_email')
+                    ->label(__('Email'))
+                    ->toggleable(),
+                TextColumn::make('contact_phone')
+                    ->label(__('Phone'))
+                    ->toggleable(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->since()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make()
+                    ->visible(fn () => ! Auth::user()?->vendor),
+            ])
+            ->defaultSort('name');
+    }
+}

--- a/app/Filament/Mine/Resources/Vendors/VendorResource.php
+++ b/app/Filament/Mine/Resources/Vendors/VendorResource.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Vendors;
+
+use App\Filament\Mine\Resources\Vendors\Pages\CreateVendor;
+use App\Filament\Mine\Resources\Vendors\Pages\EditVendor;
+use App\Filament\Mine\Resources\Vendors\Pages\ListVendors;
+use App\Filament\Mine\Resources\Vendors\Schemas\VendorForm;
+use App\Filament\Mine\Resources\Vendors\Tables\VendorsTable;
+use App\Models\Vendor;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+
+class VendorResource extends Resource
+{
+    protected static ?string $model = Vendor::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedBuildingStorefront;
+
+    protected static string|null|\UnitEnum $navigationGroup = 'Catalog';
+
+    public static function form(Schema $schema): Schema
+    {
+        return VendorForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return VendorsTable::configure($table);
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        $query = parent::getEloquentQuery();
+
+        $user = Auth::user();
+
+        if ($user?->vendor) {
+            $query->whereKey($user->vendor->id);
+        }
+
+        return $query->with('user');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListVendors::route('/'),
+            'create' => CreateVendor::route('/create'),
+            'edit' => EditVendor::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) Vendor::count();
+    }
+}

--- a/app/Http/Controllers/Api/OrderMessageController.php
+++ b/app/Http/Controllers/Api/OrderMessageController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Order;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class OrderMessageController extends Controller
+{
+    public function store(Request $request, Order $order): JsonResponse
+    {
+        $user = $request->user();
+
+        abort_if(! $user, 401);
+
+        $this->authorize('createMessage', $order);
+
+        $data = $request->validate([
+            'body' => ['required', 'string', 'max:2000'],
+        ]);
+
+        $message = $order->messages()->create([
+            'user_id' => $user->id,
+            'body' => $data['body'],
+        ])->load('user:id,name');
+
+        return response()->json([
+            'id' => $message->id,
+            'order_id' => $message->order_id,
+            'user_id' => $message->user_id,
+            'body' => $message->body,
+            'meta' => $message->meta,
+            'created_at' => optional($message->created_at)->toISOString(),
+            'updated_at' => optional($message->updated_at)->toISOString(),
+            'user' => $message->user,
+        ], 201);
+    }
+}

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+
 abstract class Controller
 {
-    //
+    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
 }

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Message extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'order_id',
+        'user_id',
+        'body',
+        'meta',
+    ];
+
+    protected $casts = [
+        'meta' => 'array',
+    ];
+
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -20,6 +20,7 @@ class Product extends Model
         'slug',
         'sku',
         'category_id',
+        'vendor_id',
         'attributes',
         'stock',
         'price',
@@ -59,6 +60,11 @@ class Product extends Model
     public function category(): BelongsTo
     {
         return $this->belongsTo(Category::class);
+    }
+
+    public function vendor(): BelongsTo
+    {
+        return $this->belongsTo(Vendor::class);
     }
 
     public function images(): HasMany
@@ -239,7 +245,7 @@ class Product extends Model
     }
 
 // щоб не ловити N+1 і аксесор працював без додаткових запитів
-    protected $with = ['images'];
+    protected $with = ['images', 'vendor'];
 
 // якщо хочеш бачити поле як атрибут (не обов'язково для таблиці)
     protected $appends = ['preview_url'];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,6 +10,7 @@ use Illuminate\Notifications\Notifiable;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class User extends Authenticatable implements FilamentUser
 {
@@ -58,6 +59,16 @@ class User extends Authenticatable implements FilamentUser
     public function loyaltyPointTransactions(): HasMany
     {
         return $this->hasMany(LoyaltyPointTransaction::class);
+    }
+
+    public function vendor(): HasOne
+    {
+        return $this->hasOne(Vendor::class);
+    }
+
+    public function messages(): HasMany
+    {
+        return $this->hasMany(Message::class);
     }
 
     public function loyaltyPointsBalance(): int

--- a/app/Models/Vendor.php
+++ b/app/Models/Vendor.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Builder;
+
+class Vendor extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'name',
+        'slug',
+        'contact_email',
+        'contact_phone',
+        'description',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function products(): HasMany
+    {
+        return $this->hasMany(Product::class);
+    }
+
+    public function scopeVisibleTo(Builder $query, ?User $user): Builder
+    {
+        if (! $user?->vendor) {
+            return $query;
+        }
+
+        return $query->whereKey($user->vendor->id);
+    }
+}

--- a/app/Policies/OrderPolicy.php
+++ b/app/Policies/OrderPolicy.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Order;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class OrderPolicy
+{
+    use HandlesAuthorization;
+
+    public function before(User $user, string $ability): bool|null
+    {
+        if (! $user->vendor) {
+            return true;
+        }
+
+        return null;
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Order $order): bool
+    {
+        return $this->managesOrder($user, $order);
+    }
+
+    public function update(User $user, Order $order): bool
+    {
+        return $this->managesOrder($user, $order);
+    }
+
+    public function delete(User $user, Order $order): bool
+    {
+        return $this->managesOrder($user, $order);
+    }
+
+    public function createMessage(User $user, Order $order): bool
+    {
+        return $this->managesOrder($user, $order);
+    }
+
+    protected function managesOrder(User $user, Order $order): bool
+    {
+        $vendor = $user->vendor;
+
+        if (! $vendor) {
+            return true;
+        }
+
+        if ($order->user_id && $order->user_id === $user->id) {
+            return true;
+        }
+
+        return $order->involvesVendor($vendor->id);
+    }
+}

--- a/app/Policies/ProductPolicy.php
+++ b/app/Policies/ProductPolicy.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ProductPolicy
+{
+    use HandlesAuthorization;
+
+    public function before(User $user, string $ability): bool|null
+    {
+        if (! $user->vendor) {
+            return true;
+        }
+
+        return null;
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Product $product): bool
+    {
+        return $this->ownsProduct($user, $product);
+    }
+
+    public function create(User $user): bool
+    {
+        return (bool) $user->vendor;
+    }
+
+    public function update(User $user, Product $product): bool
+    {
+        return $this->ownsProduct($user, $product);
+    }
+
+    public function delete(User $user, Product $product): bool
+    {
+        return $this->ownsProduct($user, $product);
+    }
+
+    protected function ownsProduct(User $user, Product $product): bool
+    {
+        $vendor = $user->vendor;
+
+        if (! $vendor) {
+            return true;
+        }
+
+        return (int) ($product->vendor_id ?? 0) === $vendor->id;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -14,6 +14,9 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Auth\Events\Login;
 use App\Models\Product;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Gate;
+use App\Policies\ProductPolicy;
+use App\Policies\OrderPolicy;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -40,6 +43,9 @@ class AppServiceProvider extends ServiceProvider
                 Limit::perMinute(120)->by(optional($request->user())->id ?: 'guest'),
             ];
         });
+
+        Gate::policy(Product::class, ProductPolicy::class);
+        Gate::policy(Order::class, OrderPolicy::class);
 
         if (Config::get('scout.driver') === 'meilisearch') {
             Product::created(fn($p) => $p->searchable());

--- a/app/Providers/Filament/MinePanelProvider.php
+++ b/app/Providers/Filament/MinePanelProvider.php
@@ -23,6 +23,7 @@ use Illuminate\View\Middleware\ShareErrorsFromSession;
 use App\Filament\Mine\Resources\Products\ProductResource;
 use App\Filament\Mine\Resources\Categories\CategoryResource;
 use App\Filament\Mine\Resources\Orders\OrderResource;
+use App\Filament\Mine\Resources\Vendors\VendorResource;
 
 class MinePanelProvider extends PanelProvider
 {
@@ -43,6 +44,7 @@ class MinePanelProvider extends PanelProvider
             ->resources([
                 ProductResource::class,
                 CategoryResource::class,
+                VendorResource::class,
                 OrderResource::class,
             ])
             ->navigationGroups([

--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Message;
+use App\Models\Order;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Message>
+ */
+class MessageFactory extends Factory
+{
+    protected $model = Message::class;
+
+    public function definition(): array
+    {
+        return [
+            'order_id' => Order::factory(),
+            'user_id' => User::factory(),
+            'body' => $this->faker->paragraph(),
+            'meta' => null,
+        ];
+    }
+}

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Product;
+use App\Models\Vendor;
 use App\Models\Warehouse;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
@@ -45,6 +46,7 @@ class ProductFactory extends Factory
             'slug' => Str::slug($name) . '-' . Str::lower(Str::random(6)),
             'sku' => Str::upper(Str::random(10)),
             'category_id' => Category::factory(),
+            'vendor_id' => Vendor::factory(),
             'attributes' => [
                 'size' => $this->faker->randomElement(['S','M','L']),
                 'color' => $this->faker->safeColorName(),

--- a/database/factories/VendorFactory.php
+++ b/database/factories/VendorFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Models\Vendor;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Vendor>
+ */
+class VendorFactory extends Factory
+{
+    protected $model = Vendor::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->company();
+
+        return [
+            'user_id' => User::factory(),
+            'name' => $name,
+            'slug' => Str::slug($name) . '-' . Str::lower(Str::random(5)),
+            'contact_email' => $this->faker->unique()->companyEmail(),
+            'contact_phone' => $this->faker->phoneNumber(),
+            'description' => $this->faker->optional()->sentence(10),
+        ];
+    }
+}

--- a/database/migrations/2025_10_07_000000_create_vendors_table.php
+++ b/database/migrations/2025_10_07_000000_create_vendors_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('vendors', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->string('contact_email')->nullable();
+            $table->string('contact_phone')->nullable();
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('vendors');
+    }
+};

--- a/database/migrations/2025_10_07_000100_create_messages_table.php
+++ b/database/migrations/2025_10_07_000100_create_messages_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->text('body');
+            $table->json('meta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('messages');
+    }
+};

--- a/database/migrations/2025_10_07_000200_add_vendor_id_to_products_table.php
+++ b/database/migrations/2025_10_07_000200_add_vendor_id_to_products_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->foreignId('vendor_id')->nullable()->after('category_id')->constrained()->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('vendor_id');
+        });
+    }
+};

--- a/database/seeders/DemoCatalogSeeder.php
+++ b/database/seeders/DemoCatalogSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Category;
 use App\Models\Product;
+use App\Models\Vendor;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Storage;
@@ -19,9 +20,13 @@ class DemoCatalogSeeder extends Seeder
         // 5 категорій
         $cats = Category::factory()->count(5)->create();
 
-        // 60 товарів, кожному ставимо випадкову категорію
-        $products = Product::factory()->count(60)->make()->each(function (Product $p) use ($cats) {
+        // створимо кілька продавців
+        $vendors = Vendor::factory()->count(5)->create();
+
+        // 60 товарів, кожному ставимо випадкову категорію та продавця
+        $products = Product::factory()->count(60)->make()->each(function (Product $p) use ($cats, $vendors) {
             $p->category_id = $cats->random()->id;
+            $p->vendor_id = $vendors->random()->id;
             $p->save();
         });
 

--- a/resources/views/filament/mine/resources/orders/pages/messages.blade.php
+++ b/resources/views/filament/mine/resources/orders/pages/messages.blade.php
@@ -1,0 +1,42 @@
+<x-filament::page>
+    <div class="space-y-6">
+        <x-filament::section>
+            <x-slot name="heading">{{ __('Conversation') }}</x-slot>
+            <div class="space-y-4">
+                @forelse($this->messages as $message)
+                    <div class="rounded-xl border p-4 @class([
+                        'bg-primary-50 border-primary-200' => $message['is_author'],
+                        'bg-white border-gray-200' => ! $message['is_author'],
+                    ])">
+                        <div class="flex items-start justify-between gap-4">
+                            <div>
+                                <p class="text-sm font-semibold text-gray-900">
+                                    {{ $message['user']->name ?? __('System') }}
+                                </p>
+                                <p class="text-xs text-gray-500">
+                                    {{ optional($message['created_at'])->diffForHumans() }}
+                                </p>
+                            </div>
+                        </div>
+                        <div class="mt-3 text-sm text-gray-700 whitespace-pre-line">
+                            {{ $message['body'] }}
+                        </div>
+                    </div>
+                @empty
+                    <p class="text-sm text-gray-500">{{ __('No messages yet.') }}</p>
+                @endforelse
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <x-slot name="heading">{{ __('New message') }}</x-slot>
+            <form wire:submit.prevent="send" class="space-y-4">
+                {{ $this->form }}
+
+                <x-filament::button type="submit">
+                    {{ __('Send') }}
+                </x-filament::button>
+            </form>
+        </x-filament::section>
+    </div>
+</x-filament::page>

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\{AddressController,
     ProductController,
     CartController,
     OrderController,
+    OrderMessageController,
     ReviewController,
     WishlistController};
 
@@ -20,6 +21,9 @@ $productsAndOrders = function () {
     Route::get('products/{slug}', [ProductController::class, 'show']);
     Route::get('products/{id}/reviews', [ReviewController::class, 'index']);
     Route::middleware('auth:sanctum')->post('products/{id}/reviews', [ReviewController::class, 'store']);
+
+    Route::get('seller/{vendor}/products', [ProductController::class, 'sellerProducts'])
+        ->whereNumber('vendor');
 
     // Checkout
     Route::post('orders', [OrderController::class, 'store']);
@@ -52,4 +56,5 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('profile/wishlist', [WishlistController::class, 'index']);
     Route::post('profile/wishlist/{product}', [WishlistController::class, 'store']);
     Route::delete('profile/wishlist/{product}', [WishlistController::class, 'destroy']);
+    Route::post('orders/{order}/messages', [OrderMessageController::class, 'store']);
 });


### PR DESCRIPTION
## Summary
- add vendor and message persistence plus factories to support multi-seller catalogs
- enforce seller scoping and expose seller product listing and order message APIs with policy gates
- extend Filament admin with vendor management resource and order conversation page for messaging

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68c942a9be248331bb4d51660492888b