### PR TITLE
Sync wishlist with authenticated backend

### DIFF
--- a/resources/js/shop/hooks/useWishlist.tsx
+++ b/resources/js/shop/hooks/useWishlist.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { WishlistApi } from '../api';
-import { getWishlist, setWishlist, type WishItem } from '../ui/wishlist';
+import type {AxiosError} from 'axios';
+import {WishlistApi} from '../api';
+import {getWishlist, setWishlist, type WishItem} from '../ui/wishlist';
+import useAuth from './useAuth';
 
 type Ctx = {
     items: WishItem[];
@@ -9,55 +11,142 @@ type Ctx = {
     remove: (id: number) => void;
     toggle: (p: WishItem) => void;
     clear: () => void;
+    isLoading: boolean;
+    error: string | null;
 };
 
 const Ctx = React.createContext<Ctx | null>(null);
 
-export function WishlistProvider({ children }: { children: React.ReactNode }) {
-    const [items, setItems] = React.useState<WishItem[]>(() => getWishlist());
-    const syncMode = React.useRef<'unknown' | 'remote' | 'local'>('unknown');
+function dedupe(items: WishItem[]): WishItem[] {
+    const seen = new Set<number>();
+    const result: WishItem[] = [];
+    for (const item of items) {
+        if (seen.has(item.id)) continue;
+        seen.add(item.id);
+        result.push(item);
+    }
+    return result;
+}
+
+export function WishlistProvider({children}: {children: React.ReactNode}) {
+    const {isAuthenticated, isReady, user, token} = useAuth();
+    const [items, setItems] = React.useState<WishItem[]>(() => dedupe(getWishlist()));
+    const [isLoading, setIsLoading] = React.useState(false);
+    const [error, setError] = React.useState<string | null>(null);
+    const syncMode = React.useRef<'unknown' | 'remote' | 'local'>('local');
     const itemsRef = React.useRef(items);
 
     const setList = React.useCallback((next: WishItem[] | ((prev: WishItem[]) => WishItem[])) => {
         setItems(prev => {
             const resolved = typeof next === 'function' ? (next as (prev: WishItem[]) => WishItem[])(prev) : next;
-            setWishlist(resolved);
-            return resolved;
+            const normalized = dedupe(resolved);
+            setWishlist(normalized);
+            return normalized;
         });
     }, []);
 
-    const handleApiError = React.useCallback((error: any) => {
-        const status = error?.response?.status;
+    const handleApiError = React.useCallback((error: unknown) => {
+        const err = error as AxiosError<{ message?: string }>;
+        const status = err?.response?.status;
+        const fallback =
+            status === 401
+                ? 'Увійдіть, щоб синхронізувати обране.'
+                : 'Не вдалося синхронізувати список бажаного.';
+        const message = err?.response?.data?.message ?? err?.message ?? fallback;
+        console.error('Wishlist API error', error);
         syncMode.current = status === 401 ? 'local' : 'unknown';
+        setError(message);
+        return status;
     }, []);
 
     React.useEffect(() => {
         itemsRef.current = items;
     }, [items]);
 
-    // початковий sync з API
-    React.useEffect(() => {
-        let mounted = true;
+    const authUserId = user?.id ?? null;
 
-        (async () => {
+    React.useEffect(() => {
+        if (!isReady) {
+            if (token) {
+                setIsLoading(true);
+            }
+            return;
+        }
+
+        if (!isAuthenticated) {
+            syncMode.current = 'local';
+            setError(null);
+            setIsLoading(false);
+            setItems(dedupe(getWishlist()));
+            return;
+        }
+
+        let cancelled = false;
+
+        const syncWithRemote = async () => {
+            setIsLoading(true);
+            setError(null);
             try {
                 const remote = await WishlistApi.list();
-                if (!mounted) return;
+                if (cancelled) return;
+
+                const local = dedupe(getWishlist());
+                const remoteIds = new Set(remote.map(item => item.id));
+                const extras = local.filter(item => !remoteIds.has(item.id));
+
+                let merged = [...remote];
+
+                if (extras.length) {
+                    const results = await Promise.allSettled(
+                        extras.map(item => WishlistApi.add(item.id))
+                    );
+                    if (cancelled) return;
+
+                    let hadFailures = false;
+                    results.forEach((result, index) => {
+                        const fallback = extras[index];
+                        if (result.status === 'fulfilled') {
+                            const payload = result.value ?? fallback;
+                            merged = [payload, ...merged.filter(x => x.id !== payload.id)];
+                        } else {
+                            hadFailures = true;
+                            console.error('Failed to sync wishlist item', result.reason);
+                        }
+                    });
+
+                    if (hadFailures) {
+                        setError('Деякі товари не вдалося синхронізувати зі списком бажаного.');
+                    }
+                }
+
+                if (cancelled) return;
+                setList(merged);
                 syncMode.current = 'remote';
-                setList(remote);
-            } catch (error: any) {
-                if (!mounted) return;
-                handleApiError(error);
+            } catch (error) {
+                if (cancelled) return;
+                const status = handleApiError(error);
+                if (status === 401) {
+                    setItems(dedupe(getWishlist()));
+                }
+            } finally {
+                if (!cancelled) {
+                    setIsLoading(false);
+                }
             }
-        })();
+        };
 
-        return () => { mounted = false; };
-    }, [handleApiError, setList]);
+        syncWithRemote();
 
-    // sync з іншими вкладками
+        return () => {
+            cancelled = true;
+        };
+    }, [authUserId, handleApiError, isAuthenticated, isReady, setList, token]);
+
     React.useEffect(() => {
         const onStorage = (e: StorageEvent) => {
-            if (e.key === 'wishlist_v1') setItems(getWishlist());
+            if (e.key === 'wishlist_v1') {
+                setItems(dedupe(getWishlist()));
+            }
         };
         window.addEventListener('storage', onStorage);
         return () => window.removeEventListener('storage', onStorage);
@@ -73,6 +162,7 @@ export function WishlistProvider({ children }: { children: React.ReactNode }) {
                     const rest = prev.filter(x => x.id !== payload.id);
                     return [payload, ...rest];
                 });
+                setError(null);
             })
             .catch(handleApiError);
     }, [handleApiError, setList]);
@@ -82,6 +172,7 @@ export function WishlistProvider({ children }: { children: React.ReactNode }) {
         WishlistApi.remove(productId)
             .then(() => {
                 syncMode.current = 'remote';
+                setError(null);
             })
             .catch(handleApiError);
     }, [handleApiError]);
@@ -112,6 +203,7 @@ export function WishlistProvider({ children }: { children: React.ReactNode }) {
     const clear = React.useCallback(() => {
         const prev = itemsRef.current;
         setList([]);
+        setError(null);
         if (!prev.length || syncMode.current === 'local') {
             return;
         }
@@ -129,7 +221,9 @@ export function WishlistProvider({ children }: { children: React.ReactNode }) {
         remove,
         toggle,
         clear,
-    }), [add, clear, has, items, remove, toggle]);
+        isLoading,
+        error,
+    }), [add, clear, error, has, isLoading, items, remove, toggle]);
 
     return <Ctx.Provider value={api}>{children}</Ctx.Provider>;
 }

