### PR TITLE
Avoid duplicate order confirmation dispatch

### DIFF
--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use App\Jobs\SendOrderConfirmation;
 use App\Models\{Address, Cart, Coupon, LoyaltyPointTransaction, Order, OrderItem, Warehouse};
 use App\Enums\ShipmentStatus;
 use App\Services\Carts\CartPricingService;
@@ -216,8 +215,6 @@ class OrderController extends Controller
                 'status' => ShipmentStatus::Pending,
             ]);
         });
-
-        SendOrderConfirmation::dispatch($order);
 
         $order->load('items.product.images', 'items.product.vendor', 'shipment');
 

--- a/app/Observers/OrderObserver.php
+++ b/app/Observers/OrderObserver.php
@@ -11,6 +11,8 @@ use BackedEnum;
 
 class OrderObserver
 {
+    public bool $afterCommit = true;
+
     public function created(Order $order): void
     {
         SendOrderConfirmation::dispatch($order)->afterCommit();

--- a/tests/Feature/OrderFlowTest.php
+++ b/tests/Feature/OrderFlowTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Enums\ShipmentStatus;
+use App\Mail\OrderPlacedMail;
 use App\Models\{Address, Cart, CartItem, Order, Product, Shipment};
+use Illuminate\Support\Facades\Mail;
 
 it('creates order from cart', function () {
 
@@ -39,4 +41,32 @@ it('creates order from cart', function () {
     expect(Shipment::count())->toBe(1);
 
     $response->assertJsonPath('shipment.status', 'pending');
+});
+
+it('sends a single confirmation email when order is created', function () {
+    Mail::fake();
+
+    $product = Product::factory()->create([
+        'stock' => 5,
+        'price' => 10.50,
+    ]);
+
+    $cart = Cart::factory()->create();
+
+    CartItem::factory()->create([
+        'cart_id' => $cart->id,
+        'product_id' => $product->id,
+        'qty' => 2,
+        'price' => $product->price,
+    ]);
+
+    $payload = [
+        'cart_id' => $cart->id,
+        'email' => 'test@example.com',
+        'shipping_address' => ['name' => 'John', 'city' => 'Kyiv', 'addr' => 'Street 1'],
+    ];
+
+    $this->postJson('/api/orders', $payload)->assertCreated();
+
+    Mail::assertSent(OrderPlacedMail::class, 1);
 });


### PR DESCRIPTION
## Summary
- remove the explicit SendOrderConfirmation dispatch from the API order controller
- ensure the Order observer always runs after the database commit before dispatching the job
- add a feature test that asserts a single confirmation email is sent when an order is created

## Testing
- php artisan test --filter=OrderFlowTest

------
https://chatgpt.com/codex/tasks/task_e_68ca979e59b48331b52309f817307e3a