### PR TITLE
Add profile section pages for orders, addresses, and points

### DIFF
--- a/resources/js/components/nav-user.tsx
+++ b/resources/js/components/nav-user.tsx
@@ -1,16 +1,38 @@
-import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuGroup,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar } from '@/components/ui/sidebar';
 import { UserInfo } from '@/components/user-info';
-import { UserMenuContent } from '@/components/user-menu-content';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { useMobileNavigation } from '@/hooks/use-mobile-navigation';
+import { logout } from '@/routes';
 import { type SharedData } from '@/types';
-import { usePage } from '@inertiajs/react';
-import { ChevronsUpDown } from 'lucide-react';
+import { Link, router, usePage } from '@inertiajs/react';
+import { ChevronsUpDown, LogOut, MapPin, Package, Sparkles, User as UserIcon } from 'lucide-react';
+
+const profileLinks = [
+    { href: '/profile', label: 'Профіль', icon: UserIcon },
+    { href: '/profile/orders', label: 'Мої замовлення', icon: Package },
+    { href: '/profile/addresses', label: 'Збережені адреси', icon: MapPin },
+    { href: '/profile/points', label: 'Бонусні бали', icon: Sparkles },
+] as const;
 
 export function NavUser() {
     const { auth } = usePage<SharedData>().props;
     const { state } = useSidebar();
     const isMobile = useIsMobile();
+    const cleanup = useMobileNavigation();
+
+    const handleLogout = () => {
+        cleanup();
+        router.flushAll();
+    };
 
     return (
         <SidebarMenu>
@@ -27,7 +49,33 @@ export function NavUser() {
                         align="end"
                         side={isMobile ? 'bottom' : state === 'collapsed' ? 'left' : 'bottom'}
                     >
-                        <UserMenuContent user={auth.user} />
+                        <DropdownMenuLabel className="p-0 font-normal">
+                            <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+                                <UserInfo user={auth.user} showEmail={true} />
+                            </div>
+                        </DropdownMenuLabel>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuGroup>
+                            {profileLinks.map((item) => (
+                                <DropdownMenuItem asChild key={item.href}>
+                                    <a
+                                        href={item.href}
+                                        onClick={cleanup}
+                                        className="flex items-center gap-2 px-1 py-1 text-sm text-foreground hover:no-underline"
+                                    >
+                                        <item.icon className="h-4 w-4" />
+                                        {item.label}
+                                    </a>
+                                </DropdownMenuItem>
+                            ))}
+                        </DropdownMenuGroup>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem asChild>
+                            <Link className="flex items-center gap-2" href={logout()} as="button" onClick={handleLogout}>
+                                <LogOut className="h-4 w-4" />
+                                Вийти
+                            </Link>
+                        </DropdownMenuItem>
                     </DropdownMenuContent>
                 </DropdownMenu>
             </SidebarMenuItem>

--- a/resources/js/shop/api.tsx
+++ b/resources/js/shop/api.tsx
@@ -1,15 +1,12 @@
-import axios from 'axios'
-import { normalizeLang } from './i18n/config';
+import axios from 'axios';
 import type { WishItem } from './ui/wishlist';
 
-const API_BASE =
-    (import.meta as any).env?.VITE_API_URL ||
-    'http://localhost:8080/api'
+const API_BASE = (import.meta as any).env?.VITE_API_URL || 'http://localhost:8080/api';
 
 export const api = axios.create({
     baseURL: API_BASE,
     withCredentials: true, // потрібні cookie (cart_id)
-})
+});
 
 /* ==================== TYPES ==================== */
 export type AuthUser = {
@@ -26,80 +23,80 @@ type AuthTokenResponse = {
 };
 
 export type Image = {
-    id: number
-    url: string
-    alt?: string
-    is_primary?: boolean
-}
+    id: number;
+    url: string;
+    alt?: string;
+    is_primary?: boolean;
+};
 
 export type Product = {
-    id: number
-    name: string
-    slug: string
-    category_id: number
-    price: number | string
-    price_old?: number | string | null
-    preview_url?: string | null
+    id: number;
+    name: string;
+    slug: string;
+    category_id: number;
+    price: number | string;
+    price_old?: number | string | null;
+    preview_url?: string | null;
     images?: { url: string; alt?: string; is_primary?: boolean }[];
-    [k: string]: any
-}
+    [k: string]: any;
+};
 
 export type ProductsQuery = {
     page?: number;
     per_page?: number;
     category_id?: number;
     search?: string;
-    sort?: 'new'|'price_asc'|'price_desc';
+    sort?: 'new' | 'price_asc' | 'price_desc';
     color?: string[];
     size?: string[];
     min_price?: number;
     max_price?: number;
-    with_facets?: 0|1;
+    with_facets?: 0 | 1;
 };
 
 export type Category = {
-    id: number
-    name: string
-    slug?: string
-}
+    id: number;
+    name: string;
+    slug?: string;
+};
 
 export type Paginated<T> = {
-    data: T[]
-    current_page?: number
-    last_page?: number
-    per_page?: number | string
-    total?: number
-    next_page_url?: string | null
-    prev_page_url?: string | null
-    [k: string]: any
-}
+    data: T[];
+    current_page?: number;
+    last_page?: number;
+    per_page?: number | string;
+    total?: number;
+    next_page_url?: string | null;
+    prev_page_url?: string | null;
+    [k: string]: any;
+};
 
 export type CartItem = {
-    id: number
-    product_id: number
-    name?: string
-    slug?: string
-    image?: string
-    price: number | string
-    qty: number
-    line_total?: number
-    product?: Product
-}
+    id: number;
+    product_id: number;
+    name?: string;
+    slug?: string;
+    image?: string;
+    price: number | string;
+    qty: number;
+    line_total?: number;
+    product?: Product;
+};
 
 export type Cart = {
-    id: string
-    status: 'active' | 'ordered' | string
-    items: CartItem[]
-    total: number | string
-    subtotal?: number | string
+    id: string;
+    status: 'active' | 'ordered' | string;
+    items: CartItem[];
+    total: number | string;
+    subtotal?: number | string;
     discounts?: {
-        coupon?: { code?: string | null; amount?: number | string | null }
-        loyalty_points?: { used?: number | string | null; value?: number | string | null }
-        total?: number | string | null
-    }
-    available_points?: number
-    max_redeemable_points?: number
-}
+        coupon?: { code?: string | null; amount?: number | string | null };
+        loyalty_points?: { used?: number | string | null; value?: number | string | null };
+        total?: number | string | null;
+    };
+    available_points?: number;
+    max_redeemable_points?: number;
+};
 export type Facets = Record<string, Record<string, number>>;
 
 export type PaginatedWithFacets<T> = Paginated<T> & {
@@ -107,90 +104,110 @@ export type PaginatedWithFacets<T> = Paginated<T> & {
 };
 
 export type ReviewUser = {
-    id: number
-    name: string
-}
+    id: number;
+    name: string;
+};
 
 export type Review = {
-    id: number
-    product_id: number
-    user_id: number
-    rating: number
-    text?: string | null
-    status?: string | null
-    created_at?: string | null
-    updated_at?: string | null
-    user?: ReviewUser | null
-}
+    id: number;
+    product_id: number;
+    user_id: number;
+    rating: number;
+    text?: string | null;
+    status?: string | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+    user?: ReviewUser | null;
+};
 
 type ReviewListResponse = {
-    data: Review[]
-    average_rating: number | string | null
-    reviews_count: number
-}
+    data: Review[];
+    average_rating: number | string | null;
+    reviews_count: number;
+};
 
 type ReviewCreatePayload = {
-    rating: number
-    text?: string | null
-}
+    rating: number;
+    text?: string | null;
+};
 
 type ReviewCreateResponse = {
-    data: Review
-    message?: string
-}
+    data: Review;
+    message?: string;
+};
 
 export type Address = {
-    id: number
-    name: string
-    city: string
-    addr: string
-    postal_code?: string | null
-    phone?: string | null
-}
+    id: number;
+    name: string;
+    city: string;
+    addr: string;
+    postal_code?: string | null;
+    phone?: string | null;
+};
 
 export type Shipment = {
-    status?: string | null
-    tracking_number?: string | null
-    shipped_at?: string | null
-    delivered_at?: string | null
-}
+    status?: string | null;
+    tracking_number?: string | null;
+    shipped_at?: string | null;
+    delivered_at?: string | null;
+};
 
 export type OrderItemResponse = {
-    id: number
-    product_id: number
-    qty: number
-    price: number | string
-    subtotal?: number | string
-    preview_url?: string | null
-    name?: string | null
-    product?: Product | null
-}
+    id: number;
+    product_id: number;
+    qty: number;
+    price: number | string;
+    subtotal?: number | string;
+    preview_url?: string | null;
+    name?: string | null;
+    product?: Product | null;
+};
 
 export type OrderResponse = {
-    number: string
-    email: string
-    status?: string
-    payment_status?: string | null
-    subtotal?: number | string
-    total: number | string
-    discount_total?: number | string | null
-    coupon_code?: string | null
-    coupon_discount?: number | string | null
-    loyalty_points_used?: number | string | null
-    loyalty_points_value?: number | string | null
-    currency?: string
-    base_currency?: string
-    items: OrderItemResponse[]
-    shipment?: Shipment | null
+    number: string;
+    email: string;
+    status?: string;
+    payment_status?: string | null;
+    subtotal?: number | string;
+    total: number | string;
+    discount_total?: number | string | null;
+    coupon_code?: string | null;
+    coupon_discount?: number | string | null;
+    loyalty_points_used?: number | string | null;
+    loyalty_points_value?: number | string | null;
+    currency?: string;
+    base_currency?: string;
+    items: OrderItemResponse[];
+    shipment?: Shipment | null;
     shipping_address?: {
-        name?: string
-        city?: string
-        addr?: string
-        postal_code?: string | null
-        phone?: string | null
-    }
-    note?: string | null
-}
+        name?: string;
+        city?: string;
+        addr?: string;
+        postal_code?: string | null;
+        phone?: string | null;
+    };
+    note?: string | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+};
+
+export type LoyaltyPointTransaction = {
+    id: number;
+    order_id?: number | null;
+    type?: string | null;
+    points: number | string;
+    amount?: number | string | null;
+    description?: string | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+};
+
+export type LoyaltyPointsResponse = {
+    balance: number;
+    transactions: LoyaltyPointTransaction[];
+    total_earned?: number | string | null;
+    total_spent?: number | string | null;
+};
 
 /* ==================== AUTH ==================== */
 export const AuthApi = {
@@ -228,28 +245,28 @@ export const ProductsApi = {
         per_page?: number;
         search?: string;
         category_id?: number;
-        sort?: 'new'|'price_asc'|'price_desc';
-        with_facets?: 0|1;
+        sort?: 'new' | 'price_asc' | 'price_desc';
+        with_facets?: 0 | 1;
     }) {
-        return api.get('/products', { params }).then(r => r.data);
+        return api.get('/products', { params }).then((r) => r.data);
     },
     show(slug: string) {
-        return api.get<Product>(`/products/${encodeURIComponent(slug)}`).then(r => r.data)
+        return api.get<Product>(`/products/${encodeURIComponent(slug)}`).then((r) => r.data);
     },
     related: fetchRelatedProducts,
