### PR TITLE
Add billing address support to checkout

### DIFF
--- a/resources/js/shop/api.tsx
+++ b/resources/js/shop/api.tsx
@@ -228,6 +228,14 @@ export type OrderResponse = {
         postal_code?: string | null;
         phone?: string | null;
     };
+    billing_address?: {
+        name?: string;
+        company?: string | null;
+        tax_id?: string | null;
+        city?: string | null;
+        addr?: string | null;
+        postal_code?: string | null;
+    } | null;
     note?: string | null;
     created_at?: string | null;
     updated_at?: string | null;
@@ -545,7 +553,14 @@ export const OrdersApi = {
             postal_code?: string | null;
             phone?: string | null;
         };
-        billing_address?: Record<string, unknown>;
+        billing_address?: {
+            name: string;
+            company?: string | null;
+            tax_id?: string | null;
+            city: string;
+            addr: string;
+            postal_code?: string | null;
+        } | null;
         note?: string;
     }): Promise<OrderResponse> {
         const cart_id = await requireCartId();

--- a/resources/js/shop/pages/OrderConfirmation.tsx
+++ b/resources/js/shop/pages/OrderConfirmation.tsx
@@ -37,6 +37,14 @@ type Order = {
         postal_code?: string | null;
         phone?: string | null;
     };
+    billing_address?: {
+        name?: string | null;
+        company?: string | null;
+        tax_id?: string | null;
+        city?: string | null;
+        addr?: string | null;
+        postal_code?: string | null;
+    } | null;
     currency?: string | null;
 };
 
@@ -139,6 +147,29 @@ export default function OrderConfirmation() {
                         {order.shipping_address.postal_code && <div>{order.shipping_address.postal_code}</div>}
                         {order.shipping_address.phone && <div>{order.shipping_address.phone}</div>}
                     </div>
+                )}
+            </div>
+            <div className="rounded-xl border border-gray-200 p-4 space-y-2">
+                <h2 className="text-lg font-semibold">Платіжні дані</h2>
+                {order.billing_address ? (
+                    <div className="text-sm text-gray-600">
+                        {order.billing_address.company && (
+                            <div className="font-medium text-gray-800">{order.billing_address.company}</div>
+                        )}
+                        {order.billing_address.name && <div>{order.billing_address.name}</div>}
+                        {order.billing_address.tax_id && (
+                            <div className="text-xs text-gray-500">
+                                Податковий номер: {order.billing_address.tax_id}
+                            </div>
+                        )}
+                        {order.billing_address.city && <div>{order.billing_address.city}</div>}
+                        {order.billing_address.addr && <div>{order.billing_address.addr}</div>}
+                        {order.billing_address.postal_code && <div>{order.billing_address.postal_code}</div>}
+                    </div>
+                ) : (
+                    <p className="text-sm text-gray-600">
+                        Реквізити для рахунку збігаються з адресою доставки.
+                    </p>
                 )}
             </div>
             <div className="border rounded-xl overflow-hidden">


### PR DESCRIPTION
## Summary
- add an optional billing details section to the checkout address step with validation
- include billing data in order creation payloads and surface it during payment and confirmation

## Testing
- `npm run types` *(fails: repository is missing numerous route/action modules referenced across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ca69f040d4833181054709dc1a7dda