### PR TITLE
Use shared layout for verify email

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -35,7 +35,7 @@ class AuthController extends Controller
 
         $user->loadMissing('twoFactorSecret');
 
-        $verificationUrl = $this->queueEmailVerification($user);
+        $verificationUrl = $this->queueEmailVerification($user, true);
 
         Mail::to($user)->queue(new WelcomeMail($user, $verificationUrl));
 

--- a/resources/views/emails/auth/verify-email.blade.php
+++ b/resources/views/emails/auth/verify-email.blade.php
@@ -1,19 +1,27 @@
-<!DOCTYPE html>
-<html lang="uk">
-<head>
-    <meta charset="UTF-8">
-    <title>Підтвердіть електронну адресу</title>
-</head>
-<body>
-    <h1>Привіт, {{ $user->name }}!</h1>
-    <p>Щоб активувати свій обліковий запис у Shop, підтвердіть електронну адресу протягом наступної години.</p>
-    <p>
-        <a href="{{ $verificationUrl }}" style="display:inline-block;padding:12px 24px;background-color:#2563eb;color:#ffffff;text-decoration:none;border-radius:6px;">
-            Підтвердити електронну адресу
-        </a>
+@php
+    $appName = config('app.name', 'Shop');
+    $heading = __('Підтвердіть електронну адресу для :app', ['app' => $appName]);
+    $introLines = [
+        __('Привіт, :name!', ['name' => $user->name]),
+        __('Щоб активувати свій обліковий запис у :app, підтвердіть електронну адресу протягом наступної години.', ['app' => $appName]),
+    ];
+@endphp
+
+<x-emails.auth.layout
+    :title="__('Підтвердіть електронну адресу')"
+    :heading="$heading"
+    :intro-lines="$introLines"
+    :button-url="$verificationUrl"
+    :button-label="__('Підтвердити електронну адресу')"
+>
+    @if ($verificationUrl)
+        <p style="margin:0 0 16px 0;color:#444;font-size:14px;">
+            {{ __('Кнопка не працює? Скопіюйте та вставте це посилання у свій браузер:') }}
+            <a href="{{ $verificationUrl }}" style="color:#2563eb;text-decoration:none;">{{ $verificationUrl }}</a>
+        </p>
+    @endif
+
+    <p style="margin:0;color:#666;font-size:13px;">
+        {{ __('Якщо ви не створювали обліковий запис, просто проігноруйте цей лист.') }}
     </p>
-    <p>Якщо кнопка не працює, скопіюйте та вставте це посилання у свій браузер:</p>
-    <p><a href="{{ $verificationUrl }}">{{ $verificationUrl }}</a></p>
-    <p>Якщо ви не створювали обліковий запис, проігноруйте цей лист.</p>
-</body>
-</html>
+</x-emails.auth.layout>


### PR DESCRIPTION
## Summary
- render the verify-email mailable through the shared auth email layout with heading, intro lines and CTA
- ensure new user registration also queues the verification email so both welcome and verify mails share the refreshed look

## Testing
- php artisan test tests/Feature/Auth/RegistrationTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cb91c593008331947e391d50f3d2f1