### PR TITLE
Hide empty billing block on order confirmation

### DIFF
--- a/resources/js/shop/pages/OrderConfirmation.tsx
+++ b/resources/js/shop/pages/OrderConfirmation.tsx
@@ -100,6 +100,14 @@ export default function OrderConfirmation() {
               .replace(/^[a-zа-яіїєґ]/i, (c) => c.toUpperCase())
         : null;
     const currency = order.currency ?? 'EUR';
+    const billingAddress = order.billing_address ?? null;
+    const hasBillingDetails = billingAddress
+        ? Object.values(billingAddress).some((value) => {
+              if (value == null) return false;
+              if (typeof value === 'string') return value.trim().length > 0;
+              return Boolean(value);
+          })
+        : false;
 
     return (
         <div className="max-w-6xl mx-auto p-4 space-y-6">
@@ -149,29 +157,23 @@ export default function OrderConfirmation() {
                     </div>
                 )}
             </div>
-            <div className="rounded-xl border border-gray-200 p-4 space-y-2">
-                <h2 className="text-lg font-semibold">Платіжні дані</h2>
-                {order.billing_address ? (
+            {hasBillingDetails && billingAddress && (
+                <div className="rounded-xl border border-gray-200 p-4 space-y-2">
+                    <h2 className="text-lg font-semibold">Платіжні дані</h2>
                     <div className="text-sm text-gray-600">
-                        {order.billing_address.company && (
-                            <div className="font-medium text-gray-800">{order.billing_address.company}</div>
+                        {billingAddress.company && (
+                            <div className="font-medium text-gray-800">{billingAddress.company}</div>
                         )}
-                        {order.billing_address.name && <div>{order.billing_address.name}</div>}
-                        {order.billing_address.tax_id && (
-                            <div className="text-xs text-gray-500">
-                                Податковий номер: {order.billing_address.tax_id}
-                            </div>
+                        {billingAddress.name && <div>{billingAddress.name}</div>}
+                        {billingAddress.tax_id && (
+                            <div className="text-xs text-gray-500">Податковий номер: {billingAddress.tax_id}</div>
                         )}
-                        {order.billing_address.city && <div>{order.billing_address.city}</div>}
-                        {order.billing_address.addr && <div>{order.billing_address.addr}</div>}
-                        {order.billing_address.postal_code && <div>{order.billing_address.postal_code}</div>}
+                        {billingAddress.city && <div>{billingAddress.city}</div>}
+                        {billingAddress.addr && <div>{billingAddress.addr}</div>}
+                        {billingAddress.postal_code && <div>{billingAddress.postal_code}</div>}
                     </div>
-                ) : (
-                    <p className="text-sm text-gray-600">
-                        Реквізити для рахунку збігаються з адресою доставки.
-                    </p>
-                )}
-            </div>
+                </div>
+            )}
             <div className="border rounded-xl overflow-hidden">
                 <table className="w-full">
                     <thead className="bg-gray-50 text-left text-sm">

--- a/resources/js/shop/pages/__tests__/OrderConfirmation.test.tsx
+++ b/resources/js/shop/pages/__tests__/OrderConfirmation.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import OrderConfirmation from '../OrderConfirmation';
+import { OrdersApi } from '../../api';
+
+type OrderResponse = Awaited<ReturnType<typeof OrdersApi.show>>;
+
+vi.mock('../../components/SeoHead', () => ({
+    default: () => null,
+}));
+
+vi.mock('@/shop/components/PayOrder', () => ({
+    default: () => <div data-testid="pay-order" />,
+}));
+
+vi.mock('../../components/OrderChat', () => ({
+    default: () => null,
+}));
+
+vi.mock('../../ui/ga', () => ({
+    GA: {
+        purchase: vi.fn(),
+    },
+}));
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+function renderOrderPage(order: OrderResponse) {
+    vi.spyOn(OrdersApi, 'show').mockResolvedValueOnce(order);
+
+    render(
+        <MemoryRouter initialEntries={[`/order/${order.number}`]}>
+            <Routes>
+                <Route path="/order/:number" element={<OrderConfirmation />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe('OrderConfirmation billing details', () => {
+    const baseOrder: OrderResponse = {
+        id: 1,
+        number: 'ORD-001',
+        total: 120,
+        email: 'buyer@example.com',
+        status: 'placed',
+        payment_status: 'pending',
+        items: [],
+        shipment: null,
+        shipping_address: null,
+        billing_address: null,
+        currency: 'EUR',
+    };
+
+    it('renders billing block when billing address has fields', async () => {
+        renderOrderPage({
+            ...baseOrder,
+            billing_address: {
+                name: 'John Doe',
+                city: 'Kyiv',
+                addr: 'Main st. 1',
+                postal_code: '01001',
+                company: null,
+                tax_id: null,
+            },
+        });
+
+        await screen.findByTestId('order-confirmed');
+
+        expect(screen.getByText('Платіжні дані')).toBeInTheDocument();
+        expect(screen.getByText('John Doe')).toBeInTheDocument();
+    });
+
+    it('does not render billing block when billing address is empty', async () => {
+        renderOrderPage({
+            ...baseOrder,
+            number: 'ORD-002',
+            billing_address: {
+                name: '',
+                city: '   ',
+                addr: '',
+                postal_code: null,
+                company: '',
+                tax_id: undefined,
+            },
+        });
+
+        await screen.findByTestId('order-confirmed');
+
+        expect(screen.queryByText('Платіжні дані')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Summary
- skip rendering the payment details card when an order has no billing fields
- cover the new behaviour with an OrderConfirmation page test

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68cad492fa5c83319af7fbfb38bb990d