### PR TITLE
Show coupon details in order confirmations

### DIFF
--- a/resources/js/shop/pages/__tests__/OrderConfirmation.test.tsx
+++ b/resources/js/shop/pages/__tests__/OrderConfirmation.test.tsx
@@ -93,4 +93,35 @@ describe('OrderConfirmation billing details', () => {
 
         expect(screen.queryByText('Платіжні дані')).not.toBeInTheDocument();
     });
+
+    it('shows coupon and totals summary when discount applied', async () => {
+        renderOrderPage({
+            ...baseOrder,
+            number: 'ORD-003',
+            items: [
+                {
+                    id: 11,
+                    product_id: 5,
+                    qty: 2,
+                    price: 50,
+                    product: null,
+                },
+            ],
+            subtotal: 100,
+            discount_total: 15,
+            coupon_code: 'SAVE15',
+            coupon_discount: 15,
+            total: 85,
+        });
+
+        await screen.findByTestId('order-confirmed');
+
+        expect(screen.getByText('Разом за товари')).toBeInTheDocument();
+        expect(screen.getByText('Купон')).toBeInTheDocument();
+        expect(screen.getByText('SAVE15')).toBeInTheDocument();
+        expect(screen.getByText('Знижка')).toBeInTheDocument();
+        expect(screen.getByText(/−15,00/)).toBeInTheDocument();
+        expect(screen.getByText('До сплати')).toBeInTheDocument();
+        expect(screen.getByText(/85,00/)).toBeInTheDocument();
+    });
 });

--- a/resources/views/emails/orders/delivered.blade.php
+++ b/resources/views/emails/orders/delivered.blade.php
@@ -9,7 +9,10 @@
 
     $total = (float) ($order->total ?? 0);
     $subtotal = (float) ($order->subtotal ?? $total);
-    $discount = (float) ($order->discount_total ?? 0);
+    $discount = max(0, (float) ($order->discount_total ?? (($order->coupon_discount ?? 0) + ($order->loyalty_points_value ?? 0))));
+    $couponCode = $order->coupon_code;
+    $loyaltyPointsUsed = (int) ($order->loyalty_points_used ?? 0);
+    $loyaltyPointsValue = max(0, (float) ($order->loyalty_points_value ?? 0));
     $timezone = config('app.timezone', 'UTC');
     $deliveredAt = $order->shipment?->delivered_at;
 @endphp
@@ -31,10 +34,27 @@
             <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Сума товарів') }}</td>
             <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">{{ \App\Support\OrderMailFormatter::money($order, $subtotal) }}</td>
         </tr>
+        @if(!empty($couponCode))
+            <tr>
+                <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Купон') }}</td>
+                <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">{{ $couponCode }}</td>
+            </tr>
+        @endif
         @if($discount > 0)
             <tr>
-                <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Знижки') }}</td>
+                <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Знижка') }}</td>
                 <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#d20000;font-weight:600;">−{{ \App\Support\OrderMailFormatter::money($order, $discount) }}</td>
+            </tr>
+        @endif
+        @if($loyaltyPointsUsed > 0)
+            <tr>
+                <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Використані бали') }}</td>
+                <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">
+                    {{ number_format($loyaltyPointsUsed, 0, ',', ' ') }}
+                    @if($loyaltyPointsValue > 0)
+                        <span style="color:#666;font-weight:600;">(−{{ \App\Support\OrderMailFormatter::money($order, $loyaltyPointsValue) }})</span>
+                    @endif
+                </td>
             </tr>
         @endif
         <tr>

--- a/resources/views/emails/orders/paid.blade.php
+++ b/resources/views/emails/orders/paid.blade.php
@@ -7,6 +7,11 @@
     $buttonUrl = config('app.url');
     $buttonLabel = __('До магазину');
     $total = (float) ($order->total ?? 0);
+    $subtotal = (float) ($order->subtotal ?? $total);
+    $discountTotal = max(0, (float) ($order->discount_total ?? (($order->coupon_discount ?? 0) + ($order->loyalty_points_value ?? 0))));
+    $couponCode = $order->coupon_code;
+    $loyaltyPointsUsed = (int) ($order->loyalty_points_used ?? 0);
+    $loyaltyPointsValue = max(0, (float) ($order->loyalty_points_value ?? 0));
     $timezone = config('app.timezone', 'UTC');
 @endphp
 
@@ -23,6 +28,33 @@
             <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Номер замовлення') }}</td>
             <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">{{ $order->number }}</td>
         </tr>
