### PR TITLE
Add delivered shipment mail notification

### DIFF
--- a/app/Jobs/SendOrderStatusMail.php
+++ b/app/Jobs/SendOrderStatusMail.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Mail\OrderDeliveredMail;
 use App\Mail\OrderPaidMail;
 use App\Mail\OrderShippedMail;
 use App\Models\Order;
@@ -29,9 +30,10 @@ class SendOrderStatusMail implements ShouldQueue
         }
 
         match ($this->status) {
-            'paid'    => Mail::to($order->email)->send(new OrderPaidMail($order)),
-            'shipped' => Mail::to($order->email)->send(new OrderShippedMail($order)),
-            default   => null,
+            'paid'      => Mail::to($order->email)->send(new OrderPaidMail($order)),
+            'shipped'   => Mail::to($order->email)->send(new OrderShippedMail($order)),
+            'delivered' => Mail::to($order->email)->send(new OrderDeliveredMail($order)),
+            default     => null,
         };
     }
 }

--- a/app/Mail/OrderDeliveredMail.php
+++ b/app/Mail/OrderDeliveredMail.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Order;
+use Illuminate\Mail\Mailable;
+
+class OrderDeliveredMail extends Mailable
+{
+    public function __construct(public Order $order) {}
+
+    public function build()
+    {
+        return $this
+            ->subject("Order {$this->order->number} is delivered")
+            ->markdown('emails.orders.delivered', ['order' => $this->order]);
+    }
+}

--- a/app/Observers/ShipmentObserver.php
+++ b/app/Observers/ShipmentObserver.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Observers;
+
+use App\Enums\ShipmentStatus;
+use App\Jobs\SendOrderStatusMail;
+use App\Models\Shipment;
+
+class ShipmentObserver
+{
+    public bool $afterCommit = true;
+
+    public function updated(Shipment $shipment): void
+    {
+        if (! $shipment->wasChanged('status')) {
+            return;
+        }
+
+        if ($shipment->status !== ShipmentStatus::Delivered) {
+            return;
+        }
+
+        if (! $shipment->order_id) {
+            return;
+        }
+
+        SendOrderStatusMail::dispatch(
+            $shipment->order_id,
+            ShipmentStatus::Delivered->value
+        )->afterCommit();
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,10 +4,12 @@ namespace App\Providers;
 
 use App\Models\Currency;
 use App\Models\Order;
+use App\Models\Shipment;
 use App\Models\Warehouse;
 use App\Observers\OrderObserver;
 use App\Observers\ProductObserver;
 use App\Observers\CurrencyObserver;
+use App\Observers\ShipmentObserver;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -46,6 +48,7 @@ class AppServiceProvider extends ServiceProvider
         Product::observe(ProductObserver::class);
         Order::observe(OrderObserver::class);
         Currency::observe(CurrencyObserver::class);
+        Shipment::observe(ShipmentObserver::class);
         Event::listen(Login::class, MergeGuestCart::class);
         Event::listen(Login::class, ClaimGuestOrders::class);
 

--- a/resources/views/emails/orders/delivered.blade.php
+++ b/resources/views/emails/orders/delivered.blade.php
@@ -1,0 +1,17 @@
+@component('mail::message')
+    # It's here!
+
+    Your order **{{ $order->number }}** has been **delivered**.
+
+    @component('mail::panel')
+        Total: **{{ number_format((float)$order->total, 2) }}**
+        Status: **{{ $order->status }}**
+    @endcomponent
+
+    @component('mail::button', ['url' => config('app.url')])
+        View order
+    @endcomponent
+
+    Cheers,<br>
+    {{ config('app.name') }}
+@endcomponent

--- a/tests/Feature/ShipmentDeliveryMailTest.php
+++ b/tests/Feature/ShipmentDeliveryMailTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Enums\ShipmentStatus;
+use App\Mail\OrderDeliveredMail;
+use App\Models\Order;
+use Illuminate\Support\Facades\Mail;
+
+it('sends delivery email once when shipment is delivered', function () {
+    Mail::fake();
+
+    $order = Order::factory()->create([
+        'email' => 'customer@example.com',
+    ]);
+
+    $shipment = $order->shipment;
+
+    $shipment->update(['status' => ShipmentStatus::Delivered]);
+
+    Mail::assertSent(OrderDeliveredMail::class, 1);
+
+    Mail::assertSent(OrderDeliveredMail::class, function (OrderDeliveredMail $mail) use ($order) {
+        return $mail->order->is($order);
+    });
+});


### PR DESCRIPTION
## Summary
- introduce an OrderDeliveredMail mailable and markdown template for delivered shipments
- extend SendOrderStatusMail to support the delivered status and register a shipment observer
- dispatch the delivered notification when a shipment status changes to delivered and cover it with a feature test

## Testing
- php artisan test *(warnings: multiple tests warn about missing `.env` file in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca99c416f083319063c1c0c2694f7e