### PR TITLE
Claim guest orders on login

### DIFF
--- a/app/Listeners/ClaimGuestOrders.php
+++ b/app/Listeners/ClaimGuestOrders.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Models\Order;
+use Illuminate\Auth\Events\Login;
+use Illuminate\Support\Facades\DB;
+
+class ClaimGuestOrders
+{
+    public function handle(Login $event): void
+    {
+        $user = $event->user;
+
+        if (! $user || ! $user->email) {
+            return;
+        }
+
+        DB::transaction(function () use ($user) {
+            $orders = Order::query()
+                ->whereNull('user_id')
+                ->where('email', $user->email)
+                ->with('shippingAddress')
+                ->lockForUpdate()
+                ->get();
+
+            if ($orders->isEmpty()) {
+                return;
+            }
+
+            foreach ($orders as $order) {
+                $order->forceFill(['user_id' => $user->id])->saveQuietly();
+
+                $shippingAddress = $order->shippingAddress;
+
+                if ($shippingAddress && $shippingAddress->user_id === null) {
+                    $shippingAddress->forceFill(['user_id' => $user->id])->saveQuietly();
+                }
+            }
+        });
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,6 +12,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
+use App\Listeners\ClaimGuestOrders;
 use App\Listeners\MergeGuestCart;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Auth\Events\Login;
@@ -46,6 +47,7 @@ class AppServiceProvider extends ServiceProvider
         Order::observe(OrderObserver::class);
         Currency::observe(CurrencyObserver::class);
         Event::listen(Login::class, MergeGuestCart::class);
+        Event::listen(Login::class, ClaimGuestOrders::class);
 
         RateLimiter::for('api', function (Request $request) {
             return [

--- a/tests/Feature/Auth/LoginOrdersTest.php
+++ b/tests/Feature/Auth/LoginOrdersTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+beforeEach(function () {
+    config(['auth.guards.sanctum' => [
+        'driver' => 'session',
+        'provider' => 'users',
+    ]]);
+});
+
+it('claims guest orders for the user upon login', function () {
+    $password = 'secret-password';
+
+    $user = User::factory()->create([
+        'email' => 'customer@example.com',
+        'password' => Hash::make($password),
+    ]);
+
+    $order = Order::factory()
+        ->has(OrderItem::factory()->count(1), 'items')
+        ->create([
+            'email' => $user->email,
+            'user_id' => null,
+        ]);
+
+    $shippingAddressId = $order->shipping_address_id;
+
+    $login = $this->postJson('/api/auth/login', [
+        'email' => $user->email,
+        'password' => $password,
+    ])->assertOk()->json();
+
+    expect($login)->toHaveKeys(['token', 'user']);
+
+    $this->actingAs($user, 'sanctum');
+
+    $ordersResponse = $this->getJson('/api/profile/orders?currency=USD')
+        ->assertOk()
+        ->json();
+
+    expect($ordersResponse)->toHaveCount(1);
+    expect($ordersResponse[0]['id'])->toBe($order->id);
+
+    $this->assertDatabaseHas('orders', [
+        'id' => $order->id,
+        'user_id' => $user->id,
+    ]);
+
+    $this->assertDatabaseHas('addresses', [
+        'id' => $shippingAddressId,
+        'user_id' => $user->id,
+    ]);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,13 +6,31 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
+    protected function setUpTraits()
+    {
+        $this->configureEnvironment();
+
+        return parent::setUpTraits();
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->configureEnvironment();
+    }
+
+    private function configureEnvironment(): void
+    {
         config([
             'database.default' => 'sqlite',
             'database.connections.sqlite.database' => ':memory:',
+            'mail.default' => 'log',
         ]);
-        config(['scout.driver' => null]);
+
+        config([
+            'queue.default' => 'sync',
+            'scout.driver' => null,
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- add a ClaimGuestOrders listener that assigns guest orders and addresses to the authenticating user during login
- register the new listener alongside MergeGuestCart and tighten the test harness configuration for sqlite, sync queues, and log mail
- cover the behaviour with a feature test that logs in and asserts the guest order appears in the profile API

## Testing
- ./vendor/bin/pest tests/Feature/Auth/LoginOrdersTest.php
- ./vendor/bin/pest tests/Feature/ProfileOrdersTest.php

------
https://chatgpt.com/codex/tasks/task_e_68ca78c677c0833198a49a8116943e87