### PR TITLE
Add cart actions to catalog cards and test

### DIFF
--- a/resources/js/shop/pages/Catalog.test.tsx
+++ b/resources/js/shop/pages/Catalog.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+const cartApiMock = {
+    add: vi.fn<[number, number?], Promise<unknown>>(),
+};
+
+const fetchCategoriesMock = vi.fn();
+const fetchProductsMock = vi.fn();
+
+vi.mock('../api', () => ({
+    fetchCategories: fetchCategoriesMock,
+    fetchProducts: fetchProductsMock,
+    CartApi: cartApiMock,
+}));
+
+vi.mock('../useCart', () => ({
+    __esModule: true,
+    default: () => ({
+        add: cartApiMock.add,
+    }),
+}));
+
+vi.mock('../components/WishlistButton', () => ({
+    __esModule: true,
+    default: () => <div data-testid="wishlist-button" />, // stub to simplify rendering
+}));
+
+vi.mock('../components/SeoHead', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+vi.mock('../components/JsonLd', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+vi.mock('../ui/ga', () => ({
+    GA: { view_item_list: vi.fn() },
+}));
+
+vi.mock('@/components/ui/button', () => ({
+    Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+        <button {...props}>{children}</button>
+    ),
+}), { virtual: true });
+
+vi.mock('@/components/ui/card', () => ({
+    Card: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+        <div {...props}>{children}</div>
+    ),
+}), { virtual: true });
+
+vi.mock('@/components/ui/input', () => ({
+    Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}), { virtual: true });
+
+vi.mock('@/components/ui/skeleton', () => ({
+    Skeleton: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+        <div {...props}>{children}</div>
+    ),
+}), { virtual: true });
+
+vi.mock('@/components/ui/select', () => {
+    const Select = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+    const SelectTrigger = ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+        <button {...props}>{children}</button>
+    );
+    const SelectValue = ({ children }: { children?: React.ReactNode }) => <span>{children}</span>;
+    const SelectContent = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+    const SelectItem = ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+        <div {...props}>{children}</div>
+    );
+    return { Select, SelectTrigger, SelectValue, SelectContent, SelectItem };
+}, { virtual: true });
+
+const { default: Catalog } = await import('./Catalog');
+
+function createDeferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+describe('Catalog page', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        const product = {
+            id: 101,
+            name: 'Тестовий товар',
+            slug: 'test-product',
+            price: 1999,
+            images: [],
+        };
+
+        fetchCategoriesMock.mockResolvedValue([]);
+        fetchProductsMock.mockResolvedValue({
+            data: [product],
+            current_page: 1,
+            last_page: 1,
+            per_page: 12,
+            total: 1,
+            from: 1,
+            to: 1,
+            facets: {},
+        });
+        cartApiMock.add.mockResolvedValue({});
+    });
+
+    it('calls CartApi.add when clicking the Buy button', async () => {
+        const user = userEvent.setup();
+        const deferred = createDeferred<unknown>();
+        cartApiMock.add.mockReturnValueOnce(deferred.promise);
+
+        render(
+            <MemoryRouter>
+                <Catalog />
+            </MemoryRouter>
+        );
+
+        const buyButton = await screen.findByRole('button', { name: 'Купити' });
+        await user.click(buyButton);
+
+        expect(cartApiMock.add).toHaveBeenCalledWith(101);
+
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: 'Купуємо…' })).toBeDisabled()
+        );
+
+        deferred.resolve({});
+
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: 'Купити' })).toBeEnabled()
+        );
+    });
+});

--- a/resources/js/shop/pages/Catalog.tsx
+++ b/resources/js/shop/pages/Catalog.tsx
@@ -24,6 +24,8 @@ import SeoHead from '../components/SeoHead';
 import JsonLd from '../components/JsonLd';
 import { useHreflangs } from '../hooks/useHreflangs';
 import { GA } from '../ui/ga';
+import useCart from '../useCart';
+import { Loader2 } from 'lucide-react';
 
 type SortKey = 'price_asc' | 'price_desc' | 'new';
 
@@ -33,6 +35,8 @@ export default function Catalog() {
     const [page, setPage] = useState(1);
     const [lastPage, setLastPage] = useState(1);
     const [loading, setLoading] = useState(true);
+    const [addingId, setAddingId] = useState<number | null>(null);
+    const { add } = useCart();
 
     // пошук у URL
     const [q, setQ] = useQueryParam('q', '');
@@ -454,8 +458,12 @@ export default function Catalog() {
                             (p.images && p.images.length > 0 ? p.images[0] : undefined);
 
                         return (
-                            <Card key={p.id} className="overflow-hidden">
-                                <Link to={`/product/${p.slug ?? p.id}`} className="block" data-testid="catalog-card">
+                            <Card key={p.id} className="flex h-full flex-col overflow-hidden">
+                                <Link
+                                    to={`/product/${p.slug ?? p.id}`}
+                                    className="flex flex-1 flex-col"
+                                    data-testid="catalog-card"
+                                >
                                     <div className="aspect-square bg-muted/40">
                                         {primary ? (
                                             <img
@@ -475,10 +483,31 @@ export default function Catalog() {
                                         <div className="mt-1 text-sm text-muted-foreground">{formatPrice(p.price)}</div>
                                     </div>
                                 </Link>
-                                <h1 className="text-2xl font-semibold flex items-center gap-3">
-                                    {p.name}
-                                    <WishlistButton product={p} />
-                                </h1>
+                                <div className="flex flex-wrap items-center gap-2 border-t px-3 py-3">
+                                    <WishlistButton product={p} className="flex-1 justify-center" />
+                                    <Button
+                                        type="button"
+                                        className="flex-1"
+                                        disabled={addingId === p.id}
+                                        onClick={async () => {
+                                            setAddingId(p.id);
+                                            try {
+                                                await add(p.id);
+                                            } finally {
+                                                setAddingId((current) => (current === p.id ? null : current));
+                                            }
+                                        }}
+                                    >
+                                        {addingId === p.id ? (
+                                            <>
+                                                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                                                <span>Купуємо…</span>
+                                            </>
+                                        ) : (
+                                            'Купити'
+                                        )}
+                                    </Button>
+                                </div>
                             </Card>
                         );
                     })}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import laravel from 'laravel-vite-plugin';
 import { defineConfig } from 'vite';
+import path from 'node:path';
 
 const isVitest = process.env.VITEST === 'true';
 const useWayfinder = !isVitest && process.env.WAYFINDER !== 'off';
@@ -53,6 +54,11 @@ export default defineConfig({
     ],
     esbuild: {
         jsx: 'automatic',
+    },
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, 'resources/js'),
+        },
     },
     test: {
         environment: 'jsdom',


### PR DESCRIPTION
## Summary
- add cart integration to catalog cards with a buy button that shows a loading state
- ensure Vitest can resolve the @ alias during testing
- cover the new behaviour with a Catalog page test that confirms CartApi.add is called

## Testing
- `npm run test -- Catalog`


------
https://chatgpt.com/codex/tasks/task_e_68cac17d80e4833198f492d1d8aea2ea