### PR TITLE
Quote Wayfinder DB memory value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Generate Wayfinder actions
         env:
           DB_CONNECTION: sqlite
-          DB_DATABASE: :memory:
+          DB_DATABASE: ":memory:"
         run: php artisan wayfinder:generate --with-form
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- quote the sqlite in-memory database value in the Wayfinder generation workflow step to ensure valid YAML

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca5578d5748331ad4e152964103b32