### PR TITLE
Implement API password reset flow

### DIFF
--- a/resources/js/shop/api.tsx
+++ b/resources/js/shop/api.tsx
@@ -296,6 +296,14 @@ export const AuthApi = {
         const { data } = await api.post<{ message?: string }>('/email/resend');
         return data;
     },
+    async requestPasswordReset(payload: { email: string }) {
+        const { data } = await api.post<{ message?: string }>('/password/email', payload);
+        return data;
+    },
+    async resetPassword(payload: { token: string; email: string; password: string; password_confirmation: string }) {
+        const { data } = await api.post<{ message?: string }>('/password/reset', payload);
+        return data;
+    },
 };
 
 export const TwoFactorApi = {

--- a/resources/js/shop/main.tsx
+++ b/resources/js/shop/main.tsx
@@ -13,6 +13,7 @@ import { initMonitoring } from './monitoring';
 import CartPage from './pages/Cart';
 import CatalogPage from './pages/Catalog';
 import CheckoutPage from './pages/Checkout';
+import ForgotPasswordPage from './pages/ForgotPassword';
 import LoginPage from './pages/Login';
 import NotFoundPage from './pages/NotFound';
 import OrderConfirmationPage from './pages/OrderConfirmation';
@@ -22,6 +23,7 @@ import ProfileAddressesPage from './pages/ProfileAddresses';
 import ProfileOrdersPage from './pages/ProfileOrders';
 import ProfilePointsPage from './pages/ProfilePoints';
 import RegisterPage from './pages/Register';
+import ResetPasswordPage from './pages/ResetPassword';
 import SellerPage from './pages/SellerPage';
 import WishlistPage from './pages/Wishlist';
 import './sentry';
@@ -111,6 +113,8 @@ if (el) {
                                             <Route path="/order/:number" element={<OrderConfirmationPage />} />
                                             <Route path="/wishlist" element={<WishlistPage />} />
                                             <Route path="/login" element={<LoginPage />} />
+                                            <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+                                            <Route path="/reset-password/:token" element={<ResetPasswordPage />} />
                                             <Route path="/register" element={<RegisterPage />} />
                                             <Route path="/profile" element={<ProfilePage />} />
                                             <Route path="/profile/orders" element={<ProfileOrdersPage />} />

--- a/resources/js/shop/pages/ForgotPassword.tsx
+++ b/resources/js/shop/pages/ForgotPassword.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { AuthApi } from '../api';
+import { resolveErrorMessage } from '../lib/errors';
+
+const EMAIL_REGEX = /[^@\s]+@[^@\s]+\.[^@\s]+/;
+
+export default function ForgotPasswordPage() {
+    const [email, setEmail] = React.useState('');
+    const [submitting, setSubmitting] = React.useState(false);
+    const [error, setError] = React.useState<string | null>(null);
+    const [status, setStatus] = React.useState<string | null>(null);
+    const [emailError, setEmailError] = React.useState<string | null>(null);
+
+    const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (submitting) return;
+
+        const trimmedEmail = email.trim();
+
+        if (!trimmedEmail) {
+            setEmailError('Вкажіть email.');
+            return;
+        }
+
+        if (!EMAIL_REGEX.test(trimmedEmail)) {
+            setEmailError('Вкажіть коректну електронну адресу.');
+            return;
+        }
+
+        setEmailError(null);
+        setError(null);
+        setStatus(null);
+        setSubmitting(true);
+
+        try {
+            const response = await AuthApi.requestPasswordReset({ email: trimmedEmail });
+            setStatus(response?.message ?? 'Посилання для відновлення пароля надіслано.');
+        } catch (err) {
+            setError(resolveErrorMessage(err, 'Не вдалося надіслати лист. Спробуйте ще раз.'));
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="mx-auto flex min-h-[calc(100vh-3.5rem)] w-full max-w-6xl flex-col items-center justify-center px-4 py-16">
+            <div className="w-full max-w-md rounded-lg border bg-white p-8 shadow-sm">
+                <h1 className="mb-6 text-2xl font-semibold">Відновлення пароля</h1>
+                <p className="mb-4 text-sm text-gray-600">
+                    Введіть email, і ми надішлемо посилання для відновлення пароля.
+                </p>
+                {status && (
+                    <div className="mb-4 rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">{status}</div>
+                )}
+                {error && (
+                    <div className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>
+                )}
+                <form className="space-y-4" onSubmit={handleSubmit} noValidate>
+                    <div className="space-y-1">
+                        <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                            Email
+                        </label>
+                        <input
+                            id="email"
+                            type="email"
+                            autoComplete="email"
+                            value={email}
+                            onChange={(event) => setEmail(event.target.value)}
+                            className="w-full rounded border px-3 py-2 text-sm focus:border-black focus:outline-none focus:ring-2 focus:ring-black/10"
+                            required
+                        />
+                        {emailError && <p className="text-xs text-red-600">{emailError}</p>}
+                    </div>
+                    <button
+                        type="submit"
+                        disabled={submitting}
+                        className="w-full rounded bg-black px-4 py-2 text-sm font-medium text-white transition hover:bg-black/90 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                        {submitting ? 'Надсилаємо…' : 'Надіслати посилання'}
+                    </button>
+                </form>
+                <p className="mt-6 text-sm text-gray-600">
+                    Пам’ятаєте пароль?{' '}
+                    <Link to="/login" className="font-medium text-blue-600 hover:text-blue-500">
+                        Повернутися до входу
+                    </Link>
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/shop/pages/Login.tsx
+++ b/resources/js/shop/pages/Login.tsx
@@ -104,6 +104,11 @@ export default function LoginPage() {
                             onChange={event => setPassword(event.target.value)}
                             className="w-full rounded border px-3 py-2 text-sm focus:border-black focus:outline-none focus:ring-2 focus:ring-black/10"
                         />
+                        <div className="flex justify-end">
+                            <Link to="/forgot-password" className="text-xs font-medium text-blue-600 hover:text-blue-500">
+                                Забули пароль?
+                            </Link>
+                        </div>
                     </div>
                     {needsOtp && (
                         <div className="space-y-1">

--- a/resources/js/shop/pages/ResetPassword.tsx
+++ b/resources/js/shop/pages/ResetPassword.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { Link, Navigate, useParams } from 'react-router-dom';
+import { AuthApi } from '../api';
+import { resolveErrorMessage } from '../lib/errors';
+
+const EMAIL_REGEX = /[^@\s]+@[^@\s]+\.[^@\s]+/;
+
+export default function ResetPasswordPage() {
+    const params = useParams<{ token: string }>();
+    const token = params.token ?? '';
+    const [email, setEmail] = React.useState('');
+    const [password, setPassword] = React.useState('');
+    const [passwordConfirmation, setPasswordConfirmation] = React.useState('');
+    const [submitting, setSubmitting] = React.useState(false);
+    const [error, setError] = React.useState<string | null>(null);
+    const [status, setStatus] = React.useState<string | null>(null);
+    const [emailError, setEmailError] = React.useState<string | null>(null);
+    const [passwordError, setPasswordError] = React.useState<string | null>(null);
+    const [passwordConfirmationError, setPasswordConfirmationError] = React.useState<string | null>(null);
+
+    if (!token) {
+        return <Navigate to="/forgot-password" replace />;
+    }
+
+    const validate = () => {
+        let valid = true;
+        const trimmedEmail = email.trim();
+        const trimmedPassword = password.trim();
+        const trimmedConfirmation = passwordConfirmation.trim();
+
+        if (!trimmedEmail) {
+            setEmailError('Вкажіть email.');
+            valid = false;
+        } else if (!EMAIL_REGEX.test(trimmedEmail)) {
+            setEmailError('Вкажіть коректну електронну адресу.');
+            valid = false;
+        } else {
+            setEmailError(null);
+        }
+
+        if (!trimmedPassword) {
+            setPasswordError('Вкажіть новий пароль.');
+            valid = false;
+        } else if (trimmedPassword.length < 8) {
+            setPasswordError('Пароль має містити щонайменше 8 символів.');
+            valid = false;
+        } else {
+            setPasswordError(null);
+        }
+
+        if (!trimmedConfirmation) {
+            setPasswordConfirmationError('Підтвердіть новий пароль.');
+            valid = false;
+        } else if (trimmedPassword !== trimmedConfirmation) {
+            setPasswordConfirmationError('Паролі не співпадають.');
+            valid = false;
+        } else {
+            setPasswordConfirmationError(null);
+        }
+
+        return valid;
+    };
+
+    const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (submitting) return;
+
+        if (!validate()) {
+            return;
+        }
+
+        setSubmitting(true);
+        setError(null);
+        setStatus(null);
+
+        try {
+            const trimmedEmail = email.trim();
+            const trimmedPassword = password.trim();
+            const response = await AuthApi.resetPassword({
+                token,
+                email: trimmedEmail,
+                password: trimmedPassword,
+                password_confirmation: passwordConfirmation.trim(),
+            });
+            setStatus(response?.message ?? 'Пароль успішно змінено. Тепер можна увійти.');
+        } catch (err) {
+            setError(resolveErrorMessage(err, 'Не вдалося змінити пароль. Перевірте дані та спробуйте ще раз.'));
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="mx-auto flex min-h-[calc(100vh-3.5rem)] w-full max-w-6xl flex-col items-center justify-center px-4 py-16">
+            <div className="w-full max-w-md rounded-lg border bg-white p-8 shadow-sm">
+                <h1 className="mb-6 text-2xl font-semibold">Скидання пароля</h1>
+                <p className="mb-4 text-sm text-gray-600">Введіть дані, щоб встановити новий пароль до акаунта.</p>
+                {status && (
+                    <div className="mb-4 rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">{status}</div>
+                )}
+                {error && (
+                    <div className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>
+                )}
+                <form className="space-y-4" onSubmit={handleSubmit} noValidate>
+                    <div className="space-y-1">
+                        <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                            Email
+                        </label>
+                        <input
+                            id="email"
+                            type="email"
+                            autoComplete="email"
+                            value={email}
+                            onChange={(event) => setEmail(event.target.value)}
+                            className="w-full rounded border px-3 py-2 text-sm focus:border-black focus:outline-none focus:ring-2 focus:ring-black/10"
+                            required
+                        />
+                        {emailError && <p className="text-xs text-red-600">{emailError}</p>}
+                    </div>
+                    <div className="space-y-1">
+                        <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                            Новий пароль
+                        </label>
+                        <input
+                            id="password"
+                            type="password"
+                            autoComplete="new-password"
+                            value={password}
+                            onChange={(event) => setPassword(event.target.value)}
+                            className="w-full rounded border px-3 py-2 text-sm focus:border-black focus:outline-none focus:ring-2 focus:ring-black/10"
+                            required
+                        />
+                        {passwordError && <p className="text-xs text-red-600">{passwordError}</p>}
+                    </div>
+                    <div className="space-y-1">
+                        <label htmlFor="password_confirmation" className="block text-sm font-medium text-gray-700">
+                            Підтвердження пароля
+                        </label>
+                        <input
+                            id="password_confirmation"
+                            type="password"
+                            autoComplete="new-password"
+                            value={passwordConfirmation}
+                            onChange={(event) => setPasswordConfirmation(event.target.value)}
+                            className="w-full rounded border px-3 py-2 text-sm focus:border-black focus:outline-none focus:ring-2 focus:ring-black/10"
+                            required
+                        />
+                        {passwordConfirmationError && <p className="text-xs text-red-600">{passwordConfirmationError}</p>}
+                    </div>
+                    <button
+                        type="submit"
+                        disabled={submitting}
+                        className="w-full rounded bg-black px-4 py-2 text-sm font-medium text-white transition hover:bg-black/90 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                        {submitting ? 'Зберігаємо…' : 'Змінити пароль'}
+                    </button>
+                </form>
+                <p className="mt-6 text-sm text-gray-600">
+                    Повернутися до{' '}
+                    <Link to="/login" className="font-medium text-blue-600 hover:text-blue-500">
+                        сторінки входу
+                    </Link>
+                    .
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/shop/pages/__tests__/ForgotPassword.test.tsx
+++ b/resources/js/shop/pages/__tests__/ForgotPassword.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ForgotPasswordPage from '../ForgotPassword';
+
+describe('ForgotPasswordPage', () => {
+    it('renders the forgot password form', () => {
+        render(
+            <MemoryRouter>
+                <ForgotPasswordPage />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByRole('heading', { name: /відновлення пароля/i })).toBeInTheDocument();
+        expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /надіслати посилання/i })).toBeInTheDocument();
+    });
+});

--- a/resources/js/shop/pages/__tests__/ResetPassword.test.tsx
+++ b/resources/js/shop/pages/__tests__/ResetPassword.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import ResetPasswordPage from '../ResetPassword';
+
+describe('ResetPasswordPage', () => {
+    it('renders the reset password form', () => {
+        render(
+            <MemoryRouter initialEntries={["/reset-password/test-token"]}>
+                <Routes>
+                    <Route path="/reset-password/:token" element={<ResetPasswordPage />} />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByRole('heading', { name: /скидання пароля/i })).toBeInTheDocument();
+        expect(screen.getByLabelText(/новий пароль/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /змінити пароль/i })).toBeInTheDocument();
+    });
+});

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,6 +27,11 @@ Route::prefix('auth')->group(function () {
     });
 });
 
+Route::middleware('guest:sanctum')->group(function () {
+    Route::post('password/email', [AuthController::class, 'requestPasswordReset']);
+    Route::post('password/reset', [AuthController::class, 'resetPassword']);
+});
+
 Route::middleware('auth:sanctum')->post('email/resend', [AuthController::class, 'resendEmailVerification']);
 
 Route::get('email/verify/{id}/{hash}', VerifyEmailController::class)

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Password;
+
+beforeEach(function () {
+    config(['auth.guards.sanctum' => [
+        'driver' => 'session',
+        'provider' => 'users',
+    ]]);
+});
+
+it('sends a password reset link to an existing user', function () {
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    $response = $this->postJson('/api/password/email', [
+        'email' => $user->email,
+    ]);
+
+    $response->assertOk()->assertJson([
+        'message' => trans(Password::RESET_LINK_SENT),
+    ]);
+
+    Notification::assertSentTo($user, ResetPassword::class);
+});
+
+it('returns validation error when email is not found', function () {
+    Notification::fake();
+
+    $response = $this->postJson('/api/password/email', [
+        'email' => 'missing@example.com',
+    ]);
+
+    $response->assertStatus(422)->assertJsonValidationErrors(['email']);
+
+    Notification::assertNothingSent();
+});
+
+it('resets the password with a valid token', function () {
+    Notification::fake();
+
+    $user = User::factory()->create([
+        'password' => Hash::make('initial-password'),
+    ]);
+
+    $token = Password::broker()->createToken($user);
+
+    $response = $this->postJson('/api/password/reset', [
+        'token' => $token,
+        'email' => $user->email,
+        'password' => 'new-secure-password',
+        'password_confirmation' => 'new-secure-password',
+    ]);
+
+    $response->assertOk()->assertJson([
+        'message' => trans(Password::PASSWORD_RESET),
+    ]);
+
+    expect(Hash::check('new-secure-password', $user->fresh()->password))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- add Laravel password reset request and confirmation endpoints with JSON responses
- expose guest Sanctum routes for password reset flow
- implement forgot/reset password React pages with API helpers and tests

## Testing
- php artisan test --testsuite=Feature
- CI=1 npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cb9add7ad883319efb57498b352cdf