-}
+};
 
 export const CategoriesApi = {
     list() {
-        return api.get<Category[]>('/categories').then(r => r.data)
+        return api.get<Category[]>('/categories').then((r) => r.data);
     },
-}
+};
 
 export const AddressesApi = {
     list() {
-        return api.get<Address[]>('/profile/addresses').then(r => r.data)
+        return api.get<Address[]>('/profile/addresses').then((r) => r.data);
     },
-}
+};
 
 /* Сумісні з існуючим кодом Catalog.tsx обгортки: */
 export async function fetchProducts(params: ProductsQuery) {
@@ -257,32 +274,27 @@ export async function fetchProducts(params: ProductsQuery) {
         params: {
             ...params,
             color: params.color && params.color.length ? params.color : undefined,
-            size:  params.size  && params.size.length  ? params.size  : undefined,
+            size: params.size && params.size.length ? params.size : undefined,
             min_price: params.min_price ?? undefined,
             max_price: params.max_price ?? undefined,
-        }
+        },
     });
     return r.data as PaginatedWithFacets<Product>;
 }
 
-export async function fetchProductFacets(params: {
-    search?: string;
-    category_id?: number;
-    color?: string[];
-    size?: string[];
-}) {
+export async function fetchProductFacets(params: { search?: string; category_id?: number; color?: string[]; size?: string[] }) {
     const sp = new URLSearchParams();
     if (params.search) sp.set('search', params.search);
     if (params.category_id) sp.set('category_id', String(params.category_id));
-    (params.color ?? []).forEach(c => sp.append('filter[color][]', c));
-    (params.size  ?? []).forEach(s => sp.append('filter[size][]', s));
+    (params.color ?? []).forEach((c) => sp.append('filter[color][]', c));
+    (params.size ?? []).forEach((s) => sp.append('filter[size][]', s));
 
     const { data } = await api.get(`/products/facets?${sp.toString()}`);
     return data as {
         facets: {
             ['category_id']?: Record<string, number>;
             ['attrs.color']?: Record<string, number>;
-            ['attrs.size']?:  Record<string, number>;
+            ['attrs.size']?: Record<string, number>;
         };
         nbHits: number;
         driver: string;
@@ -290,34 +302,29 @@ export async function fetchProductFacets(params: {
     };
 }
 
-export async function fetchRelatedProducts(
-    category_id: number,
-    exclude_id?: number,
-    limit = 4
-): Promise<Product[]> {
+export async function fetchRelatedProducts(category_id: number, exclude_id?: number, limit = 4): Promise<Product[]> {
     const res = await fetchProducts({ page: 1, per_page: limit + 1, category_id, sort: 'new' });
     const items = res.data ?? [];
-    const filtered = exclude_id ? items.filter(p => p.id !== exclude_id) : items;
+    const filtered = exclude_id ? items.filter((p) => p.id !== exclude_id) : items;
     return filtered.slice(0, limit);
 }
 
-
 export async function fetchCategories(): Promise<Category[]> {
-    return CategoriesApi.list()
+    return CategoriesApi.list();
 }
 
 /* ==================== REVIEWS ==================== */
 
 export const ReviewsApi = {
     async list(productId: number): Promise<ReviewListResponse> {
-        const { data } = await api.get<ReviewListResponse>(`/products/${encodeURIComponent(productId)}/reviews`)
-        return data
+        const { data } = await api.get<ReviewListResponse>(`/products/${encodeURIComponent(productId)}/reviews`);
+        return data;
     },
     async create(productId: number, payload: ReviewCreatePayload): Promise<ReviewCreateResponse> {
-        const { data } = await api.post<ReviewCreateResponse>(`/products/${encodeURIComponent(productId)}/reviews`, payload)
-        return data
+        const { data } = await api.post<ReviewCreateResponse>(`/products/${encodeURIComponent(productId)}/reviews`, payload);
+        return data;
     },
-}
+};
 
 /* ==================== WISHLIST ==================== */
 
@@ -336,63 +343,66 @@ export const WishlistApi = {
 };
 
 /* ==================== CART ==================== */
-let activeCartId: string | null = null
-const setActiveCartId = (id: string) => { activeCartId = id }
+let activeCartId: string | null = null;
+const setActiveCartId = (id: string) => {
+    activeCartId = id;
+};
 
 export function resetCartCache() {
     activeCartId = null;
 }
 
-
-export const CART_KEY = 'cart_id'
-export async function ensureCartId() { return requireCartId() }
+export const CART_KEY = 'cart_id';
+export async function ensureCartId() {
+    return requireCartId();
+}
 export async function fetchCartById(id: string) {
-    const { data } = await api.get<Cart>(`/cart/${id}`)
-    setActiveCartId(data.id)
-    return data
+    const { data } = await api.get<Cart>(`/cart/${id}`);
+    setActiveCartId(data.id);
+    return data;
 }
 
 async function getCart(): Promise<Cart> {
-    const { data } = await api.get<Cart>('/cart')
-    setActiveCartId(data.id)
-    return data
+    const { data } = await api.get<Cart>('/cart');
+    setActiveCartId(data.id);
+    return data;
 }
 async function showCart(id: string): Promise<Cart> {
-    const { data } = await api.get<Cart>(`/cart/${id}`)
-    setActiveCartId(data.id)
-    return data
+    const { data } = await api.get<Cart>(`/cart/${id}`);
+    setActiveCartId(data.id);
+    return data;
 }
 async function requireCartId(): Promise<string> {
-    if (activeCartId) return activeCartId
-    const { data } = await api.get<Cart>('/cart') // створить активний кошик і поверне id
-    setActiveCartId(data.id)
-    return data.id
+    if (activeCartId) return activeCartId;
+    const { data } = await api.get<Cart>('/cart'); // створить активний кошик і поверне id
+    setActiveCartId(data.id);
+    return data.id;
 }
 
 async function addToCart(product_id: number, qty = 1): Promise<Cart> {
-    const id = await requireCartId()
-    const { data } = await api.post<Cart>(`/cart/${id}/items`, { product_id, qty })
-    setActiveCartId(data.id)
-    return data
+    const id = await requireCartId();
+    const { data } = await api.post<Cart>(`/cart/${id}/items`, { product_id, qty });
+    setActiveCartId(data.id);
+    return data;
 }
 async function updateCartItem(item_id: number, qty: number): Promise<Cart> {
-    const id = await requireCartId()
-    const { data } = await api.patch<Cart>(`/cart/${id}/items/${item_id}`, { qty })
-    return data
+    const id = await requireCartId();
+    const { data } = await api.patch<Cart>(`/cart/${id}/items/${item_id}`, { qty });
+    return data;
 }
 async function removeCartItem(item_id: number): Promise<Cart> {
-    const id = await requireCartId()
-    const { data } = await api.delete<Cart>(`/cart/${id}/items/${item_id}`)
-    return data
+    const id = await requireCartId();
+    const { data } = await api.delete<Cart>(`/cart/${id}/items/${item_id}`);
+    return data;
 }
 async function applyCouponToCart(code?: string | null): Promise<Cart> {
-    const cart_id = await requireCartId()
+    const cart_id = await requireCartId();
     const { data } = await api.post<Cart>('/cart/apply-coupon', {
         cart_id,
         code: code ?? null,
-    })
-    setActiveCartId(data.id)
-    return data
+    });
+    setActiveCartId(data.id);
+    return data;
 }
 async function refreshCart(): Promise<Cart> {
     try {
@@ -417,31 +427,34 @@ export const CartApi = {
     remove: removeCartItem,
     applyCoupon: applyCouponToCart,
     refresh: refreshCart,
-}
+};
 
 /* ==================== ORDERS ==================== */
 
 export const OrdersApi = {
     async create(payload: {
-        email: string
+        email: string;
         shipping_address: {
-            name: string
-            city: string
-            addr: string
-            postal_code?: string | null
-            phone?: string | null
-        }
-        billing_address?: Record<string, unknown>
-        note?: string
+            name: string;
+            city: string;
+            addr: string;
+            postal_code?: string | null;
+            phone?: string | null;
+        };
+        billing_address?: Record<string, unknown>;
+        note?: string;
     }): Promise<OrderResponse> {
-        const cart_id = await requireCartId()
-        const { data } = await api.post<OrderResponse>('/orders', { cart_id, ...payload })
-        return data
+        const cart_id = await requireCartId();
+        const { data } = await api.post<OrderResponse>('/orders', { cart_id, ...payload });
+        return data;
     },
     show(number: string) {
-        return api.get<OrderResponse>(`/orders/${encodeURIComponent(number)}`).then(r => r.data)
+        return api.get<OrderResponse>(`/orders/${encodeURIComponent(number)}`).then((r) => r.data);
     },
-}
+    listMine() {
+        return api.get<OrderResponse[]>('/profile/orders').then((r) => r.data);
+    },
+};
 
 export async function refreshOrderStatus(number: string, payment_intent?: string) {
     const res = await fetch(`/api/payment/refresh/${encodeURIComponent(number)}`, {
@@ -452,3 +465,9 @@ export async function refreshOrderStatus(number: string, payment_intent?: string
     if (!res.ok) throw new Error('refresh failed');
     return res.json();
 }
+
+export const ProfileApi = {
+    fetchPoints() {
+        return api.get<LoyaltyPointsResponse>('/profile/points').then((r) => r.data);
+    },
+};

--- a/resources/js/shop/components/ProfileNavigation.tsx
+++ b/resources/js/shop/components/ProfileNavigation.tsx
@@ -1,0 +1,35 @@
+import { NavLink } from 'react-router-dom';
+
+const links = [
+    { to: '/profile', label: 'Профіль', end: true },
+    { to: '/profile/orders', label: 'Мої замовлення' },
+    { to: '/profile/addresses', label: 'Збережені адреси' },
+    { to: '/profile/points', label: 'Бонусні бали' },
+] as const;
+
+export default function ProfileNavigation() {
+    return (
+        <nav className="mb-6 w-full overflow-x-auto">
+            <ul className="flex gap-2 text-sm">
+                {links.map((link) => (
+                    <li key={link.to}>
+                        <NavLink
+                            to={link.to}
+                            end={link.end}
+                            className={({ isActive }) =>
+                                [
+                                    'inline-flex items-center rounded-full border px-3 py-1 transition-colors',
+                                    isActive
+                                        ? 'border-black bg-black text-white'
+                                        : 'border-gray-200 text-gray-700 hover:border-black hover:text-black',
+                                ].join(' ')
+                            }
+                        >
+                            {link.label}
+                        </NavLink>
+                    </li>
+                ))}
+            </ul>
+        </nav>
+    );
+}

--- a/resources/js/shop/main.tsx
+++ b/resources/js/shop/main.tsx
@@ -1,30 +1,33 @@
 import React from 'react';
-import {createRoot} from 'react-dom/client';
-import {BrowserRouter, Routes, Route, useLocation} from 'react-router-dom';
-import CatalogPage from './pages/Catalog';
-import ProductPage from './pages/Product';
-import CartPage from './pages/Cart';
-import CheckoutPage from './pages/Checkout';
-import OrderConfirmationPage from './pages/OrderConfirmation';
-import {NotifyProvider, useNotify} from './ui/notify';
-import {CartProvider} from './useCart';
-import Header from './components/Header';
-import {WishlistProvider} from './hooks/useWishlist';
-import WishlistPage from './pages/Wishlist';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom';
 import '../../css/app.css';
-import {AppErrorBoundary} from './ui/ErrorBoundary';
-import JsonLd from './components/JsonLd';
 import CookieConsent from './components/CookieConsent';
-import {initAnalyticsOnLoad} from './ui/analytics';
-import {initMonitoring} from './monitoring';
-import NotFoundPage from './pages/NotFound';
-import './sentry';
+import Header from './components/Header';
+import JsonLd from './components/JsonLd';
+import { AuthProvider } from './hooks/useAuth';
+import { WishlistProvider } from './hooks/useWishlist';
 import LocaleProvider from './i18n/LocaleProvider';
-import {normalizeLang} from './i18n/config';
+import { normalizeLang } from './i18n/config';
+import { initMonitoring } from './monitoring';
+import CartPage from './pages/Cart';
+import CatalogPage from './pages/Catalog';
+import CheckoutPage from './pages/Checkout';
 import LoginPage from './pages/Login';
-import RegisterPage from './pages/Register';
+import NotFoundPage from './pages/NotFound';
+import OrderConfirmationPage from './pages/OrderConfirmation';
+import ProductPage from './pages/Product';
 import ProfilePage from './pages/Profile';
-import {AuthProvider} from './hooks/useAuth';
+import ProfileAddressesPage from './pages/ProfileAddresses';
+import ProfileOrdersPage from './pages/ProfileOrders';
+import ProfilePointsPage from './pages/ProfilePoints';
+import RegisterPage from './pages/Register';
+import WishlistPage from './pages/Wishlist';
+import './sentry';
+import { AppErrorBoundary } from './ui/ErrorBoundary';
+import { initAnalyticsOnLoad } from './ui/analytics';
+import { NotifyProvider, useNotify } from './ui/notify';
+import { CartProvider } from './useCart';
 
 initAnalyticsOnLoad();
 
@@ -34,8 +37,7 @@ const el = document.getElementById('shop-root');
 
 const origin = typeof window !== 'undefined' ? window.location.origin : '';
 
-
-function LangGate({children}: { children: any }) {
+function LangGate({ children }: { children: any }) {
     const seg1 = typeof window !== 'undefined' ? window.location.pathname.split('/').filter(Boolean)[0] : '';
     const lang = normalizeLang(seg1);
     return <LocaleProvider initial={lang}>{children}</LocaleProvider>;
@@ -49,8 +51,8 @@ const websiteLd = {
     potentialAction: {
         '@type': 'SearchAction',
         target: `${origin}/?q={search_term_string}`,
-        'query-input': 'required name=search_term_string'
-    }
+        'query-input': 'required name=search_term_string',
+    },
 };
 
 const orgLd = {
@@ -64,18 +66,20 @@ const orgLd = {
         'https://www.facebook.com/yourpage',
         'https://www.instagram.com/yourpage',
     ],
-    contactPoint: [{
-        '@type': 'ContactPoint',
-        telephone: '+380-00-000-0000',
-        contactType: 'customer service',
-        areaServed: 'UA',
-        availableLanguage: ['uk']
-    }]
+    contactPoint: [
+        {
+            '@type': 'ContactPoint',
+            telephone: '+380-00-000-0000',
+            contactType: 'customer service',
+            areaServed: 'UA',
+            availableLanguage: ['uk'],
+        },
+    ],
 };
 
 function RouteToastAutoClear() {
     const location = useLocation();
-    const {clearAll} = useNotify();
+    const { clearAll } = useNotify();
     React.useEffect(() => {
         clearAll();
     }, [location.pathname, location.search, clearAll]);
@@ -92,22 +96,25 @@ if (el) {
                             <LangGate>
                                 <BrowserRouter>
                                     <AppErrorBoundary>
-                                        <RouteToastAutoClear/>
-                                        <CookieConsent/>
-                                        <Header/>
-                                        <JsonLd data={websiteLd}/>
-                                        <JsonLd data={orgLd}/>
+                                        <RouteToastAutoClear />
+                                        <CookieConsent />
+                                        <Header />
+                                        <JsonLd data={websiteLd} />
+                                        <JsonLd data={orgLd} />
                                         <Routes>
-                                            <Route path="/" element={<CatalogPage/>}/>
-                                            <Route path="/product/:slug" element={<ProductPage/>}/>
-                                            <Route path="/cart" element={<CartPage/>}/>
-                                            <Route path="/checkout" element={<CheckoutPage/>}/>
-                                            <Route path="/order/:number" element={<OrderConfirmationPage/>}/>
-                                            <Route path="/wishlist" element={<WishlistPage/>}/>
-                                            <Route path="/login" element={<LoginPage/>}/>
-                                            <Route path="/register" element={<RegisterPage/>}/>
-                                            <Route path="/profile" element={<ProfilePage/>}/>
-                                            <Route path="*" element={<NotFoundPage/>}/>
+                                            <Route path="/" element={<CatalogPage />} />
+                                            <Route path="/product/:slug" element={<ProductPage />} />
+                                            <Route path="/cart" element={<CartPage />} />
+                                            <Route path="/checkout" element={<CheckoutPage />} />
+                                            <Route path="/order/:number" element={<OrderConfirmationPage />} />
+                                            <Route path="/wishlist" element={<WishlistPage />} />
+                                            <Route path="/login" element={<LoginPage />} />
+                                            <Route path="/register" element={<RegisterPage />} />
+                                            <Route path="/profile" element={<ProfilePage />} />
+                                            <Route path="/profile/orders" element={<ProfileOrdersPage />} />
+                                            <Route path="/profile/addresses" element={<ProfileAddressesPage />} />
+                                            <Route path="/profile/points" element={<ProfilePointsPage />} />
+                                            <Route path="*" element={<NotFoundPage />} />
                                         </Routes>
                                     </AppErrorBoundary>
                                 </BrowserRouter>
@@ -116,6 +123,6 @@ if (el) {
                     </CartProvider>
                 </AuthProvider>
             </NotifyProvider>
-        </React.StrictMode>
+        </React.StrictMode>,
     );
 }

--- a/resources/js/shop/pages/Profile.tsx
+++ b/resources/js/shop/pages/Profile.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import {Navigate, useLocation} from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
+import ProfileNavigation from '../components/ProfileNavigation';
 import useAuth from '../hooks/useAuth';
-import {resolveErrorMessage} from '../lib/errors';
+import { resolveErrorMessage } from '../lib/errors';
 
 export default function ProfilePage() {
-    const {user, isAuthenticated, isReady, isLoading, logout} = useAuth();
+    const { user, isAuthenticated, isReady, isLoading, logout } = useAuth();
     const location = useLocation();
     const [error, setError] = React.useState<string | null>(null);
     const [pending, setPending] = React.useState(false);
@@ -23,7 +24,7 @@ export default function ProfilePage() {
     }
 
     if (!isAuthenticated) {
-        return <Navigate to="/login" state={{from: redirectTo}} replace/>;
+        return <Navigate to="/login" state={{ from: redirectTo }} replace />;
     }
 
     const handleLogout = async () => {
@@ -39,18 +40,18 @@ export default function ProfilePage() {
     };
 
     return (
-        <div className="mx-auto flex min-h-[calc(100vh-3.5rem)] w-full max-w-6xl flex-col items-center justify-center px-4 py-16">
-            <div className="w-full max-w-2xl rounded-lg border bg-white p-8 shadow-sm">
-                <h1 className="mb-6 text-2xl font-semibold">Профіль</h1>
+        <div className="mx-auto flex min-h-[calc(100vh-3.5rem)] w-full max-w-6xl flex-col px-4 py-16">
+            <div className="w-full lg:w-3/4 xl:w-2/3">
+                <h1 className="mb-4 text-2xl font-semibold">Профіль</h1>
                 <p className="mb-6 text-sm text-gray-600">
-                    Ласкаво просимо,{' '}
-                    <span className="font-medium text-gray-900">{user?.name ?? 'користувачу'}</span>.
+                    Ласкаво просимо, <span className="font-medium text-gray-900">{user?.name ?? 'користувачу'}</span>. Керуйте своїми даними та
+                    перейдіть до інших розділів профілю.
                 </p>
-                {error && (
-                    <div className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-                        {error}
-                    </div>
-                )}
+                <ProfileNavigation />
+            </div>
+            <div className="mt-4 w-full max-w-2xl rounded-lg border bg-white p-8 shadow-sm">
+                <h2 className="mb-6 text-xl font-semibold">Особисті дані</h2>
+                {error && <div className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
                 <dl className="space-y-4 text-sm text-gray-700">
                     <div>
                         <dt className="font-medium text-gray-900">ID</dt>
@@ -70,9 +71,7 @@ export default function ProfilePage() {
                     </div>
                 </dl>
                 <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <p className="text-xs text-gray-500">
-                        Токен Sanctum збережено локально для авторизованих запитів до API.
-                    </p>
+                    <p className="text-xs text-gray-500">Токен Sanctum збережено локально для авторизованих запитів до API.</p>
                     <button
                         type="button"
                         onClick={handleLogout}

--- a/resources/js/shop/pages/ProfileAddresses.tsx
+++ b/resources/js/shop/pages/ProfileAddresses.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { AddressesApi, type Address } from '../api';
+import ProfileNavigation from '../components/ProfileNavigation';
+import useAuth from '../hooks/useAuth';
+import { resolveErrorMessage } from '../lib/errors';
+
+export default function ProfileAddressesPage() {
+    const { isAuthenticated, isReady } = useAuth();
+    const location = useLocation();
+    const redirectTo = React.useMemo(() => {
+        const path = `${location.pathname ?? ''}${location.search ?? ''}${location.hash ?? ''}`;
+        return path || '/profile/addresses';
+    }, [location.hash, location.pathname, location.search]);
+
+    const [addresses, setAddresses] = React.useState<Address[]>([]);
+    const [loading, setLoading] = React.useState(false);
+    const [error, setError] = React.useState<string | null>(null);
+
+    React.useEffect(() => {
+        if (!isReady || !isAuthenticated) {
+            return;
+        }
+
+        let ignore = false;
+        setLoading(true);
+        setError(null);
+
+        AddressesApi.list()
+            .then((list) => {
+                if (!ignore) {
+                    setAddresses(list);
+                }
+            })
+            .catch((err) => {
+                if (!ignore) {
+                    setError(resolveErrorMessage(err, 'Не вдалося завантажити адреси.'));
+                }
+            })
+            .finally(() => {
+                if (!ignore) {
+                    setLoading(false);
+                }
+            });
+
+        return () => {
+            ignore = true;
+        };
+    }, [isAuthenticated, isReady]);
+
+    if (!isReady) {
+        return (
+            <div className="flex min-h-[calc(100vh-3.5rem)] items-center justify-center px-4 py-16">
+                <p className="text-sm text-gray-500">Завантаження адрес…</p>
+            </div>
+        );
+    }
+
+    if (!isAuthenticated) {
+        return <Navigate to="/login" state={{ from: redirectTo }} replace />;
+    }
+
+    return (
+        <div className="mx-auto flex min-h-[calc(100vh-3.5rem)] w-full max-w-6xl flex-col px-4 py-16">
+            <div className="w-full">
+                <h1 className="mb-4 text-2xl font-semibold">Збережені адреси</h1>
+                <p className="mb-8 text-sm text-gray-600">Керуйте адресами доставки, щоб швидко оформлювати нові замовлення.</p>
+                <ProfileNavigation />
+                {error && <div className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
+                {loading ? (
+                    <div className="flex items-center justify-center rounded-lg border bg-white px-6 py-16 text-sm text-gray-500 shadow-sm">
+                        Завантаження…
+                    </div>
+                ) : addresses.length === 0 ? (
+                    <div className="rounded-lg border bg-white px-6 py-16 text-center text-sm text-gray-600 shadow-sm">
+                        У вас ще немає збережених адрес. Додайте адресу під час оформлення замовлення.
+                    </div>
+                ) : (
+                    <div className="grid gap-4 sm:grid-cols-2">
+                        {addresses.map((address) => (
+                            <article key={address.id} className="rounded-lg border bg-white p-6 shadow-sm">
+                                <h2 className="text-base font-semibold text-gray-900">{address.name || 'Без назви'}</h2>
+                                <dl className="mt-4 space-y-2 text-sm text-gray-700">
+                                    <div>
+                                        <dt className="font-medium text-gray-900">Місто</dt>
+                                        <dd>{address.city || '—'}</dd>
+                                    </div>
+                                    <div>
+                                        <dt className="font-medium text-gray-900">Адреса</dt>
+                                        <dd>{address.addr || '—'}</dd>
+                                    </div>
+                                    {address.postal_code && (
+                                        <div>
+                                            <dt className="font-medium text-gray-900">Поштовий індекс</dt>
+                                            <dd>{address.postal_code}</dd>
+                                        </div>
+                                    )}
+                                    {address.phone && (
+                                        <div>
+                                            <dt className="font-medium text-gray-900">Телефон</dt>
+                                            <dd>{address.phone}</dd>
+                                        </div>
+                                    )}
+                                </dl>
+                            </article>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/resources/js/shop/pages/ProfileOrders.tsx
+++ b/resources/js/shop/pages/ProfileOrders.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { Link, Navigate, useLocation } from 'react-router-dom';
+import { OrdersApi, type OrderResponse } from '../api';
+import ProfileNavigation from '../components/ProfileNavigation';
+import useAuth from '../hooks/useAuth';
+import { resolveErrorMessage } from '../lib/errors';
+import { formatPrice } from '../ui/format';
+
+function formatDate(dateString?: string | null) {
+    if (!dateString) return '—';
+    const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) {
+        return dateString;
+    }
+    return date.toLocaleDateString('uk-UA', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+}
+
+export default function ProfileOrdersPage() {
+    const { isAuthenticated, isReady } = useAuth();
+    const location = useLocation();
+    const redirectTo = React.useMemo(() => {
+        const path = `${location.pathname ?? ''}${location.search ?? ''}${location.hash ?? ''}`;
+        return path || '/profile/orders';
+    }, [location.hash, location.pathname, location.search]);
+
+    const [orders, setOrders] = React.useState<OrderResponse[]>([]);
+    const [loading, setLoading] = React.useState(false);
+    const [error, setError] = React.useState<string | null>(null);
+
+    React.useEffect(() => {
+        if (!isReady || !isAuthenticated) {
+            return;
+        }
+
+        let ignore = false;
+        setLoading(true);
+        setError(null);
+
+        OrdersApi.listMine()
+            .then((list) => {
+                if (!ignore) {
+                    setOrders(list);
+                }
+            })
+            .catch((err) => {
+                if (!ignore) {
+                    setError(resolveErrorMessage(err, 'Не вдалося завантажити замовлення.'));
+                }
+            })
+            .finally(() => {
+                if (!ignore) {
+                    setLoading(false);
+                }
+            });
+
+        return () => {
+            ignore = true;
+        };
+    }, [isAuthenticated, isReady]);
+
+    if (!isReady) {
+        return (
+            <div className="flex min-h-[calc(100vh-3.5rem)] items-center justify-center px-4 py-16">
+                <p className="text-sm text-gray-500">Завантаження замовлень…</p>
+            </div>
+        );
+    }
+
+    if (!isAuthenticated) {
+        return <Navigate to="/login" state={{ from: redirectTo }} replace />;
+    }
+
+    return (
+        <div className="mx-auto flex min-h-[calc(100vh-3.5rem)] w-full max-w-6xl flex-col px-4 py-16">
+            <div className="w-full">
+                <h1 className="mb-4 text-2xl font-semibold">Мої замовлення</h1>
+                <p className="mb-8 text-sm text-gray-600">Переглядайте історію покупок, статус замовлень та переходьте до їх деталей.</p>
+                <ProfileNavigation />
+                {error && <div className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
+                <div className="overflow-hidden rounded-lg border bg-white shadow-sm">
+                    {loading ? (
+                        <div className="flex items-center justify-center px-6 py-16 text-sm text-gray-500">Завантаження…</div>
+                    ) : orders.length === 0 ? (
+                        <div className="px-6 py-16 text-center text-sm text-gray-600">
+                            Ви ще не зробили жодного замовлення.{' '}
+                            <Link className="underline" to="/">
+                                Перейти до каталогу
+                            </Link>
+                            .
+                        </div>
+                    ) : (
+                        <div className="overflow-x-auto">
+                            <table className="min-w-full divide-y divide-gray-200 text-sm">
+                                <thead className="bg-gray-50">
+                                    <tr className="text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
+                                        <th className="px-4 py-3">Номер</th>
+                                        <th className="px-4 py-3">Дата</th>
+                                        <th className="px-4 py-3">Статус</th>
+                                        <th className="px-4 py-3">Сума</th>
+                                        <th className="px-4 py-3">Дії</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-gray-200">
+                                    {orders.map((order) => {
+                                        const total = formatPrice(order.total, order.currency ?? 'EUR');
+                                        return (
+                                            <tr key={order.number} className="hover:bg-gray-50">
+                                                <td className="px-4 py-4 font-medium text-gray-900">{order.number}</td>
+                                                <td className="px-4 py-4 text-gray-700">{formatDate(order.created_at)}</td>
+                                                <td className="px-4 py-4 text-gray-700">{order.status ?? '—'}</td>
+                                                <td className="px-4 py-4 text-gray-900">{total}</td>
+                                                <td className="px-4 py-4">
+                                                    <Link
+                                                        className="text-xs font-medium text-blue-600 hover:text-blue-800"
+                                                        to={`/order/${order.number}`}
+                                                    >
+                                                        Деталі замовлення
+                                                    </Link>
+                                                </td>
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                            </table>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/shop/pages/ProfilePoints.tsx
+++ b/resources/js/shop/pages/ProfilePoints.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { ProfileApi, type LoyaltyPointTransaction, type LoyaltyPointsResponse } from '../api';
+import ProfileNavigation from '../components/ProfileNavigation';
+import useAuth from '../hooks/useAuth';
+import { resolveErrorMessage } from '../lib/errors';
+
+function formatDate(dateString?: string | null) {
+    if (!dateString) return '—';
+    const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) {
+        return dateString;
+    }
+    return date.toLocaleDateString('uk-UA', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+    });
+}
+
+function getTransactionTypeLabel(type?: string | null) {
+    if (!type) {
+        return 'Операція';
+    }
+
+    switch (type) {
+        case 'earn':
+        case 'earned':
+            return 'Нарахування';
+        case 'redeem':
+        case 'spent':
+            return 'Списання';
+        default:
+            return type;
+    }
+}
+
+function normalizePoints(value: number | string) {
+    const numeric = typeof value === 'string' ? Number(value) : value;
+    if (Number.isNaN(numeric)) {
+        return value;
+    }
+    return numeric;
+}
+
+export default function ProfilePointsPage() {
+    const { isAuthenticated, isReady } = useAuth();
+    const location = useLocation();
+    const redirectTo = React.useMemo(() => {
+        const path = `${location.pathname ?? ''}${location.search ?? ''}${location.hash ?? ''}`;
+        return path || '/profile/points';
+    }, [location.hash, location.pathname, location.search]);
+
+    const [data, setData] = React.useState<LoyaltyPointsResponse | null>(null);
+    const [loading, setLoading] = React.useState(false);
+    const [error, setError] = React.useState<string | null>(null);
+
+    React.useEffect(() => {
+        if (!isReady || !isAuthenticated) {
+            return;
+        }
+
+        let ignore = false;
+        setLoading(true);
+        setError(null);
+
+        ProfileApi.fetchPoints()
+            .then((payload) => {
+                if (!ignore) {
+                    setData(payload);
+                }
+            })
+            .catch((err) => {
+                if (!ignore) {
+                    setError(resolveErrorMessage(err, 'Не вдалося завантажити інформацію про бали.'));
+                }
+            })
+            .finally(() => {
+                if (!ignore) {
+                    setLoading(false);
+                }
+            });
+
+        return () => {
+            ignore = true;
+        };
+    }, [isAuthenticated, isReady]);
+
+    if (!isReady) {
+        return (
+            <div className="flex min-h-[calc(100vh-3.5rem)] items-center justify-center px-4 py-16">
+                <p className="text-sm text-gray-500">Завантаження балів…</p>
+            </div>
+        );
+    }
+
+    if (!isAuthenticated) {
+        return <Navigate to="/login" state={{ from: redirectTo }} replace />;
+    }
+
+    const transactions: LoyaltyPointTransaction[] = data?.transactions ?? [];
+    const balance = data?.balance ?? 0;
+    const totalEarned = data?.total_earned;
+    const totalSpent = data?.total_spent;
+
+    return (
+        <div className="mx-auto flex min-h-[calc(100vh-3.5rem)] w-full max-w-6xl flex-col px-4 py-16">
+            <div className="w-full">
+                <h1 className="mb-4 text-2xl font-semibold">Бонусні бали</h1>
+                <p className="mb-8 text-sm text-gray-600">Відстежуйте доступний баланс та історію використання бонусних балів.</p>
+                <ProfileNavigation />
+                {error && <div className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
+                <div className="mb-6 grid gap-4 rounded-lg border bg-white p-6 shadow-sm sm:grid-cols-3">
+                    <div>
+                        <p className="text-xs text-gray-500 uppercase">Доступно</p>
+                        <p className="mt-2 text-3xl font-semibold text-gray-900">{balance}</p>
+                    </div>
+                    <div>
+                        <p className="text-xs text-gray-500 uppercase">Нараховано</p>
+                        <p className="mt-2 text-lg font-medium text-gray-900">
+                            {typeof totalEarned === 'number' || typeof totalEarned === 'string' ? normalizePoints(totalEarned) : '—'}
+                        </p>
+                    </div>
+                    <div>
+                        <p className="text-xs text-gray-500 uppercase">Використано</p>
+                        <p className="mt-2 text-lg font-medium text-gray-900">
+                            {typeof totalSpent === 'number' || typeof totalSpent === 'string' ? normalizePoints(totalSpent) : '—'}
+                        </p>
+                    </div>
+                </div>
+                <div className="overflow-hidden rounded-lg border bg-white shadow-sm">
+                    {loading ? (
+                        <div className="flex items-center justify-center px-6 py-16 text-sm text-gray-500">Завантаження…</div>
+                    ) : transactions.length === 0 ? (
+                        <div className="px-6 py-16 text-center text-sm text-gray-600">
+                            Історія балів порожня. Використовуйте бали під час оформлення замовлень, щоб побачити рух коштів.
+                        </div>
+                    ) : (
+                        <div className="overflow-x-auto">
+                            <table className="min-w-full divide-y divide-gray-200 text-sm">
+                                <thead className="bg-gray-50">
+                                    <tr className="text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
+                                        <th className="px-4 py-3">Дата</th>
+                                        <th className="px-4 py-3">Опис</th>
+                                        <th className="px-4 py-3">Тип</th>
+                                        <th className="px-4 py-3">Кількість</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-gray-200">
+                                    {transactions.map((transaction) => {
+                                        const pointsValue = normalizePoints(transaction.points);
+                                        return (
+                                            <tr key={transaction.id} className="hover:bg-gray-50">
+                                                <td className="px-4 py-4 text-gray-700">{formatDate(transaction.created_at)}</td>
+                                                <td className="px-4 py-4 text-gray-700">{transaction.description ?? '—'}</td>
+                                                <td className="px-4 py-4 text-gray-700">{getTransactionTypeLabel(transaction.type)}</td>
+                                                <td className="px-4 py-4 font-medium text-gray-900">{pointsValue}</td>
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                            </table>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add shop routes for profile orders, addresses, and points sections
- implement dedicated pages that fetch profile orders, saved addresses, and loyalty points via the shop API
- expose profile navigation links (including logout) in the sidebar user menu

## Testing
- npm run types *(fails: existing repository type declarations are missing for @/routes and related modules)*
- npm run lint *(fails: repository contains pre-existing lint violations unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68c964c02e3c833186c72c7800307973