### PR TITLE
Add search suggestions endpoint and integrate UI autocomplete

### DIFF
--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Product;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SearchController extends Controller
+{
+    public function suggestions(Request $request): JsonResponse
+    {
+        $query = trim((string) ($request->query('q') ?? $request->query('query', '')));
+
+        if ($query === '') {
+            return response()->json([
+                'data' => [],
+                'query' => $query,
+            ]);
+        }
+
+        $limit = (int) $request->integer('limit', 8);
+        if ($limit <= 0) {
+            $limit = 8;
+        }
+        $limit = min($limit, 20);
+
+        $currency = config('shop.currency.base', 'EUR');
+
+        try {
+            $results = Product::search($query)
+                ->where('is_active', true)
+                ->take($limit)
+                ->get();
+        } catch (\Throwable $e) {
+            $escaped = addcslashes($query, '\\%_');
+            $prefix = $escaped . '%';
+            $wordMatch = '% ' . $escaped . '%';
+
+            $results = Product::query()
+                ->select(['id', 'name', 'slug', 'price', 'price_cents'])
+                ->where('is_active', true)
+                ->where('stock', '>', 0)
+                ->where(function ($qb) use ($prefix, $wordMatch) {
+                    $qb->where('name', 'like', $prefix)
+                        ->orWhere('name', 'like', $wordMatch)
+                        ->orWhere('sku', 'like', $prefix);
+                })
+                ->orderByRaw('CASE WHEN name LIKE ? THEN 0 ELSE 1 END', [$prefix])
+                ->orderBy('name')
+                ->limit($limit)
+                ->get();
+        }
+
+        $payload = $results->map(function (Product $product) use ($currency) {
+            return [
+                'id' => $product->id,
+                'name' => $product->name,
+                'slug' => $product->slug,
+                'preview_url' => $product->preview_url,
+                'price' => $product->price !== null ? round((float) $product->price, 2) : null,
+                'currency' => $currency,
+            ];
+        })->values();
+
+        return response()->json([
+            'data' => $payload,
+            'query' => $query,
+            'driver' => config('scout.driver'),
+        ]);
+    }
+}

--- a/resources/js/shop/api.tsx
+++ b/resources/js/shop/api.tsx
@@ -55,6 +55,15 @@ export type Product = {
     [k: string]: any;
 };
 
+export type SearchSuggestion = {
+    id: number;
+    name: string;
+    slug: string;
+    preview_url?: string | null;
+    price?: number | null;
+    currency?: string | null;
+};
+
 export type ProductsQuery = {
     page?: number;
     per_page?: number;
@@ -317,6 +326,22 @@ export async function fetchProducts(params: ProductsQuery) {
         },
     });
     return r.data as PaginatedWithFacets<Product>;
