### PR TITLE
Add Filament resources for managing warehouses and currencies

### DIFF
--- a/app/Filament/Mine/Resources/Currencies/CurrencyResource.php
+++ b/app/Filament/Mine/Resources/Currencies/CurrencyResource.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Currencies;
+
+use App\Filament\Mine\Resources\Currencies\Pages\CreateCurrency;
+use App\Filament\Mine\Resources\Currencies\Pages\EditCurrency;
+use App\Filament\Mine\Resources\Currencies\Pages\ListCurrencies;
+use App\Models\Currency;
+use App\Services\Currency\CurrencyConverter;
+use BackedEnum;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Set;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Support\Str;
+
+class CurrencyResource extends Resource
+{
+    protected static ?string $model = Currency::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedBanknotes;
+
+    protected static string|null|\UnitEnum $navigationGroup = 'Settings';
+
+    protected static ?string $recordTitleAttribute = 'code';
+
+    protected static bool $shouldRegisterNavigation = true;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            TextInput::make('code')
+                ->required()
+                ->minLength(3)
+                ->maxLength(3)
+                ->unique(ignoreRecord: true)
+                ->live(onBlur: true)
+                ->afterStateUpdated(fn (Set $set, ?string $state) => $set('code', strtoupper((string) $state)))
+                ->rule('alpha:ascii'),
+            TextInput::make('rate')
+                ->label('Rate (vs base)')
+                ->numeric()
+                ->required()
+                ->minValue(0.00000001)
+                ->step('0.00000001'),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('code')
+                    ->label('Code')
+                    ->searchable()
+                    ->sortable()
+                    ->formatStateUsing(fn (string $state) => Str::upper($state)),
+                TextColumn::make('rate')
+                    ->label('Rate')
+                    ->numeric(precision: 8)
+                    ->sortable(),
+                TextColumn::make('updated_at')
+                    ->label('Updated')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListCurrencies::route('/'),
+            'create' => CreateCurrency::route('/create'),
+            'edit' => EditCurrency::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        $base = config('shop.currency.base');
+
+        if (is_string($base) && $base !== '') {
+            return strtoupper($base);
+        }
+
+        return app(CurrencyConverter::class)->getBaseCurrency();
+    }
+}

--- a/app/Filament/Mine/Resources/Currencies/Pages/CreateCurrency.php
+++ b/app/Filament/Mine/Resources/Currencies/Pages/CreateCurrency.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Currencies\Pages;
+
+use App\Filament\Mine\Resources\Currencies\CurrencyResource;
+use App\Services\Currency\CurrencyConverter;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateCurrency extends CreateRecord
+{
+    protected static string $resource = CurrencyResource::class;
+
+    protected function afterCreate(): void
+    {
+        app(CurrencyConverter::class)->refreshRates();
+    }
+}

--- a/app/Filament/Mine/Resources/Currencies/Pages/EditCurrency.php
+++ b/app/Filament/Mine/Resources/Currencies/Pages/EditCurrency.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Currencies\Pages;
+
+use App\Filament\Mine\Resources\Currencies\CurrencyResource;
+use App\Services\Currency\CurrencyConverter;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditCurrency extends EditRecord
+{
+    protected static string $resource = CurrencyResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make()
+                ->after(fn () => app(CurrencyConverter::class)->refreshRates()),
+        ];
+    }
+
+    protected function afterSave(): void
+    {
+        app(CurrencyConverter::class)->refreshRates();
+    }
+}

