### PR TITLE
Reset demo catalog seeder before populating

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,6 +82,12 @@ VITE_GA_ID=G-XXXXXXXXXX
 VITE_COOKIE_DEFAULT=granted|denied
 ```
 
+2.4 DemoCatalogSeeder (демо-каталог)
+
+- `php artisan db:seed --class=DemoCatalogSeeder`
+- Сидер перед створенням даних очищає таблиці `categories`, `vendors`, `products`, `product_images` без тригерів подій, а також скидає Meilisearch-індекс продуктів, тому його можна запускати повторно без дублювання.
+- Після повторного запуску API `/api/products?with_facets=1` і фронтовий список категорій показують назви категорій, а не резервний формат `#ID`.
+
 3) База даних та доменна модель
 
 3.1 Основні таблиці (скорочено)

--- a/database/seeders/DemoCatalogSeeder.php
+++ b/database/seeders/DemoCatalogSeeder.php
@@ -4,10 +4,11 @@ namespace Database\Seeders;
 
 use App\Models\Category;
 use App\Models\Product;
+use App\Models\ProductImage;
 use App\Models\Vendor;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 class DemoCatalogSeeder extends Seeder
@@ -17,6 +18,17 @@ class DemoCatalogSeeder extends Seeder
 
     public function run(): void
     {
+        Schema::disableForeignKeyConstraints();
+
+        ProductImage::withoutEvents(fn () => ProductImage::truncate());
+        Product::withoutEvents(fn () => Product::truncate());
+        Vendor::withoutEvents(fn () => Vendor::truncate());
+        Category::withoutEvents(fn () => Category::truncate());
+
+        Schema::enableForeignKeyConstraints();
+
+        Product::query()->unsearchable();
+
         // 5 категорій
         $cats = Category::factory()->count(5)->create();
 
@@ -51,6 +63,8 @@ class DemoCatalogSeeder extends Seeder
                 ]);
             }
         });
+
+        Product::query()->searchable();
     }
 
 //    /**


### PR DESCRIPTION
## Summary
- clear demo catalog tables with events disabled before creating new demo data
- reset the product search index before and after seeding to refresh Meilisearch
- document that DemoCatalogSeeder can be rerun without duplicates and facets show proper names

## Testing
- php artisan db:seed --class=DemoCatalogSeeder


------
https://chatgpt.com/codex/tasks/task_e_68cbc68f931c8331b3e08d695e041cad