### PR TITLE
Refine order email templates

### DIFF
--- a/app/Mail/OrderPaidMail.php
+++ b/app/Mail/OrderPaidMail.php
@@ -12,7 +12,7 @@ class OrderPaidMail extends Mailable
     public function build()
     {
         return $this
-            ->subject("Order {$this->order->number} is paid")
-            ->markdown('emails.orders.paid', ['order' => $this->order]);
+            ->subject("Замовлення {$this->order->number} оплачене")
+            ->view('emails.orders.paid', ['order' => $this->order]);
     }
 }

--- a/app/Mail/OrderPlacedMail.php
+++ b/app/Mail/OrderPlacedMail.php
@@ -20,7 +20,7 @@ class OrderPlacedMail extends Mailable
     public function build(): self
     {
         return $this->subject("Ваше замовлення #{$this->order->number} прийнято")
-            ->markdown('emails.orders.placed', [
+            ->view('emails.orders.placed', [
                 'order' => $this->order->loadMissing(['items.product']),
             ]);
     }

--- a/app/Mail/OrderShippedMail.php
+++ b/app/Mail/OrderShippedMail.php
@@ -12,7 +12,7 @@ class OrderShippedMail extends Mailable
     public function build()
     {
         return $this
-            ->subject("Order {$this->order->number} is shipped")
-            ->markdown('emails.orders.shipped', ['order' => $this->order]);
+            ->subject("Замовлення {$this->order->number} відправлено")
+            ->view('emails.orders.shipped', ['order' => $this->order]);
     }
 }

--- a/app/Support/OrderMailFormatter.php
+++ b/app/Support/OrderMailFormatter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Order;
+use App\Services\Currency\CurrencyConverter;
+
+class OrderMailFormatter
+{
+    public static function money(Order $order, float $amount, ?string $currency = null): string
+    {
+        /** @var CurrencyConverter $converter */
+        $converter = app(CurrencyConverter::class);
+
+        $baseCurrency = strtoupper($converter->getBaseCurrency());
+        $orderCurrency = strtoupper($currency ?? $order->currency ?? $baseCurrency);
+        $baseAmount = $converter->convertToBase($amount, $orderCurrency);
+
+        $formatCurrency = static function (float $value, string $code): string {
+            $formatted = number_format($value, 2, ',', ' ');
+
+            return $code === 'UAH'
+                ? sprintf('%s грн', $formatted)
+                : sprintf('%s %s', $formatted, $code);
+        };
+
+        $amounts = [
+            'UAH' => $formatCurrency($converter->convertFromBase($baseAmount, 'UAH'), 'UAH'),
+            $baseCurrency => $formatCurrency($baseAmount, $baseCurrency),
+        ];
+
+        return implode(' / ', array_unique(array_values($amounts)));
+    }
+}

--- a/resources/views/components/emails/orders/layout.blade.php
+++ b/resources/views/components/emails/orders/layout.blade.php
@@ -1,0 +1,71 @@
+@props([
+    'order',
+    'title' => null,
+    'heading' => null,
+    'introLines' => [],
+    'buttonUrl' => null,
+    'buttonLabel' => null,
+    'footerNote' => null,
+])
+
+@php
+    $introLines = is_string($introLines) ? [$introLines] : (array) $introLines;
+    $footerNote ??= __('Якщо виникли питання — просто відповідайте на цей лист.');
+    $orderEmail = $order->email ?? null;
+
+@endphp
+<!doctype html>
+<html lang="uk">
+<head>
+    <meta charset="utf-8">
+    <title>{{ $title ?? (isset($order) ? __('Замовлення #:number', ['number' => $order->number ?? '']) : config('app.name')) }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+</head>
+<body style="margin:0;padding:0;background:#f6f7f9;font-family:system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f6f7f9;padding:24px 0;">
+    <tr>
+        <td align="center">
+            <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden">
+                <tr>
+                    <td style="padding:24px 24px 0 24px;">
+                        @if($heading)
+                            <h1 style="margin:0 0 8px 0;font-size:20px;color:#111">{{ $heading }}</h1>
+                        @endif
+                        @foreach($introLines as $line)
+                            <p style="margin:0 0 12px 0;color:#444;font-size:14px">{!! nl2br(e($line)) !!}</p>
+                        @endforeach
+                        @if($orderEmail && empty($introLines))
+                            <p style="margin:0 0 12px 0;color:#444;font-size:14px">
+                                {{ __('Ми надішлемо оновлення на :email.', ['email' => $orderEmail]) }}
+                            </p>
+                        @endif
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding:0 24px 24px 24px">
+                        {{ $slot }}
+                    </td>
+                </tr>
+                @if($buttonUrl && $buttonLabel)
+                    <tr>
+                        <td style="padding:0 24px 32px 24px;">
+                            <a href="{{ $buttonUrl }}" style="display:inline-block;background:#111;color:#fff;text-decoration:none;padding:12px 24px;border-radius:8px;font-size:14px;font-weight:600;">
+                                {{ $buttonLabel }}
+                            </a>
+                        </td>
+                    </tr>
+                @endif
+                <tr>
+                    <td style="padding:0 24px 24px 24px;color:#666;font-size:12px">
+                        {{ $footerNote }}
+                    </td>
+                </tr>
+            </table>
+            <div style="color:#999;font-size:11px;margin-top:10px">
+                © {{ now()->year }} {{ config('app.name', 'Shop') }}
+            </div>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/resources/views/emails/orders/paid.blade.php
+++ b/resources/views/emails/orders/paid.blade.php
@@ -1,17 +1,42 @@
-@component('mail::message')
-    # Payment received
+@php
+    $heading = __('Оплату отримано');
+    $introLines = [
+        __('Замовлення №:number успішно оплачене.', ['number' => $order->number]),
+        __('Ми готуємо його до відправлення та повідомимо про наступні кроки.'),
+    ];
+    $buttonUrl = config('app.url');
+    $buttonLabel = __('До магазину');
+    $total = (float) ($order->total ?? 0);
+    $timezone = config('app.timezone', 'UTC');
+@endphp
 
-    Your order **{{ $order->number }}** is now **paid**.
-
-    @component('mail::panel')
-        Total: **{{ number_format((float)$order->total, 2) }}**
-        Status: **{{ $order->status }}**
-    @endcomponent
-
-    @component('mail::button', ['url' => config('app.url')])
-        Go to shop
-    @endcomponent
-
-    Thanks,<br>
-    {{ config('app.name') }}
-@endcomponent
+<x-emails.orders.layout
+    :order="$order"
+    :heading="$heading"
+    :intro-lines="$introLines"
+    :button-url="$buttonUrl"
+    :button-label="$buttonLabel"
+>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse">
+        <tbody>
+        <tr>
+            <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Номер замовлення') }}</td>
+            <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">{{ $order->number }}</td>
+        </tr>
+        <tr>
+            <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Сума до сплати') }}</td>
+            <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">{{ \App\Support\OrderMailFormatter::money($order, $total) }}</td>
+        </tr>
+        <tr>
+            <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Статус') }}</td>
+            <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#0b7a29;font-weight:700;">{{ __('Оплачено') }}</td>
+        </tr>
+        @if($order->paid_at)
+            <tr>
+                <td style="padding:10px 0;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Дата оплати') }}</td>
+                <td align="right" style="padding:10px 0;font-size:14px;color:#111;font-weight:600;">{{ $order->paid_at->timezone($timezone)->format('d.m.Y H:i') }}</td>
+            </tr>
+        @endif
+        </tbody>
+    </table>
+</x-emails.orders.layout>

--- a/resources/views/emails/orders/placed.blade.php
+++ b/resources/views/emails/orders/placed.blade.php
@@ -1,89 +1,62 @@
 @php
-    $items = $order->items ?? collect();
-    $total = (float)($order->total ?? $items->sum(fn($i)=> (float)$i->price * (int)$i->qty));
+    $items = ($order->items ?? collect())->map(function ($item) {
+        $name = $item->name ?? $item->product->name ?? ('#' . $item->product_id);
+        $price = (float) ($item->price ?? $item->product->price ?? 0);
+        $qty = max((int) ($item->qty ?? 1), 1);
+        $img = $item->preview_url
+            ?? optional($item->product?->images?->firstWhere('is_primary', true))->url
+            ?? optional($item->product?->images?->first())->url
+            ?? $item->product?->preview_url;
+
+        return [
+            'name' => $name,
+            'price' => $price,
+            'qty' => $qty,
+            'sum' => $price * $qty,
+            'img' => $img,
+        ];
+    });
+
+    $total = (float) ($order->total ?? $items->sum('sum'));
+    $heading = __('Дякуємо за замовлення!');
+    $introLines = [
+        __('Замовлення №:number оформлено.', ['number' => $order->number]),
+        __('Ми надішлемо оновлення на :email.', ['email' => $order->email]),
+    ];
 @endphp
-    <!doctype html>
-<html lang="uk">
-<head>
-    <meta charset="utf-8">
-    <title>Підтвердження замовлення {{ $order->number }}</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-</head>
-<body style="margin:0;padding:0;background:#f6f7f9;font-family:system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;">
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f6f7f9;padding:24px 0;">
-    <tr>
-        <td align="center">
-            <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden">
-                <tr>
-                    <td style="padding:24px 24px 0 24px;">
-                        <h1 style="margin:0 0 8px 0;font-size:20px;color:#111">Дякуємо за замовлення!</h1>
-                        <p style="margin:0 0 16px 0;color:#444;font-size:14px">
-                            Замовлення <b>{{ $order->number }}</b> оформлено.
-                            Ми надішлемо оновлення на <b>{{ $order->email }}</b>.
-                        </p>
-                    </td>
-                </tr>
 
-                <tr>
-                    <td style="padding:0 24px 16px 24px">
-                        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse">
-                            <thead>
-                            <tr>
-                                <th align="left" style="padding:8px 0;border-bottom:1px solid #eee;font-size:12px;color:#666">Товар</th>
-                                <th align="center" style="padding:8px 0;border-bottom:1px solid #eee;font-size:12px;color:#666">К-сть</th>
-                                <th align="right" style="padding:8px 0;border-bottom:1px solid #eee;font-size:12px;color:#666">Ціна</th>
-                                <th align="right" style="padding:8px 0;border-bottom:1px solid #eee;font-size:12px;color:#666">Сума</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            @foreach($items as $it)
-                                @php
-                                    $name  = $it->name ?? $it->product->name ?? ('#'.$it->product_id);
-                                    $price = (float)($it->price ?? $it->product->price ?? 0);
-                                    $qty   = (int)($it->qty ?? 1);
-                                    $sum   = $price * $qty;
-                                    $img   = $it->preview_url
-                                           ?? optional($it->product?->images?->firstWhere('is_primary', true))->url
-                                           ?? optional($it->product?->images?->first())->url
-                                           ?? $it->product?->preview_url;
-                                @endphp
-                                <tr>
-                                    <td style="padding:10px 0;border-bottom:1px solid #f1f1f1">
-                                        <div style="display:flex;gap:10px;align-items:center">
-                                            @if($img)
-                                                <img src="{{ $img }}" alt="" width="48" height="48" style="display:block;border:1px solid #eee;border-radius:8px;object-fit:cover">
-                                            @endif
-                                            <div style="font-size:14px;color:#111">{{ $name }}</div>
-                                        </div>
-                                    </td>
-                                    <td align="center" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111">{{ $qty }}</td>
-                                    <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111">{{ number_format($price,2,',',' ') }} грн</td>
-                                    <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111">{{ number_format($sum,2,',',' ') }} грн</td>
-                                </tr>
-                            @endforeach
-                            </tbody>
-                            <tfoot>
-                            <tr>
-                                <td colspan="3" align="right" style="padding:14px 0;font-weight:600;color:#111">Разом</td>
-                                <td align="right" style="padding:14px 0;font-weight:700;color:#111">{{ number_format($total,2,',',' ') }} грн</td>
-                            </tr>
-                            </tfoot>
-                        </table>
-                    </td>
-                </tr>
-
-                <tr>
-                    <td style="padding:0 24px 24px 24px;color:#666;font-size:12px">
-                        Якщо виникли питання — просто відповідайте на цей лист.
-                    </td>
-                </tr>
-            </table>
-
-            <div style="color:#999;font-size:11px;margin-top:10px">
-                © {{ date('Y') }} Shop
-            </div>
-        </td>
-    </tr>
-</table>
-</body>
-</html>
+<x-emails.orders.layout :order="$order" :heading="$heading" :intro-lines="$introLines">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse">
+        <thead>
+        <tr>
+            <th align="left" style="padding:8px 0;border-bottom:1px solid #eee;font-size:12px;color:#666">{{ __('Товар') }}</th>
+            <th align="center" style="padding:8px 0;border-bottom:1px solid #eee;font-size:12px;color:#666">{{ __('К-сть') }}</th>
+            <th align="right" style="padding:8px 0;border-bottom:1px solid #eee;font-size:12px;color:#666">{{ __('Ціна') }}</th>
+            <th align="right" style="padding:8px 0;border-bottom:1px solid #eee;font-size:12px;color:#666">{{ __('Сума') }}</th>
+        </tr>
+        </thead>
+        <tbody>
+        @foreach($items as $item)
+            <tr>
+                <td style="padding:10px 0;border-bottom:1px solid #f1f1f1">
+                    <div style="display:flex;gap:10px;align-items:center">
+                        @if($item['img'])
+                            <img src="{{ $item['img'] }}" alt="" width="48" height="48" style="display:block;border:1px solid #eee;border-radius:8px;object-fit:cover">
+                        @endif
+                        <div style="font-size:14px;color:#111">{{ $item['name'] }}</div>
+                    </div>
+                </td>
+                <td align="center" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111">{{ $item['qty'] }}</td>
+                <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111">{{ \App\Support\OrderMailFormatter::money($order, $item['price']) }}</td>
+                <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111">{{ \App\Support\OrderMailFormatter::money($order, $item['sum']) }}</td>
+            </tr>
+        @endforeach
+        </tbody>
+        <tfoot>
+        <tr>
+            <td colspan="3" align="right" style="padding:14px 0;font-weight:600;color:#111">{{ __('Разом') }}</td>
+            <td align="right" style="padding:14px 0;font-weight:700;color:#111">{{ \App\Support\OrderMailFormatter::money($order, $total) }}</td>
+        </tr>
+        </tfoot>
+    </table>
+</x-emails.orders.layout>

--- a/resources/views/emails/orders/shipped.blade.php
+++ b/resources/views/emails/orders/shipped.blade.php
@@ -1,17 +1,42 @@
-@component('mail::message')
-    # Good news!
+@php
+    $heading = __('Замовлення в дорозі');
+    $introLines = [
+        __('Ми передали замовлення №:number до служби доставки.', ['number' => $order->number]),
+        __('Надішлемо сповіщення, щойно воно прибуде.'),
+    ];
+    $buttonUrl = config('app.url');
+    $buttonLabel = __('Відстежити замовлення');
+    $total = (float) ($order->total ?? 0);
+    $timezone = config('app.timezone', 'UTC');
+@endphp
 
-    Your order **{{ $order->number }}** has been **shipped**.
-
-    @component('mail::panel')
-        Total: **{{ number_format((float)$order->total, 2) }}**
-        Status: **{{ $order->status }}**
-    @endcomponent
-
-    @component('mail::button', ['url' => config('app.url')])
-        Track order
-    @endcomponent
-
-    Cheers,<br>
-    {{ config('app.name') }}
-@endcomponent
+<x-emails.orders.layout
+    :order="$order"
+    :heading="$heading"
+    :intro-lines="$introLines"
+    :button-url="$buttonUrl"
+    :button-label="$buttonLabel"
+>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse">
+        <tbody>
+        <tr>
+            <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Номер замовлення') }}</td>
+            <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">{{ $order->number }}</td>
+        </tr>
+        <tr>
+            <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Сума замовлення') }}</td>
+            <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">{{ \App\Support\OrderMailFormatter::money($order, $total) }}</td>
+        </tr>
+        <tr>
+            <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Статус') }}</td>
+            <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#0052b4;font-weight:700;">{{ __('Відправлено') }}</td>
+        </tr>
+        @if($order->shipped_at)
+            <tr>
+                <td style="padding:10px 0;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Дата відправлення') }}</td>
+                <td align="right" style="padding:10px 0;font-size:14px;color:#111;font-weight:600;">{{ $order->shipped_at->timezone($timezone)->format('d.m.Y H:i') }}</td>
+            </tr>
+        @endif
+        </tbody>
+    </table>
+</x-emails.orders.layout>

--- a/tests/Feature/Mail/OrderEmailsTest.php
+++ b/tests/Feature/Mail/OrderEmailsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Mail;
+
+use App\Mail\OrderPaidMail;
+use App\Mail\OrderShippedMail;
+use App\Models\Order;
+use App\Models\OrderItem;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OrderEmailsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_order_paid_mail_contains_key_information(): void
+    {
+        $order = Order::factory()
+            ->has(OrderItem::factory()->count(2), 'items')
+            ->create([
+                'currency' => 'UAH',
+                'total' => 1250.75,
+                'paid_at' => now(),
+            ]);
+
+        $mailable = new OrderPaidMail($order->fresh());
+        $html = $mailable->render();
+
+        $this->assertStringContainsString('Оплату отримано', $html);
+        $this->assertStringContainsString($order->number, $html);
+        $this->assertStringContainsString('грн', $html);
+    }
+
+    public function test_order_shipped_mail_highlights_shipment_status(): void
+    {
+        $order = Order::factory()->create([
+            'currency' => 'UAH',
+            'total' => 980.15,
+            'shipped_at' => now(),
+        ]);
+
+        $mailable = new OrderShippedMail($order);
+        $html = $mailable->render();
+
+        $this->assertStringContainsString('Замовлення в дорозі', $html);
+        $this->assertStringContainsString('Відправлено', $html);
+        $this->assertStringContainsString($order->number, $html);
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable HTML layout component for order notifications with unified typography and currency formatting
- refactor the placed, paid, and shipped order emails to use the shared layout and localized copy
- switch order mailers to HTML views and add a formatter helper plus feature tests for generated markup

## Testing
- php artisan test --testsuite=Feature --filter=OrderEmailsTest

------
https://chatgpt.com/codex/tasks/task_e_68ca9b00c41c8331b0ae717032fc8a60