+        <tr>
+            <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Сума товарів') }}</td>
+            <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">{{ \App\Support\OrderMailFormatter::money($order, $subtotal) }}</td>
+        </tr>
+        @if(!empty($couponCode))
+            <tr>
+                <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Купон') }}</td>
+                <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">{{ $couponCode }}</td>
+            </tr>
+        @endif
+        @if($discountTotal > 0)
+            <tr>
+                <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Знижка') }}</td>
+                <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#d20000;font-weight:600;">−{{ \App\Support\OrderMailFormatter::money($order, $discountTotal) }}</td>
+            </tr>
+        @endif
+        @if($loyaltyPointsUsed > 0)
+            <tr>
+                <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Використані бали') }}</td>
+                <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">
+                    {{ number_format($loyaltyPointsUsed, 0, ',', ' ') }}
+                    @if($loyaltyPointsValue > 0)
+                        <span style="color:#666;font-weight:600;">(−{{ \App\Support\OrderMailFormatter::money($order, $loyaltyPointsValue) }})</span>
+                    @endif
+                </td>
+            </tr>
+        @endif
         <tr>
             <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Сума до сплати') }}</td>
             <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">{{ \App\Support\OrderMailFormatter::money($order, $total) }}</td>

--- a/resources/views/emails/orders/placed.blade.php
+++ b/resources/views/emails/orders/placed.blade.php
@@ -17,6 +17,10 @@
         ];
     });
 