--- a/app/Filament/Mine/Resources/Currencies/Pages/ListCurrencies.php
+++ b/app/Filament/Mine/Resources/Currencies/Pages/ListCurrencies.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Currencies\Pages;
+
+use App\Filament\Mine\Resources\Currencies\CurrencyResource;
+use App\Services\Currency\CurrencyConverter;
+use Filament\Actions;
+use Filament\Actions\CreateAction;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\ListRecords;
+use Illuminate\Support\Facades\Artisan;
+use Throwable;
+
+class ListCurrencies extends ListRecords
+{
+    protected static string $resource = CurrencyResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+            Actions\Action::make('refreshRates')
+                ->label('Оновити курси')
+                ->icon('heroicon-o-arrow-path')
+                ->color('gray')
+                ->requiresConfirmation()
+                ->action(function (): void {
+                    try {
+                        $exitCode = Artisan::call('currency:update');
+                        $output = trim(Artisan::output());
+
+                        if ($exitCode === 0) {
+                            Notification::make()
+                                ->title('Курси валют оновлено')
+                                ->body($output !== '' ? $output : null)
+                                ->success()
+                                ->send();
+                        } else {
+                            Notification::make()
+                                ->title('Не вдалося оновити курси валют')
+                                ->body($output !== '' ? $output : null)
+                                ->danger()
+                                ->send();
+                        }
+                    } catch (Throwable $exception) {
+                        Notification::make()
+                            ->title('Не вдалося оновити курси валют')
+                            ->body($exception->getMessage())
+                            ->danger()
+                            ->send();
+                    }
+
+                    app(CurrencyConverter::class)->refreshRates();
+                }),
+        ];
+    }
+}

--- a/app/Filament/Mine/Resources/Warehouses/Pages/CreateWarehouse.php
+++ b/app/Filament/Mine/Resources/Warehouses/Pages/CreateWarehouse.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Warehouses\Pages;
+
+use App\Filament\Mine\Resources\Warehouses\WarehouseResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateWarehouse extends CreateRecord
+{
+    protected static string $resource = WarehouseResource::class;
+}

