### PR TITLE
Run Wayfinder generation before frontend build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
           tools: composer
       - name: Install composer deps
         run: composer install --no-interaction --prefer-dist
+      - name: Generate Wayfinder actions
+        run: php artisan wayfinder:generate --with-form
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary
- run `php artisan wayfinder:generate --with-form` during the frontend build job to recreate the ignored Wayfinder actions before building the assets

## Testing
- DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan wayfinder:generate --with-form
- WAYFINDER=off npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca513d9b808331831da51d2fbdb87b