### PR TITLE
Add dynamic currency formatting helper

### DIFF
--- a/app/Filament/Mine/Resources/Coupons/Schemas/CouponForm.php
+++ b/app/Filament/Mine/Resources/Coupons/Schemas/CouponForm.php
@@ -4,11 +4,12 @@ namespace App\Filament\Mine\Resources\Coupons\Schemas;
 
 use App\Models\Coupon;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
-use Filament\Forms\Components\Select;
 use Filament\Schemas\Schema;
+use function currencySymbol;
 
 class CouponForm
 {
@@ -35,14 +36,14 @@ class CouponForm
             TextInput::make('value')
                 ->required()
                 ->numeric()
-                ->prefix(fn ($state, callable $get) => $get('type') === Coupon::TYPE_PERCENT ? '%' : '₴'),
+                ->prefix(fn ($state, callable $get) => $get('type') === Coupon::TYPE_PERCENT ? '%' : currencySymbol()),
             TextInput::make('min_cart_total')
                 ->numeric()
                 ->default(0)
-                ->prefix('₴'),
+                ->prefix(currencySymbol()),
             TextInput::make('max_discount')
                 ->numeric()
-                ->prefix('₴'),
+                ->prefix(currencySymbol()),
             TextInput::make('usage_limit')
                 ->numeric()
                 ->minValue(0)

--- a/app/Filament/Mine/Resources/Coupons/Tables/CouponsTable.php
+++ b/app/Filament/Mine/Resources/Coupons/Tables/CouponsTable.php
@@ -9,6 +9,7 @@ use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
+use function formatCurrency;
 
 class CouponsTable
 {
@@ -30,11 +31,11 @@ class CouponsTable
                     ->state(function (Coupon $record) {
                         return $record->type === Coupon::TYPE_PERCENT
                             ? number_format((float) $record->value, 2) . '%'
-                            : '₴ ' . number_format((float) $record->value, 2);
+                            : formatCurrency($record->value);
                     }),
                 TextColumn::make('min_cart_total')
                     ->label('Min cart')
-                    ->state(fn (Coupon $record) => '₴ ' . number_format((float) $record->min_cart_total, 2))
+                    ->state(fn (Coupon $record) => formatCurrency($record->min_cart_total))
                     ->toggleable(),
                 TextColumn::make('usage_limit')
                     ->label('Usage')

--- a/app/Filament/Mine/Resources/Orders/Schemas/OrderForm.php
+++ b/app/Filament/Mine/Resources/Orders/Schemas/OrderForm.php
@@ -15,6 +15,7 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
+use function currencySymbol;
 
 
 class OrderForm
@@ -60,7 +61,7 @@ class OrderForm
 
                     TextInput::make('total')
                         ->label('Total')
-                        ->prefix('₴')
+                        ->prefix(fn (?Order $record) => currencySymbol($record?->currency))
                         ->disabled()
                         ->dehydrated(false)
 

--- a/app/Filament/Mine/Resources/Products/Schemas/ProductForm.php
+++ b/app/Filament/Mine/Resources/Products/Schemas/ProductForm.php
@@ -2,12 +2,13 @@
 
 namespace App\Filament\Mine\Resources\Products\Schemas;
 
+use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\KeyValue;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Schemas\Schema;
-use Filament\Forms\Components\FileUpload;
+use function currencySymbol;
 
 class ProductForm
 {
@@ -43,7 +44,7 @@ class ProductForm
                 TextInput::make('price')
                     ->required()
                     ->numeric()
-                    ->prefix('$'),
+                    ->prefix(currencySymbol()),
                 TextInput::make('price_old')
                     ->numeric(),
                 Toggle::make('is_active')

--- a/app/Filament/Mine/Resources/Users/RelationManagers/LoyaltyPointTransactionsRelationManager.php
+++ b/app/Filament/Mine/Resources/Users/RelationManagers/LoyaltyPointTransactionsRelationManager.php
@@ -5,6 +5,7 @@ namespace App\Filament\Mine\Resources\Users\RelationManagers;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use function formatCurrency;
 
 class LoyaltyPointTransactionsRelationManager extends RelationManager
 {
@@ -28,7 +29,7 @@ class LoyaltyPointTransactionsRelationManager extends RelationManager
                     ->state(fn ($record) => (int) $record->points),
                 TextColumn::make('amount')
                     ->label('Amount')
-                    ->state(fn ($record) => '₴ ' . number_format((float) $record->amount, 2))
+                    ->state(fn ($record) => formatCurrency($record->amount, $record->order?->currency))
                     ->toggleable(),
                 TextColumn::make('description')
                     ->wrap()

--- a/app/Http/Controllers/OgImageController.php
+++ b/app/Http/Controllers/OgImageController.php
@@ -5,8 +5,9 @@ namespace App\Http\Controllers;
 use App\Models\Product;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Cache;
-use Intervention\Image\ImageManager;
 use Intervention\Image\Drivers\Gd\Driver;
+use Intervention\Image\ImageManager;
+use function formatCurrency;
 
 class OgImageController extends Controller
 {
@@ -20,8 +21,8 @@ class OgImageController extends Controller
                 if (!$p) abort(404);
             }
 
-            $title = (string)$p->name;
-            $price = number_format((float)$p->price, 2, '.', ' ') . ' ₴';
+            $title = (string) $p->name;
+            $price = formatCurrency($p->price);
             $imgUrl = $p->preview_url ?? optional($p->images()->orderByDesc('is_primary')->orderBy('id')->first())->url;
 
             $manager = new ImageManager(new Driver());

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -25,7 +25,11 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $helpers = app_path('Support/helpers.php');
+
+        if (file_exists($helpers)) {
+            require_once $helpers;
+        }
     }
 
     /**

--- a/app/Support/CurrencyFormatter.php
+++ b/app/Support/CurrencyFormatter.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Support;
+
+use NumberFormatter;
+
+class CurrencyFormatter
+{
+    /**
+     * The default number of decimals to display for monetary amounts.
+     */
+    private const DEFAULT_DECIMALS = 2;
+
+    /**
+     * Common currency symbols to avoid reliance on the intl extension.
+     *
+     * @var array<string, string>
+     */
+    private static array $symbols = [
+        'AED' => 'د.إ',
+        'AUD' => 'A$',
+        'CAD' => 'C$',
+        'CHF' => 'CHF',
+        'CNY' => '¥',
+        'CZK' => 'Kč',
+        'DKK' => 'kr',
+        'EUR' => '€',
+        'GBP' => '£',
+        'HUF' => 'Ft',
+        'JPY' => '¥',
+        'NOK' => 'kr',
+        'PLN' => 'zł',
+        'SEK' => 'kr',
+        'UAH' => '₴',
+        'USD' => '$',
+    ];
+
+    public static function base(): string
+    {
+        return strtoupper((string) config('shop.currency.base', 'EUR'));
+    }
+
+    public static function code(?string $currency = null): string
+    {
+        return strtoupper($currency ?? self::base());
+    }
+
+    public static function symbol(?string $currency = null): string
+    {
+        $code = self::code($currency);
+
+        if (isset(self::$symbols[$code])) {
+            return self::$symbols[$code];
+        }
+
+        $locale = (string) config('app.locale', 'en');
+
+        try {
+            $formatter = new NumberFormatter($locale . '@currency=' . $code, NumberFormatter::CURRENCY);
+            $symbol = $formatter->getSymbol(NumberFormatter::CURRENCY_SYMBOL);
+
+            if (is_string($symbol) && $symbol !== '') {
+                return $symbol;
+            }
+        } catch (\Throwable $exception) {
+            // Fallback to the currency code when the intl extension is missing or unsupported.
+        }
+
+        return $code;
+    }
+
+    public static function format(float|int|string|null $amount, ?string $currency = null, int $decimals = self::DEFAULT_DECIMALS): string
+    {
+        $value = number_format((float) ($amount ?? 0), $decimals);
+
+        return trim(self::symbol($currency) . ' ' . $value);
+    }
+}

--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Support\CurrencyFormatter;
+
+if (! function_exists('currencySymbol')) {
+    function currencySymbol(?string $currency = null): string
+    {
+        return CurrencyFormatter::symbol($currency);
+    }
+}
+
+if (! function_exists('baseCurrency')) {
+    function baseCurrency(): string
+    {
+        return CurrencyFormatter::base();
+    }
+}
+
+if (! function_exists('formatCurrency')) {
+    function formatCurrency(float|int|string|null $amount, ?string $currency = null, int $decimals = 2): string
+    {
+        return CurrencyFormatter::format($amount, $currency, $decimals);
+    }
+}

--- a/resources/js/shop/ui/ga.tsx
+++ b/resources/js/shop/ui/ga.tsx
@@ -8,7 +8,27 @@ type GAItem = {
     item_category?: string;
 };
 
-const CURRENCY = 'UAH';
+function detectCurrency(): string {
+    if (typeof document !== 'undefined') {
+        const currency = document.documentElement.dataset.baseCurrency;
+
+        if (currency) {
+            return currency.trim().toUpperCase();
+        }
+    }
+
+    if (typeof globalThis !== 'undefined' && typeof (globalThis as Record<string, any>).APP === 'object') {
+        const appCurrency = (globalThis as Record<string, any>).APP?.baseCurrency;
+
+        if (typeof appCurrency === 'string' && appCurrency.trim()) {
+            return appCurrency.trim().toUpperCase();
+        }
+    }
+
+    return 'EUR';
+}
+
+const CURRENCY = detectCurrency();
 
 // Безпечний шорткат: якщо gtag не ініціалізовано — нічого не робимо.
 function gtagSafe(...args: any[]) {

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -1,5 +1,10 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" @class(['dark' => ($appearance ?? 'system') == 'dark'])>
+<html
+    lang="{{ str_replace('_', '-', app()->getLocale()) }}"
+    @class(['dark' => ($appearance ?? 'system') == 'dark'])
+    data-base-currency="{{ baseCurrency() }}"
+    data-base-currency-symbol="{{ currencySymbol() }}"
+>
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -29,6 +34,13 @@
                 background-color: oklch(0.145 0 0);
             }
         </style>
+
+        <script>
+            window.APP = Object.assign({}, window.APP, {
+                baseCurrency: @js(baseCurrency()),
+                baseCurrencySymbol: @js(currencySymbol()),
+            });
+        </script>
 
         <title inertia>{{ config('app.name', 'Laravel') }}</title>
 

--- a/resources/views/filament/orders/summary.blade.php
+++ b/resources/views/filament/orders/summary.blade.php
@@ -4,8 +4,9 @@
     $record   = $getRecord();
     $items    = $record?->items ?? collect();
     $count    = (int) $items->sum('qty');
-    $subtotal = (float) $items->sum(fn($i) => (float)$i->price * (int)$i->qty);
+    $subtotal = (float) $items->sum(fn ($i) => (float) $i->price * (int) $i->qty);
     $total    = (float) ($record?->total ?? $subtotal);
+    $currency = $record?->currency;
 @endphp
 
 <div class="rounded-xl border p-4 space-y-2" wire:poll.1500ms>
@@ -16,13 +17,13 @@
 
     <div class="flex items-center justify-between">
         <div class="text-sm text-gray-500">Subtotal</div>
-        <div class="font-semibold">₴ {{ number_format($subtotal, 2) }}</div>
+        <div class="font-semibold">{{ formatCurrency($subtotal, $currency) }}</div>
     </div>
 
     <div class="border-t my-2"></div>
 
     <div class="flex items-center justify-between">
         <div class="text-sm text-gray-500">Total (order)</div>
-        <div class="text-lg font-bold">₴ {{ number_format((float)($record->total ?? 0), 2) }}</div>
+        <div class="text-lg font-bold">{{ formatCurrency($total, $currency) }}</div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add a reusable currency formatter helper and autoload it via the app service provider
- update Filament admin forms, tables, and views to display order totals with the correct currency
- expose base currency metadata to the frontend and update React/GA utilities to read it dynamically

## Testing
- composer test *(fails: missing vendor directory in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca3483f24883318cc05439bc26a87b