### PR TITLE
Disable wayfinder during CI frontend build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
         env:
           VITE_GA_ID: ${{ secrets.VITE_GA_ID }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          WAYFINDER: off
         run: npm run build
       - name: Playwright install
         run: npx playwright install --with-deps


### PR DESCRIPTION
## Summary
- add WAYFINDER=off to the frontend build step so the wayfinder plugin is skipped during CI builds

## Testing
- ❌ WAYFINDER=off npm run build *(fails locally because resources/js/routes is missing outside of CI)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ba6710d88331bef60b7dd5a61817