--- a/resources/js/shop/main.tsx
+++ b/resources/js/shop/main.tsx
@@ -86,10 +86,10 @@ if (el) {
     createRoot(el).render(
         <React.StrictMode>
             <NotifyProvider autoCloseMs={0}>
-                <CartProvider>
-                    <WishlistProvider>
-                        <LangGate>
-                            <AuthProvider>
+                <AuthProvider>
+                    <CartProvider>
+                        <WishlistProvider>
+                            <LangGate>
                                 <BrowserRouter>
                                     <AppErrorBoundary>
                                         <RouteToastAutoClear/>
@@ -111,10 +111,10 @@ if (el) {
                                         </Routes>
                                     </AppErrorBoundary>
                                 </BrowserRouter>
-                            </AuthProvider>
-                        </LangGate>
-                    </WishlistProvider>
-                </CartProvider>
+                            </LangGate>
+                        </WishlistProvider>
+                    </CartProvider>
+                </AuthProvider>
             </NotifyProvider>
         </React.StrictMode>
     );

--- a/resources/js/shop/pages/Wishlist.tsx
+++ b/resources/js/shop/pages/Wishlist.tsx
@@ -1,27 +1,55 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import {Link} from 'react-router-dom';
 import useWishlist from '../hooks/useWishlist';
-import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { formatPrice } from '../ui/format';
+import {Card} from '@/components/ui/card';
+import {Button} from '@/components/ui/button';
+import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert';
+import {Skeleton} from '@/components/ui/skeleton';
+import {formatPrice} from '../ui/format';
 
 export default function WishlistPage() {
-    const { items, clear } = useWishlist();
+    const {items, clear, isLoading, error} = useWishlist();
+    const hasItems = items.length > 0;
 
     return (
         <div className="mx-auto w-full max-w-7xl px-4 py-6" data-testid="wishlist-page">
             <div className="mb-4 flex items-center justify-between">
                 <h1 className="text-2xl font-semibold">Обране</h1>
-                {items.length > 0 && (
-                    <Button variant="outline" onClick={() => clear()}>Очистити</Button>
+                {hasItems && (
+                    <Button variant="outline" onClick={() => clear()} disabled={isLoading}>
+                        Очистити
+                    </Button>
                 )}
             </div>
 
-            {items.length === 0 ? (
-                <div className="text-muted-foreground" data-testid="wishlist-empty">
-                    Поки що порожньо.
+            {isLoading && (
+                <div className="mb-4 text-sm text-muted-foreground" data-testid="wishlist-loading">
+                    Оновлюємо список бажаного...
                 </div>
-            ) : (
+            )}
+
+            {error && (
+                <Alert variant="destructive" className="mb-4" data-testid="wishlist-error">
+                    <AlertTitle>Не вдалося оновити список</AlertTitle>
+                    <AlertDescription>{error}</AlertDescription>
+                </Alert>
+            )}
+
+            {isLoading && !hasItems ? (
+                <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+                    {Array.from({length: 4}).map((_, idx) => (
+                        <Card key={`wishlist-skeleton-${idx}`} className="overflow-hidden">
+                            <div className="aspect-square bg-muted/40">
+                                <Skeleton className="h-full w-full" />
+                            </div>
+                            <div className="space-y-2 p-3">
+                                <Skeleton className="h-4 w-3/4" />
+                                <Skeleton className="h-4 w-1/2" />
+                            </div>
+                        </Card>
+                    ))}
+                </div>
+            ) : hasItems ? (
                 <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
                     {items.map(p => (
                         <Card key={`${p.id}-${p.slug ?? ''}`} className="overflow-hidden" data-testid="wishlist-card">
@@ -30,7 +58,9 @@ export default function WishlistPage() {
                                     {p.preview_url ? (
                                         <img src={p.preview_url} alt={p.name} className="h-full w-full object-cover" />
                                     ) : (
-                                        <div className="flex h-full items-center justify-center text-sm text-muted-foreground">без фото</div>
+                                        <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                                            без фото
+                                        </div>
                                     )}
                                 </div>
                                 <div className="p-3">
@@ -40,6 +70,10 @@ export default function WishlistPage() {
                             </Link>
                         </Card>
                     ))}
+                </div>
+            ) : (
+                <div className="text-muted-foreground" data-testid="wishlist-empty">
+                    Поки що порожньо.
                 </div>
             )}
         </div>


### PR DESCRIPTION
## Summary
- update the wishlist hook to read auth state, merge local items with the remote API, and expose loading/error flags
- render loading placeholders and error alerts on the wishlist page
- reorder providers so the wishlist context can access authentication data

## Testing
- npm run lint *(fails: repository currently has numerous pre-existing lint errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68c94f007d9c833185c7c713365a3e9d