+    $subtotal = (float) ($order->subtotal ?? $items->sum('sum'));
+    $discountTotal = max(0, (float) ($order->discount_total ?? (($order->coupon_discount ?? 0) + ($order->loyalty_points_value ?? 0))));
+    $loyaltyPointsUsed = (int) ($order->loyalty_points_used ?? 0);
+    $loyaltyPointsValue = max(0, (float) ($order->loyalty_points_value ?? 0));
     $total = (float) ($order->total ?? $items->sum('sum'));
     $heading = __('Дякуємо за замовлення!');
     $introLines = [
@@ -54,7 +58,34 @@
         </tbody>
         <tfoot>
         <tr>
-            <td colspan="3" align="right" style="padding:14px 0;font-weight:600;color:#111">{{ __('Разом') }}</td>
+            <td colspan="3" align="right" style="padding:12px 0;font-weight:600;color:#111">{{ __('Разом за товари') }}</td>
+            <td align="right" style="padding:12px 0;font-weight:700;color:#111">{{ \App\Support\OrderMailFormatter::money($order, $subtotal) }}</td>
+        </tr>
+        @if(!empty($order->coupon_code))
+            <tr>
+                <td colspan="3" align="right" style="padding:12px 0;font-weight:600;color:#111">{{ __('Купон') }}</td>
+                <td align="right" style="padding:12px 0;font-weight:700;color:#111">{{ $order->coupon_code }}</td>
+            </tr>
+        @endif
+        @if($discountTotal > 0)
+            <tr>
+                <td colspan="3" align="right" style="padding:12px 0;font-weight:600;color:#111">{{ __('Знижка') }}</td>
+                <td align="right" style="padding:12px 0;font-weight:700;color:#d20000;">−{{ \App\Support\OrderMailFormatter::money($order, $discountTotal) }}</td>
+            </tr>
+        @endif
+        @if($loyaltyPointsUsed > 0)
+            <tr>
+                <td colspan="3" align="right" style="padding:12px 0;font-weight:600;color:#111">{{ __('Використані бали') }}</td>
+                <td align="right" style="padding:12px 0;font-weight:700;color:#111;">
+                    {{ number_format($loyaltyPointsUsed, 0, ',', ' ') }}
+                    @if($loyaltyPointsValue > 0)
+                        <span style="color:#666;font-weight:600;">(−{{ \App\Support\OrderMailFormatter::money($order, $loyaltyPointsValue) }})</span>
+                    @endif
+                </td>
+            </tr>
+        @endif
+        <tr>
+            <td colspan="3" align="right" style="padding:14px 0;font-weight:600;color:#111">{{ __('До сплати') }}</td>
             <td align="right" style="padding:14px 0;font-weight:700;color:#111">{{ \App\Support\OrderMailFormatter::money($order, $total) }}</td>
         </tr>
         </tfoot>

--- a/resources/views/emails/orders/shipped.blade.php
+++ b/resources/views/emails/orders/shipped.blade.php
@@ -7,6 +7,11 @@
     $buttonUrl = config('app.url');
     $buttonLabel = __('Відстежити замовлення');
     $total = (float) ($order->total ?? 0);
+    $subtotal = (float) ($order->subtotal ?? $total);
+    $discountTotal = max(0, (float) ($order->discount_total ?? (($order->coupon_discount ?? 0) + ($order->loyalty_points_value ?? 0))));
+    $couponCode = $order->coupon_code;
+    $loyaltyPointsUsed = (int) ($order->loyalty_points_used ?? 0);
+    $loyaltyPointsValue = max(0, (float) ($order->loyalty_points_value ?? 0));
     $timezone = config('app.timezone', 'UTC');
 @endphp
 
@@ -23,6 +28,33 @@
             <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Номер замовлення') }}</td>
             <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">{{ $order->number }}</td>
         </tr>
+        <tr>
+            <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Сума товарів') }}</td>
+            <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">{{ \App\Support\OrderMailFormatter::money($order, $subtotal) }}</td>
+        </tr>
+        @if(!empty($couponCode))
+            <tr>
+                <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Купон') }}</td>
+                <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">{{ $couponCode }}</td>
+            </tr>
+        @endif
+        @if($discountTotal > 0)
+            <tr>
+                <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Знижка') }}</td>
+                <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#d20000;font-weight:600;">−{{ \App\Support\OrderMailFormatter::money($order, $discountTotal) }}</td>
+            </tr>
+        @endif
+        @if($loyaltyPointsUsed > 0)
+            <tr>
+                <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Використані бали') }}</td>
+                <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">
+                    {{ number_format($loyaltyPointsUsed, 0, ',', ' ') }}
+                    @if($loyaltyPointsValue > 0)
+                        <span style="color:#666;font-weight:600;">(−{{ \App\Support\OrderMailFormatter::money($order, $loyaltyPointsValue) }})</span>
+                    @endif
+                </td>
+            </tr>
+        @endif
         <tr>
             <td style="padding:10px 0;border-bottom:1px solid #f1f1f1;color:#666;font-size:12px;text-transform:uppercase;letter-spacing:0.03em;">{{ __('Сума замовлення') }}</td>
             <td align="right" style="padding:10px 0;border-bottom:1px solid #f1f1f1;font-size:14px;color:#111;font-weight:600;">{{ \App\Support\OrderMailFormatter::money($order, $total) }}</td>

--- a/resources/views/emails/orders/status-updated.blade.php
+++ b/resources/views/emails/orders/status-updated.blade.php
@@ -1,3 +1,12 @@
+@php
+    $subtotal = (float) ($order->subtotal ?? $order->total ?? 0);
+    $total = (float) ($order->total ?? 0);
+    $discountTotal = max(0, (float) ($order->discount_total ?? (($order->coupon_discount ?? 0) + ($order->loyalty_points_value ?? 0))));
+    $couponCode = $order->coupon_code;
+    $loyaltyPointsUsed = (int) ($order->loyalty_points_used ?? 0);
+    $loyaltyPointsValue = max(0, (float) ($order->loyalty_points_value ?? 0));
+@endphp
+
 @component('mail::message')
     # Статус замовлення оновлено
 
@@ -10,7 +19,17 @@
     **Стало:** {{ $toStatus }}
 
     @component('mail::panel')
-        Сума: **{{ number_format((float)$order->total, 2) }}**
+        Сума товарів: **{{ \App\Support\OrderMailFormatter::money($order, $subtotal) }}**
+        @if(!empty($couponCode))
+        Купон: **{{ $couponCode }}**
+        @endif
+        @if($discountTotal > 0)
+        Знижка: **−{{ \App\Support\OrderMailFormatter::money($order, $discountTotal) }}**
+        @endif
+        @if($loyaltyPointsUsed > 0)
+        Використані бали: **{{ number_format($loyaltyPointsUsed, 0, ',', ' ') }}@if($loyaltyPointsValue > 0) (−{{ \App\Support\OrderMailFormatter::money($order, $loyaltyPointsValue) }})@endif**
+        @endif
+        До сплати: **{{ \App\Support\OrderMailFormatter::money($order, $total) }}**
         Статус: **{{ $toStatus }}**
         Дата: {{ $order->updated_at->format('Y-m-d H:i') }}
     @endcomponent

--- a/tests/Feature/OrderEmailsTest.php
+++ b/tests/Feature/OrderEmailsTest.php
@@ -36,6 +36,42 @@ it('sends order placed email', function () {
 });
 
 
+it('renders coupon summary in order placed email view', function () {
+    $order = Order::factory()->create([
+        'email' => 'customer@example.com',
+        'coupon_code' => 'SAVE15',
+        'coupon_discount' => 10,
+        'loyalty_points_used' => 50,
+        'loyalty_points_value' => 5,
+    ]);
+
+    $product = Product::factory()->create(['price' => 50]);
+
+    OrderItem::factory()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'qty' => 2,
+        'price' => 50,
+    ]);
+
+    $order->refresh();
+    $order->recalculateTotal();
+    $order->refresh();
+
+    $html = (new OrderPlacedMail($order->loadMissing(['items.product'])))->render();
+
+    expect($html)->toContain('Купон');
+    expect($html)->toContain('SAVE15');
+    expect($html)->toContain('Знижка');
+    expect($html)->toContain('−15');
+    expect($html)->toContain('Використані бали');
+    expect($html)->toContain('50');
+    expect($html)->toContain('−5');
+    expect($html)->toContain('До сплати');
+    expect($html)->toContain('85');
+});
+
+
 
 it('sends paid and shipped emails on status change', function () {
     Mail::fake();


### PR DESCRIPTION
## Summary
- add coupon, discount, and loyalty information to the order confirmation totals table
- render matching coupon/discount/loyalty rows in all order email templates
- cover the new UI and email rendering with unit and feature tests

## Testing
- npm run test
- php artisan test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68cad86581a88331bb45116bc11e1c2d