### PR TITLE
Update frontend CI job with PHP setup for Wayfinder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
+      - name: Install composer deps
+        run: composer install --no-interaction --prefer-dist
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
-      - name: Install deps
+      - name: Install npm deps
         run: npm ci
+      - name: Clear Laravel caches
+        run: php artisan optimize:clear
       - name: Build
         env:
           VITE_GA_ID: ${{ secrets.VITE_GA_ID }}


### PR DESCRIPTION
## Summary
- set up PHP 8.3 with composer in the frontend-build-and-tests workflow job
- run composer install and clear Laravel caches before building assets so the Wayfinder plugin can execute

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68c9aca0d50c833197f8c5f8de41824b