+}
+
+export async function fetchSearchSuggestions(
+    query: string,
+    options: { signal?: AbortSignal } = {},
+): Promise<SearchSuggestion[]> {
+    if (!query.trim()) {
+        return [];
+    }
+
+    const { data } = await api.get<{ data?: SearchSuggestion[] }>('/search/suggestions', {
+        params: { q: query },
+        signal: options.signal,
+    });
+
+    return data?.data ?? [];
 }
 
 export async function fetchSellerProducts(

--- a/resources/js/shop/components/Header.tsx
+++ b/resources/js/shop/components/Header.tsx
@@ -3,27 +3,38 @@ import useCart from '../useCart';
 import MiniCart from './MiniCart';
 import WishlistBadge from '../components/WishlistBadge';
 import { openCookiePreferences } from '../ui/analytics';
-import LanguageSwitcher from "@/shop/components/LanguageSwitcher";
+import LanguageSwitcher from '@/shop/components/LanguageSwitcher';
+import MainSearch from './MainSearch';
 
 export default function Header() {
     const { cart, total } = useCart();
     const itemsCount = (cart?.items ?? []).reduce((s, i) => s + Number(i.qty || 0), 0);
 
     return (
-        <header className="sticky top-0 z-30 bg-white/80 backdrop-blur border-b">
-            <div className="mx-auto max-w-6xl px-4 h-14 flex items-center justify-between">
-                <Link to="/" className="font-semibold tracking-tight">3D-Print Shop</Link>
-                <nav className="flex items-center gap-4 text-sm">
-                    <NavLink to="/" className={({isActive}) => isActive ? 'font-medium' : 'text-gray-600 hover:text-black'}>
-                        Каталог
-                    </NavLink>
-                    <MiniCart />
-                    <WishlistBadge />
-                    <button onClick={openCookiePreferences} className="text-xs underline">
-                        Налаштувати cookies
-                    </button>
-                    <LanguageSwitcher />
-                </nav>
+        <header className="sticky top-0 z-30 border-b bg-white/80 backdrop-blur">
+            <div className="mx-auto flex h-14 w-full max-w-6xl items-center gap-4 px-4">
+                <Link to="/" className="shrink-0 font-semibold tracking-tight">3D-Print Shop</Link>
+                <div className="flex flex-1 items-center gap-4">
+                    <div className="hidden flex-1 md:block">
+                        <MainSearch />
+                    </div>
+                    <nav className="flex items-center gap-4 text-sm">
+                        <NavLink
+                            to="/"
+                            className={({ isActive }) =>
+                                isActive ? 'font-medium' : 'text-gray-600 hover:text-black'
+                            }
+                        >
+                            Каталог
+                        </NavLink>
+                        <MiniCart />
+                        <WishlistBadge />
+                        <button onClick={openCookiePreferences} className="text-xs underline">
+                            Налаштувати cookies
+                        </button>
+                        <LanguageSwitcher />
+                    </nav>
+                </div>
             </div>
         </header>
     );

--- a/resources/js/shop/components/MainSearch.tsx
+++ b/resources/js/shop/components/MainSearch.tsx
@@ -1,0 +1,254 @@
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Loader2, Search } from 'lucide-react';
+
+import { Input } from '@/components/ui/input';
+
+import {
+    fetchSearchSuggestions,
+    type SearchSuggestion,
+} from '../api';
+import { useDebounce } from '../hooks/useDebounce';
+import { SUPPORTED_LANGS } from '../i18n/config';
+import { formatPrice } from '../ui/format';
+
+const MIN_QUERY_LENGTH = 2;
+
+export default function MainSearch() {
+    const [query, setQuery] = useState('');
+    const [isFocused, setIsFocused] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [suggestions, setSuggestions] = useState<SearchSuggestion[]>([]);
+    const [error, setError] = useState<string | null>(null);
+    const [retryTick, setRetryTick] = useState(0);
+
+    const debouncedQuery = useDebounce(query, 250);
+    const navigate = useNavigate();
+    const location = useLocation();
+
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const requestIdRef = useRef(0);
+
+    const trimmedQuery = query.trim();
+
+    const langPrefix = useMemo(() => {
+        const parts = location.pathname.split('/').filter(Boolean);
+        if (parts.length > 0 && SUPPORTED_LANGS.includes(parts[0] as any)) {
+            return `/${parts[0]}`;
+        }
+        return '';
+    }, [location.pathname]);
+
+    useEffect(() => {
+        return () => {
+            if (blurTimeoutRef.current) {
+                clearTimeout(blurTimeoutRef.current);
+            }
+        };
+    }, []);
+
+    useEffect(() => {
+        const term = debouncedQuery.trim();
+
+        if (term.length < MIN_QUERY_LENGTH) {
+            setSuggestions([]);
+            setError(null);
+            setLoading(false);
+            return;
+        }
+
+        const requestId = ++requestIdRef.current;
+
+        setLoading(true);
+        setError(null);
+
+        fetchSearchSuggestions(term)
+            .then((items) => {
+                if (requestIdRef.current !== requestId) {
+                    return;
+                }
+                setSuggestions(items);
+            })
+            .catch((err) => {
+                if (requestIdRef.current !== requestId) {
+                    return;
+                }
+                console.error('Failed to fetch search suggestions', err);
+                setSuggestions([]);
+                setError('Не вдалося завантажити підказки');
+            })
+            .finally(() => {
+                if (requestIdRef.current === requestId) {
+                    setLoading(false);
+                }
+            });
+    }, [debouncedQuery, retryTick]);
+
+    const showPanel = isFocused && (
+        trimmedQuery.length > 0 ||
+        loading ||
+        error !== null ||
+        suggestions.length > 0
+    );
+
+    const handleSubmit = (event: FormEvent) => {
+        event.preventDefault();
+        const term = trimmedQuery;
+        if (term === '') {
+            return;
+        }
+
+        const base = langPrefix || '';
+        navigate(`${base}/?q=${encodeURIComponent(term)}`);
+
+        closePanel();
+        inputRef.current?.blur();
+    };
+
+    const handleRetry = () => {
+        if (trimmedQuery.length >= MIN_QUERY_LENGTH) {
+            setRetryTick((tick) => tick + 1);
+        }
+    };
+
+    const handleSelect = (item: SearchSuggestion) => {
+        const base = langPrefix || '';
+        const target = `${base}/product/${encodeURIComponent(item.slug)}`;
+        navigate(target);
+        setQuery('');
+        setSuggestions([]);
+        closePanel();
+        inputRef.current?.blur();
+    };
+
+    const handleFocus = () => {
+        if (blurTimeoutRef.current) {
+            clearTimeout(blurTimeoutRef.current);
+            blurTimeoutRef.current = null;
+        }
+        setIsFocused(true);
+    };
+
+    const handleBlur = () => {
+        if (blurTimeoutRef.current) {
+            clearTimeout(blurTimeoutRef.current);
+        }
+        blurTimeoutRef.current = setTimeout(() => {
+            setIsFocused(false);
+        }, 120);
+    };
+
+    const closePanel = () => {
+        if (blurTimeoutRef.current) {
+            clearTimeout(blurTimeoutRef.current);
+            blurTimeoutRef.current = null;
+        }
+        setIsFocused(false);
+    };
+
+    return (
+        <div className="relative w-full max-w-xl">
+            <form onSubmit={handleSubmit} className="w-full">
+                <div className="relative">
+                    <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                    <Input
+                        ref={inputRef}
+                        value={query}
+                        onChange={(event) => setQuery(event.target.value)}
+                        onFocus={handleFocus}
+                        onBlur={handleBlur}
+                        placeholder="Пошук товарів…"
+                        className="pl-9"
+                        aria-autocomplete="list"
+                        aria-expanded={showPanel}
+                        role="combobox"
+                    />
+                </div>
+            </form>
+
+            {showPanel && (
+                <div className="absolute left-0 right-0 top-full z-40 mt-2 overflow-hidden rounded-lg border bg-white shadow-xl">
+                    {trimmedQuery.length < MIN_QUERY_LENGTH ? (
+                        <div className="px-4 py-3 text-sm text-gray-500">
+                            Введіть щонайменше {MIN_QUERY_LENGTH} символи для пошуку.
+                        </div>
+                    ) : loading ? (
+                        <div className="flex items-center gap-2 px-4 py-3 text-sm text-gray-500">
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            Завантаження…
+                        </div>
+                    ) : error ? (
+                        <div className="flex items-center justify-between gap-4 px-4 py-3 text-sm">
+                            <span className="text-red-600">{error}</span>
+                            <button
+                                type="button"
+                                onMouseDown={(event) => event.preventDefault()}
+                                onClick={handleRetry}
+                                className="text-sm font-medium text-blue-600 hover:text-blue-700"
+                            >
+                                Повторити
+                            </button>
+                        </div>
+                    ) : suggestions.length > 0 ? (
+                        <ul className="divide-y text-sm">
+                            {suggestions.map((item) => (
+                                <li key={item.id}>
+                                    <button
+                                        type="button"
+                                        onMouseDown={(event) => {
+                                            event.preventDefault();
+                                            handleSelect(item);
+                                        }}
+                                        className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-gray-50 focus:bg-gray-100"
+                                    >
+                                        {item.preview_url ? (
+                                            <img
+                                                src={item.preview_url}
+                                                alt={item.name}
+                                                loading="lazy"
+                                                className="h-10 w-10 flex-shrink-0 rounded object-cover"
+                                            />
+                                        ) : (
+                                            <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded bg-gray-100 text-xs font-semibold text-gray-500">
+                                                {item.name.slice(0, 1)}
+                                            </div>
+                                        )}
+                                        <div className="flex min-w-0 flex-1 flex-col">
+                                            <span className="truncate font-medium text-gray-900">{item.name}</span>
+                                            {typeof item.price === 'number' && (
+                                                <span className="text-xs text-gray-500">
+                                                    {formatPrice(item.price, item.currency ?? 'EUR')}
+                                                </span>
+                                            )}
+                                        </div>
+                                    </button>
+                                </li>
+                            ))}
+                            <li>
+                                <button
+                                    type="button"
+                                    onMouseDown={(event) => event.preventDefault()}
+                                    onClick={() => {
+                                        const term = trimmedQuery;
+                                        if (term) {
+                                            const base = langPrefix || '';
+                                            navigate(`${base}/?q=${encodeURIComponent(term)}`);
+                                            closePanel();
+                                            inputRef.current?.blur();
+                                        }
+                                    }}
+                                    className="flex w-full items-center justify-between gap-3 bg-gray-50 px-4 py-3 text-left text-sm font-medium text-blue-600 hover:bg-gray-100"
+                                >
+                                    Показати всі результати для “{trimmedQuery}”
+                                </button>
+                            </li>
+                        </ul>
+                    ) : (
+                        <div className="px-4 py-3 text-sm text-gray-500">Нічого не знайдено</div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,10 +9,13 @@ use App\Http\Controllers\Api\{AddressController,
     OrderController,
     OrderMessageController,
     ReviewController,
+    SearchController,
     WishlistController};
 
 //Categories
 Route::get('categories', [CategoryController::class,'index']);
+
+Route::get('search/suggestions', [SearchController::class, 'suggestions']);
 
 $productsAndOrders = function () {
     // Products


### PR DESCRIPTION
## Summary
- register a /api/search/suggestions endpoint and wire it to a new API\SearchController
- implement suggestions lookup via Scout/MeiliSearch with a database fallback and structured JSON payload
- expose search suggestions to the shop frontend with a typed API helper and a MainSearch component used in the header

## Testing
- npm run types *(fails: existing unresolved `@/routes` and related imports in the project)*
- php artisan test *(fails: vendor/autoload.php is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c97fa00a048331bf71a23e2c68b86d