--- a/app/Filament/Mine/Resources/Warehouses/Pages/EditWarehouse.php
+++ b/app/Filament/Mine/Resources/Warehouses/Pages/EditWarehouse.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Warehouses\Pages;
+
+use App\Filament\Mine\Resources\Warehouses\WarehouseResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditWarehouse extends EditRecord
+{
+    protected static string $resource = WarehouseResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Mine/Resources/Warehouses/Pages/ListWarehouses.php
+++ b/app/Filament/Mine/Resources/Warehouses/Pages/ListWarehouses.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Warehouses\Pages;
+
+use App\Filament\Mine\Resources\Warehouses\WarehouseResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListWarehouses extends ListRecords
+{
+    protected static string $resource = WarehouseResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Mine/Resources/Warehouses/WarehouseResource.php
+++ b/app/Filament/Mine/Resources/Warehouses/WarehouseResource.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Warehouses;
+
+use App\Filament\Mine\Resources\Warehouses\Pages\CreateWarehouse;
+use App\Filament\Mine\Resources\Warehouses\Pages\EditWarehouse;
+use App\Filament\Mine\Resources\Warehouses\Pages\ListWarehouses;
+use App\Models\Warehouse;
+use BackedEnum;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Set;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class WarehouseResource extends Resource
+{
+    protected static ?string $model = Warehouse::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedBuildingOffice;
+
+    protected static string|null|\UnitEnum $navigationGroup = 'Inventory';
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            TextInput::make('code')
+                ->required()
+                ->maxLength(50)
+                ->unique(ignoreRecord: true)
+                ->rule('alpha_dash')
+                ->live(onBlur: true)
+                ->afterStateUpdated(fn (Set $set, ?string $state) => $set('code', strtoupper((string) $state))),
+            TextInput::make('name')
+                ->required()
+                ->maxLength(255),
+            Textarea::make('description')
+                ->columnSpanFull(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('code')
+                    ->label('Code')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('name')
+                    ->label('Name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('description')
+                    ->label('Description')
+                    ->wrap()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('created_at')
+                    ->label('Created')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('updated_at')
+                    ->label('Updated')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListWarehouses::route('/'),
+            'create' => CreateWarehouse::route('/create'),
+            'edit' => EditWarehouse::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) Warehouse::count();
+    }
+}

--- a/app/Observers/CurrencyObserver.php
+++ b/app/Observers/CurrencyObserver.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Currency;
+use App\Services\Currency\CurrencyConverter;
+
+class CurrencyObserver
+{
+    public function saved(Currency $currency): void
+    {
+        app(CurrencyConverter::class)->refreshRates();
+    }
+
+    public function deleted(Currency $currency): void
+    {
+        app(CurrencyConverter::class)->refreshRates();
+    }
+
+    public function forceDeleted(Currency $currency): void
+    {
+        app(CurrencyConverter::class)->refreshRates();
+    }
+}

--- a/app/Policies/CurrencyPolicy.php
+++ b/app/Policies/CurrencyPolicy.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Currency;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class CurrencyPolicy
+{
+    use HandlesAuthorization;
+
+    public function before(User $user, string $ability): bool|null
+    {
+        if (! $user->vendor) {
+            return true;
+        }
+
+        return null;
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return false;
+    }
+
+    public function view(User $user, Currency $currency): bool
+    {
+        return false;
+    }
+
+    public function create(User $user): bool
+    {
+        return false;
+    }
+
+    public function update(User $user, Currency $currency): bool
+    {
+        return false;
+    }
+
+    public function delete(User $user, Currency $currency): bool
+    {
+        return false;
+    }
+}

--- a/app/Policies/WarehousePolicy.php
+++ b/app/Policies/WarehousePolicy.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\Warehouse;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class WarehousePolicy
+{
+    use HandlesAuthorization;
+
+    public function before(User $user, string $ability): bool|null
+    {
+        if (! $user->vendor) {
+            return true;
+        }
+
+        return null;
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return false;
+    }
+
+    public function view(User $user, Warehouse $warehouse): bool
+    {
+        return false;
+    }
+
+    public function create(User $user): bool
+    {
+        return false;
+    }
+
+    public function update(User $user, Warehouse $warehouse): bool
+    {
+        return false;
+    }
+
+    public function delete(User $user, Warehouse $warehouse): bool
+    {
+        return false;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,9 +2,12 @@
 
 namespace App\Providers;
 
+use App\Models\Currency;
 use App\Models\Order;
+use App\Models\Warehouse;
 use App\Observers\OrderObserver;
 use App\Observers\ProductObserver;
+use App\Observers\CurrencyObserver;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -17,6 +20,8 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Gate;
 use App\Policies\ProductPolicy;
 use App\Policies\OrderPolicy;
+use App\Policies\WarehousePolicy;
+use App\Policies\CurrencyPolicy;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -39,6 +44,7 @@ class AppServiceProvider extends ServiceProvider
     {
         Product::observe(ProductObserver::class);
         Order::observe(OrderObserver::class);
+        Currency::observe(CurrencyObserver::class);
         Event::listen(Login::class, MergeGuestCart::class);
 
         RateLimiter::for('api', function (Request $request) {
@@ -50,6 +56,8 @@ class AppServiceProvider extends ServiceProvider
 
         Gate::policy(Product::class, ProductPolicy::class);
         Gate::policy(Order::class, OrderPolicy::class);
+        Gate::policy(Warehouse::class, WarehousePolicy::class);
+        Gate::policy(Currency::class, CurrencyPolicy::class);
 
         if (Config::get('scout.driver') === 'meilisearch') {
             Product::created(fn($p) => $p->searchable());

--- a/app/Providers/Filament/MinePanelProvider.php
+++ b/app/Providers/Filament/MinePanelProvider.php
@@ -50,6 +50,8 @@ class MinePanelProvider extends PanelProvider
             ->navigationGroups([
                 'Catalog',
                 'Sales',
+                'Inventory',
+                'Settings',
             ])
             ->brandName('Shop Admin')
             ->discoverResources(in: app_path('Filament/Mine/Resources'), for: 'App\Filament\Mine\Resources')


### PR DESCRIPTION
## Summary
- add a Filament resource for warehouses with form inputs and navigation under the Inventory group
- introduce a Filament resource for currencies with CRUD, a manual rate refresh action, and a navigation badge showing the base currency
- register supporting policies and observers so that currency rate caches refresh automatically after changes

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68ca3ee276788331a0a84817c04661f2