### PR TITLE
Enable profile updates for authenticated users

### DIFF
--- a/resources/js/shop/api.tsx
+++ b/resources/js/shop/api.tsx
@@ -285,6 +285,10 @@ export const AuthApi = {
         const { data } = await api.get<AuthUser>('/auth/me');
         return data;
     },
+    async update(payload: { name?: string; email?: string; password?: string | null; password_confirmation?: string | null }) {
+        const { data } = await api.put<AuthUser>('/auth/me', payload);
+        return data;
+    },
     async logout() {
         await api.post('/auth/logout');
     },

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,7 @@ Route::prefix('auth')->group(function () {
 
     Route::middleware('auth:sanctum')->group(function () {
         Route::get('me', [AuthController::class, 'me']);
+        Route::put('me', [AuthController::class, 'update']);
         Route::post('logout', [AuthController::class, 'logout']);
     });
 });

--- a/tests/e2e-profile.spec.tsx
+++ b/tests/e2e-profile.spec.tsx
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = (process.env.E2E_BASE_URL ?? 'http://localhost:8080').replace(/\/$/, '');
+const API_BASE = (process.env.E2E_API_URL ?? `${BASE}/api`).replace(/\/$/, '');
+
+function uniqueSuffix() {
+    return Math.random().toString(36).slice(2, 10);
+}
+
+test('profile: user can update personal data', async ({ page }) => {
+    const suffix = `${Date.now()}-${uniqueSuffix()}`;
+    const email = `user+${suffix}@example.com`;
+    const password = 'Secret123!';
+
+    const registerResponse = await page.request.post(`${API_BASE}/auth/register`, {
+        data: {
+            name: 'Test User',
+            email,
+            password,
+            password_confirmation: password,
+        },
+    });
+
+    expect(registerResponse.ok()).toBeTruthy();
+    const body = await registerResponse.json();
+    expect(body?.token).toBeTruthy();
+    const token = body.token as string;
+
+    await page.addInitScript((tokenValue: string) => {
+        window.localStorage.setItem('sanctum_token', tokenValue);
+    }, token);
+
+    await page.goto(`${BASE}/profile`);
+
+    await expect(page.getByTestId('profile-form')).toBeVisible();
+
+    const newName = `Updated ${suffix}`;
+    const newEmail = `updated+${suffix}@example.com`;
+
+    await page.getByTestId('profile-name').fill(newName);
+    await page.getByTestId('profile-email').fill(newEmail);
+    await page.getByTestId('profile-password').fill(password);
+    await page.getByTestId('profile-password-confirmation').fill(password);
+
+    const waitUpdate = page.waitForResponse(
+        (response) =>
+            response.url().includes('/api/auth/me') &&
+            response.request().method() === 'PUT' &&
+            response.status() >= 200 &&
+            response.status() < 300,
+    );
+
+    await page.getByTestId('profile-save').click();
+    await waitUpdate;
+
+    await expect(page.getByTestId('profile-success')).toBeVisible();
+    await expect(page.getByTestId('profile-name-display')).toHaveText(newName);
+    await expect(page.getByTestId('profile-email-display')).toHaveText(newEmail);
+});


### PR DESCRIPTION
## Summary
- add a Sanctum-protected `PUT /auth/me` endpoint for updating the authenticated user profile
- implement the profile editing form in the shop UI using the new `AuthApi.update` call and refresh the auth state after saving
- add a Playwright end-to-end test that registers a user and verifies profile edits are persisted

## Testing
- npm run lint *(fails: existing lint rules flag many legacy `any` usages in the project)*
- composer test *(fails: vendor autoloader is missing in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7cd0c0e08331894eb6c2221092d8