### PR TITLE
Add removal control to wishlist items

### DIFF
--- a/resources/js/shop/hooks/useWishlist.tsx
+++ b/resources/js/shop/hooks/useWishlist.tsx
@@ -8,7 +8,7 @@ type Ctx = {
     items: WishItem[];
     has: (id: number) => boolean;
     add: (p: WishItem) => void;
-    remove: (id: number) => void;
+    remove: (id: number, options?: { sync?: boolean }) => void;
     toggle: (p: WishItem) => void;
     clear: () => void;
     isLoading: boolean;
@@ -187,9 +187,11 @@ export function WishlistProvider({children}: {children: React.ReactNode}) {
         syncAdd(p.id, p);
     }, [setList, syncAdd]);
 
-    const remove = React.useCallback((id: number) => {
+    const remove = React.useCallback((id: number, options?: { sync?: boolean }) => {
         setList(prev => prev.filter(x => x.id !== id));
-        syncRemove(id);
+        if (options?.sync ?? true) {
+            syncRemove(id);
+        }
     }, [setList, syncRemove]);
 
     const toggle = React.useCallback((p: WishItem) => {

--- a/resources/js/shop/pages/Wishlist.tsx
+++ b/resources/js/shop/pages/Wishlist.tsx
@@ -6,10 +6,31 @@ import {Button} from '@/components/ui/button';
 import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert';
 import {Skeleton} from '@/components/ui/skeleton';
 import {formatPrice} from '../ui/format';
+import {WishlistApi} from '../api';
+import {Loader2, X} from 'lucide-react';
 
 export default function WishlistPage() {
-    const {items, clear, isLoading, error} = useWishlist();
+    const {items, clear, isLoading, error, remove} = useWishlist();
+    const [removingIds, setRemovingIds] = React.useState<Record<number, boolean>>({});
     const hasItems = items.length > 0;
+
+    const handleRemove = React.useCallback(
+        async (productId: number) => {
+            setRemovingIds(prev => ({...prev, [productId]: true}));
+            try {
+                await WishlistApi.remove(productId);
+                remove(productId, {sync: false});
+            } catch (err) {
+                console.error('Wishlist remove error', err);
+            } finally {
+                setRemovingIds(prev => {
+                    const {[productId]: _removed, ...rest} = prev;
+                    return rest;
+                });
+            }
+        },
+        [remove],
+    );
 
     return (
         <div className="mx-auto w-full max-w-7xl px-4 py-6" data-testid="wishlist-page">
@@ -51,25 +72,49 @@ export default function WishlistPage() {
                 </div>
             ) : hasItems ? (
                 <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
-                    {items.map(p => (
-                        <Card key={`${p.id}-${p.slug ?? ''}`} className="overflow-hidden" data-testid="wishlist-card">
-                            <Link to={`/product/${p.slug ?? p.id}`} className="block">
-                                <div className="aspect-square bg-muted/40">
-                                    {p.preview_url ? (
-                                        <img src={p.preview_url} alt={p.name} className="h-full w-full object-cover" />
+                    {items.map(p => {
+                        const isRemoving = removingIds[p.id] ?? false;
+                        return (
+                            <Card
+                                key={`${p.id}-${p.slug ?? ''}`}
+                                className="relative overflow-hidden"
+                                data-testid="wishlist-card"
+                                aria-busy={isRemoving}
+                            >
+                                <Button
+                                    type="button"
+                                    size="icon"
+                                    variant="ghost"
+                                    className="absolute right-2 top-2 z-10"
+                                    disabled={isRemoving || isLoading}
+                                    onClick={() => void handleRemove(p.id)}
+                                    aria-label={`Прибрати «${p.name}» зі списку бажаного`}
+                                    data-testid="wishlist-remove-button"
+                                >
+                                    {isRemoving ? (
+                                        <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                                    ) : (
+                                        <X className="h-4 w-4" aria-hidden="true" />
+                                    )}
+                                </Button>
+                                <Link to={`/product/${p.slug ?? p.id}`} className="block">
+                                    <div className="aspect-square bg-muted/40">
+                                        {p.preview_url ? (
+                                            <img src={p.preview_url} alt={p.name} className="h-full w-full object-cover" />
                                     ) : (
                                         <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
                                             без фото
                                         </div>
                                     )}
                                 </div>
-                                <div className="p-3">
-                                    <div className="line-clamp-2 text-sm font-medium">{p.name}</div>
-                                    <div className="mt-1 text-sm text-muted-foreground">{formatPrice(p.price)}</div>
-                                </div>
-                            </Link>
-                        </Card>
-                    ))}
+                                    <div className="p-3">
+                                        <div className="line-clamp-2 text-sm font-medium">{p.name}</div>
+                                        <div className="mt-1 text-sm text-muted-foreground">{formatPrice(p.price)}</div>
+                                    </div>
+                                </Link>
+                            </Card>
+                        );
+                    })}
                 </div>
             ) : (
                 <div className="text-muted-foreground" data-testid="wishlist-empty">

--- a/resources/js/shop/pages/__tests__/Wishlist.test.tsx
+++ b/resources/js/shop/pages/__tests__/Wishlist.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {MemoryRouter} from 'react-router-dom';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import WishlistPage from '../Wishlist';
+import {WishlistApi} from '../../api';
+
+const mockUseWishlist = vi.fn();
+
+vi.mock('../../hooks/useWishlist', () => ({
+    default: () => mockUseWishlist(),
+}));
+
+describe('WishlistPage remove button', () => {
+    let removeSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        removeSpy = vi.fn();
+
+        mockUseWishlist.mockImplementation(() => {
+            const [items, setItems] = React.useState([
+                {
+                    id: 1,
+                    name: 'Тестовий товар',
+                    slug: 'test-product',
+                    price: 129900,
+                    preview_url: null,
+                },
+            ]);
+
+            const remove = (id: number, options?: {sync?: boolean}) => {
+                removeSpy(id, options);
+                setItems(prev => prev.filter(item => item.id !== id));
+            };
+
+            return {
+                items,
+                remove,
+                clear: vi.fn(),
+                has: vi.fn(),
+                add: vi.fn(),
+                toggle: vi.fn(),
+                isLoading: false,
+                error: null,
+            };
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        mockUseWishlist.mockReset();
+    });
+
+    it('removes item after clicking the remove button', async () => {
+        const user = userEvent.setup();
+        const apiRemoveSpy = vi.spyOn(WishlistApi, 'remove').mockResolvedValue(undefined as never);
+
+        render(
+            <MemoryRouter initialEntries={['/wishlist']}>
+                <WishlistPage />
+            </MemoryRouter>,
+        );
+
+        const removeButton = await screen.findByRole('button', {
+            name: 'Прибрати «Тестовий товар» зі списку бажаного',
+        });
+
+        await user.click(removeButton);
+
+        await waitFor(() => {
+            expect(apiRemoveSpy).toHaveBeenCalledWith(1);
+        });
+
+        await waitFor(() => {
+            expect(screen.queryByText('Тестовий товар')).not.toBeInTheDocument();
+        });
+
+        expect(removeSpy).toHaveBeenCalledWith(1, {sync: false});
+    });
+});


### PR DESCRIPTION
## Summary
- add an accessible per-item remove control to wishlist cards that calls the API and surfaces a loading state
- allow `useWishlist.remove` to skip remote sync when the caller already performs the API request
- cover the removal flow with a React Testing Library test to ensure items disappear after clicking the button

## Testing
- npm run test -- Wishlist

------
https://chatgpt.com/codex/tasks/task_e_68cbbf3604d08331883e6b26feccfcf0