### PR TITLE
Handle out of stock products in catalog

### DIFF
--- a/resources/js/shop/pages/Catalog.test.tsx
+++ b/resources/js/shop/pages/Catalog.test.tsx
@@ -100,6 +100,7 @@ describe('Catalog page', () => {
             slug: 'test-product',
             price: 1999,
             images: [],
+            stock: 5,
         };
 
         fetchCategoriesMock.mockResolvedValue([]);
@@ -150,6 +151,7 @@ describe('Catalog page', () => {
             slug: 'another-product',
             price: 2599,
             images: [],
+            stock: 4,
         };
 
         fetchCategoriesMock.mockResolvedValueOnce([
@@ -190,5 +192,42 @@ describe('Catalog page', () => {
         expect(colorButtons).toHaveLength(1);
         expect(colorButtons[0]).toHaveTextContent('Black');
         expect(colorButtons[0]).toHaveTextContent('(7)');
+    });
+
+    it('disables buying for products with zero stock', async () => {
+        const user = userEvent.setup();
+        fetchProductsMock.mockResolvedValueOnce({
+            data: [
+                {
+                    id: 303,
+                    name: 'Товар без залишків',
+                    slug: 'out-of-stock-product',
+                    price: 1499,
+                    images: [],
+                    stock: 0,
+                },
+            ],
+            current_page: 1,
+            last_page: 1,
+            per_page: 12,
+            total: 1,
+            from: 1,
+            to: 1,
+            facets: {},
+        });
+
+        render(
+            <MemoryRouter>
+                <Catalog />
+            </MemoryRouter>
+        );
+
+        const outOfStockButton = await screen.findByRole('button', { name: 'Немає в наявності' });
+        expect(outOfStockButton).toBeDisabled();
+
+        await user.click(outOfStockButton);
+        expect(cartApiMock.add).not.toHaveBeenCalled();
+
+        expect(screen.getAllByText('Немає в наявності')[0]).toBeInTheDocument();
     });
 });

--- a/resources/js/shop/pages/Catalog.tsx
+++ b/resources/js/shop/pages/Catalog.tsx
@@ -540,6 +540,7 @@ export default function Catalog() {
                         const primary =
                             p.images?.find((img) => img.is_primary) ??
                             (p.images && p.images.length > 0 ? p.images[0] : undefined);
+                        const inStock = Number(p.stock ?? 0) > 0;
 
                         return (
                             <Card key={p.id} className="flex h-full flex-col overflow-hidden">
@@ -565,6 +566,9 @@ export default function Catalog() {
                                     <div className="p-3">
                                         <div className="line-clamp-2 text-sm font-medium">{p.name}</div>
                                         <div className="mt-1 text-sm text-muted-foreground">{formatPrice(p.price)}</div>
+                                        {!inStock && (
+                                            <div className="mt-1 text-xs text-red-600">Немає в наявності</div>
+                                        )}
                                     </div>
                                 </Link>
                                 <div className="flex flex-wrap items-center gap-2 border-t px-3 py-3">
@@ -572,8 +576,9 @@ export default function Catalog() {
                                     <Button
                                         type="button"
                                         className="flex-1"
-                                        disabled={addingId === p.id}
+                                        disabled={!inStock || addingId === p.id}
                                         onClick={async () => {
+                                            if (!inStock) return;
                                             setAddingId(p.id);
                                             try {
                                                 await add(p.id);
@@ -582,13 +587,19 @@ export default function Catalog() {
                                             }
                                         }}
                                     >
-                                        {addingId === p.id ? (
-                                            <>
-                                                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-                                                <span>Купуємо…</span>
-                                            </>
+                                        {inStock ? (
+                                            addingId === p.id ? (
+                                                <>
+                                                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                                                    <span>Купуємо…</span>
+                                                </>
+                                            ) : (
+                                                'Купити'
+                                            )
                                         ) : (
-                                            'Купити'
+                                            <>
+                                                <span>Немає в наявності</span>
+                                            </>
                                         )}
                                     </Button>
                                 </div>


### PR DESCRIPTION
## Summary
- prevent catalog cards with zero stock from calling add-to-cart and show an out-of-stock label
- adjust the buy button to reflect loading or availability states based on stock
- extend catalog page tests to cover out-of-stock products and include stock data in fixtures

## Testing
- npm run test -- Catalog

------
https://chatgpt.com/codex/tasks/task_e_68cbb89a28e88331bcce76f1b3435d18