### PR TITLE
Ensure demo seeder populates product stocks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -91,6 +91,7 @@ VITE_COOKIE_DEFAULT=granted|denied
 - `vendors` — відображення продавця на користувача (`user_id` unique, `name`, `slug`, контакти, опис; `database/migrations/2025_10_07_000000_create_vendors_table.php`). Продукти підтягують `vendor` для сторінки продавця (`App\Http\Controllers\Api\ProductController::sellerProducts`).
 - `warehouses` — реєстр складів з базовим записом `MAIN` (`database/migrations/2025_10_05_000000_create_warehouses_table.php`), який використовується методами `App\Models\Product` для резервування/звільнення залишків.
 - `product_stocks` — залишки по складах (`product_id`, `warehouse_id`, `qty`, `reserved`, `unique` пара) з ініціалізацією зі старого поля `stock` (`database/migrations/2025_10_05_000100_create_product_stock_table.php`).
+- `database/seeders/DemoCatalogSeeder.php` — наповнює склад `MAIN` та створює записи у `product_stocks` через `afterCreating` фабрики продуктів.
 - `currencies` — курси валют, база береться з `config('shop.currency.base')` і використовується сервісом `App\Services\Currency\CurrencyConverter` (`database/migrations/2025_10_06_000000_create_currencies_table.php`).
 - `reviews` — оцінки/коментарі з `status=pending|approved|rejected`, `rating` 1–5 та індексом за `product_id` (`database/migrations/2025_10_01_120000_create_reviews_table.php`, модель `App\Models\Review`).
 

--- a/database/seeders/DemoCatalogSeeder.php
+++ b/database/seeders/DemoCatalogSeeder.php
@@ -24,11 +24,15 @@ class DemoCatalogSeeder extends Seeder
         $vendors = Vendor::factory()->count(5)->create();
 
         // 60 товарів, кожному ставимо випадкову категорію та продавця
-        $products = Product::factory()->count(60)->make()->each(function (Product $p) use ($cats, $vendors) {
-            $p->category_id = $cats->random()->id;
-            $p->vendor_id = $vendors->random()->id;
-            $p->save();
-        });
+        $products = Product::factory()
+            ->count(60)
+            ->state(function () use ($cats, $vendors) {
+                return [
+                    'category_id' => $cats->random()->id,
+                    'vendor_id' => $vendors->random()->id,
+                ];
+            })
+            ->create();
 
         // 1–3 зображення на товар + одне головне
         $products->each(function (Product $p) {


### PR DESCRIPTION
## Summary
- ensure demo catalog seeder creates products so factory afterCreating hooks run and stocks are generated
- document that DemoCatalogSeeder populates the MAIN warehouse and product_stocks records

## Testing
- REDIS_CLIENT=predis QUEUE_CONNECTION=sync SCOUT_DRIVER=collection DB_CONNECTION=sqlite DB_DATABASE=/workspace/shop.loc/database/database.sqlite php artisan migrate:fresh --seed

------
https://chatgpt.com/codex/tasks/task_e_68c9b2ac348c8331ae6e82cd4575929e