### PR TITLE
Ensure cart recreates when status ordered

### DIFF
--- a/resources/js/shop/api.test.ts
+++ b/resources/js/shop/api.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+    const getMock = vi.fn();
+    const postMock = vi.fn();
+    const patchMock = vi.fn();
+    const deleteMock = vi.fn();
+
+    return { getMock, postMock, patchMock, deleteMock };
+});
+
+vi.mock('axios', () => {
+    const createMock = vi.fn(() => ({
+        get: mocks.getMock,
+        post: mocks.postMock,
+        patch: mocks.patchMock,
+        delete: mocks.deleteMock,
+    }));
+
+    return {
+        __esModule: true,
+        default: {
+            create: createMock,
+        },
+    };
+});
+
+import { CartApi, resetCartCache } from './api';
+
+describe('CartApi', () => {
+    const { getMock, postMock, patchMock, deleteMock } = mocks;
+
+    beforeEach(() => {
+        getMock.mockReset();
+        postMock.mockReset();
+        patchMock.mockReset();
+        deleteMock.mockReset();
+        resetCartCache();
+    });
+
+    it('creates a new cart when the current cart is already ordered before adding items', async () => {
+        getMock
+            .mockImplementationOnce(async (url: string) => {
+                expect(url).toBe('/cart');
+                return {
+                    data: { id: 'existing-cart', status: 'active', items: [], total: 0 },
+                };
+            })
+            .mockImplementationOnce(async (url: string) => {
+                expect(url).toBe('/cart/existing-cart');
+                return {
+                    data: { id: 'existing-cart', status: 'ordered', items: [], total: 0 },
+                };
+            })
+            .mockImplementationOnce(async (url: string) => {
+                expect(url).toBe('/cart');
+                return {
+                    data: { id: 'new-cart', status: 'active', items: [], total: 0 },
+                };
+            });
+
+        postMock.mockImplementationOnce(async (url: string, body: unknown) => {
+            expect(url).toBe('/cart/new-cart/items');
+            expect(body).toEqual({ product_id: 42, qty: 1 });
+            return {
+                data: { id: 'new-cart', status: 'active', items: [], total: 0 },
+            };
+        });
+
+        const initialCart = await CartApi.get();
+        expect(initialCart.id).toBe('existing-cart');
+
+        const updatedCart = await CartApi.add(42, 1);
+        expect(updatedCart.id).toBe('new-cart');
+
+        expect(getMock).toHaveBeenCalledTimes(3);
+        expect(postMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/resources/js/shop/api.tsx
+++ b/resources/js/shop/api.tsx
@@ -501,7 +501,18 @@ async function showCart(id: string): Promise<Cart> {
     return data;
 }
 async function requireCartId(): Promise<string> {
-    if (activeCartId) return activeCartId;
+    if (activeCartId) {
+        try {
+            const existingCart = await showCart(activeCartId);
+            if (String(existingCart?.status ?? '') === 'active') {
+                return existingCart.id;
+            }
+        } catch (error) {
+            // Якщо відбулася помилка — створюємо новий кошик
+        }
+        resetCartCache();
+    }
+
     const { data } = await api.get<Cart>('/cart'); // створить активний кошик і поверне id
     setActiveCartId(data.id);
     return data.id;


### PR DESCRIPTION
## Summary
- verify an existing cart before reuse and recreate it when it is no longer active
- add a Vitest spec ensuring addToCart requests a fresh cart after an ordered response

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cbc0a9bc908331a536b71725590c0d