### PR TITLE
Align delivered order email with shared layout

### DIFF
--- a/app/Mail/OrderDeliveredMail.php
+++ b/app/Mail/OrderDeliveredMail.php
@@ -12,9 +12,11 @@ class OrderDeliveredMail extends Mailable
     public function build()
     {
         return $this
-            ->subject("Order {$this->order->number} is delivered")
+            ->subject("Замовлення {$this->order->number} доставлено")
             ->tag('order-delivered')
             ->metadata(['type' => 'order'])
-            ->markdown('emails.orders.delivered', ['order' => $this->order]);
+            ->view('emails.orders.delivered', [
+                'order' => $this->order->loadMissing(['shipment']),
+            ]);
     }
 }


### PR DESCRIPTION
## Summary
- replace the delivered order email with the shared order layout and localized copy that highlights the key totals
- update `OrderDeliveredMail` to render the Blade view and eager-load shipment data for delivery timestamps

## Testing
- `php artisan test --filter=ShipmentDeliveryMailTest` *(fails in CI without an `.env` file; produces a warning locally)*

------
https://chatgpt.com/codex/tasks/task_e_68caccd6b7a0833195e4d0045cb9bf75