### PR TITLE
Add profile orders API listing

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -67,6 +67,7 @@ Route::post('/payments/intent', [PaymentController::class, 'intent']);
 Route::post('/payment/refresh/{number}', [PaymentController::class, 'refreshStatus']);
 
 Route::middleware('auth:sanctum')->group(function () {
+    Route::get('profile/orders', [OrderController::class, 'index']);
     Route::apiResource('profile/addresses', AddressController::class);
     Route::get('profile/wishlist', [WishlistController::class, 'index']);
     Route::post('profile/wishlist/{product}', [WishlistController::class, 'store']);

--- a/tests/Feature/ProfileOrdersTest.php
+++ b/tests/Feature/ProfileOrdersTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\User;
+
+beforeEach(function () {
+    config(['auth.guards.sanctum' => [
+        'driver' => 'session',
+        'provider' => 'users',
+    ]]);
+});
+
+it('returns the current user orders with related data', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    Order::factory()
+        ->count(2)
+        ->for($user)
+        ->has(OrderItem::factory()->count(2), 'items')
+        ->create([
+            'subtotal' => 150,
+            'total' => 200,
+        ]);
+
+    Order::factory()
+        ->for($otherUser)
+        ->has(OrderItem::factory()->count(1), 'items')
+        ->create();
+
+    $this->actingAs($user, 'sanctum');
+
+    $response = $this->getJson('/api/profile/orders?currency=USD')
+        ->assertOk()
+        ->json();
+
+    expect($response)->toBeArray();
+    expect($response)->toHaveCount(2);
+    expect(collect($response)->pluck('user_id')->unique()->all())->toBe([$user->id]);
+    expect(collect($response)->pluck('currency')->unique()->all())->toBe(['USD']);
+
+    $firstOrder = $response[0];
+    expect($firstOrder['items'])->not()->toBeEmpty();
+    expect($firstOrder['shipment'])->not()->toBeNull();
+
+    $firstItem = $firstOrder['items'][0];
+    expect($firstItem['product'])->not()->toBeNull();
+    expect($firstItem['product']['vendor'])->not()->toBeNull();
+});
+
+it('denies access to orders list for guests', function () {
+    $this->getJson('/api/profile/orders')->assertUnauthorized();
+});


### PR DESCRIPTION
## Summary
- add an index action to return the authenticated user orders with eager-loaded relations and currency handling
- expose the new endpoint via GET /profile/orders behind the auth:sanctum middleware
- cover the profile orders listing with Pest feature tests

## Testing
- ./vendor/bin/pest --filter=ProfileOrdersTest

------
https://chatgpt.com/codex/tasks/task_e_68ca48c390e88331af4d4d6fc9265d27