### PR TITLE
Fix base controller inheritance and add wishlist tests

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -5,8 +5,9 @@ namespace App\Http\Controllers;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
 
-abstract class Controller
+abstract class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,6 +22,7 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
+        <env name="REDIS_CLIENT" value="predis"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>

--- a/tests/Feature/WishlistApiTest.php
+++ b/tests/Feature/WishlistApiTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Models\Product;
+use App\Models\User;
+use App\Models\Wishlist;
+use Illuminate\Support\Carbon;
+use Laravel\Sanctum\Sanctum;
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+
+it('returns wishlist items for an authenticated user', function () {
+    $user = User::factory()->create();
+    $product = Product::factory()->createQuietly();
+
+    Wishlist::query()->create([
+        'user_id' => $user->id,
+        'product_id' => $product->id,
+    ]);
+
+    Sanctum::actingAs($user, [], 'sanctum');
+
+    getJson('/api/profile/wishlist')
+        ->assertOk()
+        ->assertJsonFragment([
+            'id' => $product->id,
+            'name' => $product->name,
+        ]);
+});
+
+it('upserts wishlist items when syncing after login', function () {
+    $user = User::factory()->create();
+    $product = Product::factory()->createQuietly();
+
+    Sanctum::actingAs($user, [], 'sanctum');
+
+    Carbon::setTestNow(Carbon::parse('2024-01-01 12:00:00'));
+
+    postJson("/api/profile/wishlist/{$product->id}")
+        ->assertOk()
+        ->assertJsonFragment([
+            'id' => $product->id,
+        ]);
+
+    expect(Wishlist::query()->count())->toBe(1);
+
+    $originalUpdatedAt = Wishlist::query()->first()->updated_at;
+
+    Carbon::setTestNow(Carbon::parse('2024-01-01 12:05:00'));
+
+    postJson("/api/profile/wishlist/{$product->id}")
+        ->assertOk();
+
+    Carbon::setTestNow();
+
+    expect(Wishlist::query()->count())->toBe(1)
+        ->and(Wishlist::query()->first()->updated_at->gt($originalUpdatedAt))->toBeTrue();
+
+    getJson('/api/profile/wishlist')
+        ->assertOk()
+        ->assertJsonCount(1);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,6 +9,10 @@ abstract class TestCase extends BaseTestCase
     protected function setUp(): void
     {
         parent::setUp();
+        config([
+            'database.default' => 'sqlite',
+            'database.connections.sqlite.database' => ':memory:',
+        ]);
         config(['scout.driver' => null]);
     }
 }


### PR DESCRIPTION
## Summary
- update the base Controller class to extend Illuminate\Routing\Controller so middleware helpers remain available
- ensure the test environment uses the in-memory sqlite connection and Predis
- add feature coverage for the wishlist API including sync behaviour

## Testing
- REDIS_CLIENT=predis DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=WishlistApiTest

------
https://chatgpt.com/codex/tasks/task_e_68ca6fba0fd08331917810a3350ae669