### PR TITLE
Add profile loyalty points endpoint

### DIFF
--- a/app/Http/Controllers/Api/ProfilePointsController.php
+++ b/app/Http/Controllers/Api/ProfilePointsController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+
+class ProfilePointsController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $user = auth()->user();
+
+        $transactions = $user->loyaltyPointTransactions()
+            ->latest()
+            ->get();
+
+        $totalEarned = (int) $transactions->sum(fn ($transaction) => max(0, (int) $transaction->points));
+        $totalSpent = (int) $transactions->sum(fn ($transaction) => $transaction->points < 0 ? abs((int) $transaction->points) : 0);
+
+        return response()->json([
+            'balance' => $user->loyaltyPointsBalance(),
+            'transactions' => $transactions,
+            'total_earned' => $totalEarned,
+            'total_spent' => $totalSpent,
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\{AddressController,
     ProductController,
     CartController,
     OrderController,
+    ProfilePointsController,
     OrderMessageController,
     ReviewController,
     SearchController,
@@ -72,6 +73,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('profile/wishlist', [WishlistController::class, 'index']);
     Route::post('profile/wishlist/{product}', [WishlistController::class, 'store']);
     Route::delete('profile/wishlist/{product}', [WishlistController::class, 'destroy']);
+    Route::get('profile/points', [ProfilePointsController::class, 'index']);
     Route::get('orders/{order}/messages', [OrderMessageController::class, 'index']);
     Route::post('orders/{order}/messages', [OrderMessageController::class, 'store']);
     Route::get('profile/two-factor', [TwoFactorController::class, 'show']);

--- a/tests/Feature/ProfilePointsTest.php
+++ b/tests/Feature/ProfilePointsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Models\{LoyaltyPointTransaction, User};
+
+it('returns loyalty point summary for authenticated user', function () {
+    $user = User::factory()->create();
+
+    LoyaltyPointTransaction::factory()
+        ->for($user)
+        ->earn(120)
+        ->create([
+            'created_at' => now()->subDays(3),
+            'updated_at' => now()->subDays(3),
+        ]);
+
+    LoyaltyPointTransaction::factory()
+        ->for($user)
+        ->redeem(40)
+        ->create([
+            'created_at' => now()->subDays(2),
+            'updated_at' => now()->subDays(2),
+        ]);
+
+    LoyaltyPointTransaction::factory()
+        ->for($user)
+        ->adjustment(-10)
+        ->create([
+            'created_at' => now()->subDay(),
+            'updated_at' => now()->subDay(),
+        ]);
+
+    $latest = LoyaltyPointTransaction::factory()
+        ->for($user)
+        ->adjustment(15)
+        ->create([
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+    $this->actingAs($user, 'sanctum');
+
+    $response = $this->getJson('/api/profile/points')->assertOk();
+
+    $response->assertJson([
+        'balance' => 120 - 40 - 10 + 15,
+        'total_earned' => 120 + 15,
+        'total_spent' => 40 + 10,
+    ]);
+
+    $response->assertJsonCount(4, 'transactions');
+
+    expect($response->json('transactions.0.id'))->toBe($latest->id);
+});
+
+it('requires authentication to view loyalty point summary', function () {
+    $this->getJson('/api/profile/points')->assertUnauthorized();
+});


### PR DESCRIPTION
## Summary
- add an authenticated profile points controller that returns loyalty balance, totals, and recent transactions
- expose the profile points endpoint inside the auth:sanctum API routes
- cover the new endpoint behaviour with feature tests for authenticated and guest access

## Testing
- vendor/bin/pest --filter ProfilePointsTest

------
https://chatgpt.com/codex/tasks/task_e_68ca4d77f2808331b4d232ea18e20cee