### PR TITLE
Add auth-aware navigation to shop header

### DIFF
--- a/resources/js/shop/components/Header.tsx
+++ b/resources/js/shop/components/Header.tsx
@@ -1,14 +1,25 @@
 import { Link, NavLink } from 'react-router-dom';
-import useCart from '../useCart';
+import { ChevronDown } from 'lucide-react';
+
+import useAuth from '../hooks/useAuth';
 import MiniCart from './MiniCart';
 import WishlistBadge from '../components/WishlistBadge';
 import { openCookiePreferences } from '../ui/analytics';
 import LanguageSwitcher from '@/shop/components/LanguageSwitcher';
 import MainSearch from './MainSearch';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 
 export default function Header() {
-    const { cart, total } = useCart();
-    const itemsCount = (cart?.items ?? []).reduce((s, i) => s + Number(i.qty || 0), 0);
+    const { isAuthenticated, user, logout, isReady } = useAuth();
+
+    const displayName = user?.name?.trim() || user?.email?.trim() || 'Мій профіль';
 
     return (
         <header className="sticky top-0 z-30 border-b bg-white/80 backdrop-blur">
@@ -32,6 +43,48 @@ export default function Header() {
                         <button onClick={openCookiePreferences} className="text-xs underline">
                             Налаштувати cookies
                         </button>
+                        {!isReady ? (
+                            <span className="text-xs text-gray-500">Завантаження…</span>
+                        ) : isAuthenticated ? (
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <button className="flex items-center gap-1 text-sm font-medium text-gray-700 transition-colors hover:text-black">
+                                        <span>{displayName}</span>
+                                        <ChevronDown className="h-4 w-4" />
+                                    </button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="end" className="min-w-[12rem]">
+                                    <DropdownMenuLabel className="flex flex-col gap-0.5">
+                                        <span className="text-sm font-medium text-gray-900">{displayName}</span>
+                                        {user?.email ? (
+                                            <span className="text-xs text-gray-500">{user.email}</span>
+                                        ) : null}
+                                    </DropdownMenuLabel>
+                                    <DropdownMenuSeparator />
+                                    <DropdownMenuItem asChild>
+                                        <Link to="/profile" className="block w-full">
+                                            Мій профіль
+                                        </Link>
+                                    </DropdownMenuItem>
+                                    <DropdownMenuSeparator />
+                                    <DropdownMenuItem onSelect={() => void logout()}>
+                                        Вийти
+                                    </DropdownMenuItem>
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                        ) : (
+                            <div className="flex items-center gap-3">
+                                <Link to="/login" className="text-sm font-medium text-gray-700 transition-colors hover:text-black">
+                                    Увійти
+                                </Link>
+                                <Link
+                                    to="/register"
+                                    className="rounded border border-black px-3 py-1 text-xs font-semibold uppercase tracking-wide text-black transition-colors hover:bg-black hover:text-white"
+                                >
+                                    Зареєструватися
+                                </Link>
+                            </div>
+                        )}
                         <LanguageSwitcher />
                     </nav>
                 </div>


### PR DESCRIPTION
## Summary
- connect the shop header to the auth context so guests see login/register calls to action and authenticated users get a profile/logout dropdown
- keep the existing navigation structure intact, including the cookie preferences button, while surfacing the user identity in the header

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ca71b4200c8331b8db5c56b0c00fe9