### PR TITLE
Add env copy step to frontend CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Copy env
+        run: cp .env.example .env || true
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
## Summary
- add a step to copy `.env.example` to `.env` in the frontend workflow so artisan commands use a local env file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca4fc157588331b8aac14fa7bba86d