### PR TITLE
Refresh order before checkout confirmation

### DIFF
--- a/resources/js/shop/components/PayOrder.tsx
+++ b/resources/js/shop/components/PayOrder.tsx
@@ -4,7 +4,13 @@ import { Elements, PaymentElement, useElements, useStripe } from '@stripe/react-
 import { Button } from '@/components/ui/button';
 import { useNotify } from '../ui/notify';
 
-function Inner({ number, onPaid }: { number: string; onPaid?: (status?: string) => void }) {
+function Inner({
+    number,
+    onPaid,
+}: {
+    number: string;
+    onPaid?: (status?: string, paymentIntentId?: string) => void;
+}) {
     const stripe = useStripe();
     const elements = useElements();
     const { error: notifyError, success } = useNotify();
@@ -26,12 +32,13 @@ function Inner({ number, onPaid }: { number: string; onPaid?: (status?: string) 
                 notifyError({ title: error.message || 'Оплата не пройшла' });
             } else {
                 const status = paymentIntent?.status;
+                const paymentIntentId = paymentIntent?.id;
                 if (status === 'succeeded') {
                     success({ title: 'Оплата успішна' });
-                    onPaid?.(status);
+                    onPaid?.(status, paymentIntentId);
                 } else if (status === 'processing') {
                     success({ title: 'Оплата обробляється…' });
-                    onPaid?.(status);
+                    onPaid?.(status, paymentIntentId);
                 } else {
                     // якщо 3DS або редірект — Stripe сам обробить сценарій
                     success({ title: 'Оплата обробляється…' });
@@ -52,7 +59,13 @@ function Inner({ number, onPaid }: { number: string; onPaid?: (status?: string) 
     );
 }
 
-export default function PayOrder({ number, onPaid }: { number: string; onPaid?: (status?: string) => void }) {
+export default function PayOrder({
+    number,
+    onPaid,
+}: {
+    number: string;
+    onPaid?: (status?: string, paymentIntentId?: string) => void;
+}) {
     const [clientSecret, setClientSecret] = useState<string | null>(null);
     const [publishableKey, setPublishableKey] = useState<string | null>(null);
 


### PR DESCRIPTION
## Summary
- include the payment intent id when notifying PayOrder consumers about payment completion
- refresh the order status with the payment intent before navigating to the confirmation page, retrying once on failure

## Testing
- npm run types *(fails: existing type errors from unrelated missing aliases)*

------
https://chatgpt.com/codex/tasks/task_e_68ca691a9ae08331808c9f4b42d11e52