### PR TITLE
Log user in after password reset

### DIFF
--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -7,6 +7,7 @@ use App\Models\User;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
@@ -53,6 +54,8 @@ class NewPasswordController extends Controller
                 ])->save();
 
                 event(new PasswordReset($user));
+
+                Auth::login($user);
             }
         );
 
@@ -60,7 +63,7 @@ class NewPasswordController extends Controller
         // the application's home authenticated view. If there is an error we can
         // redirect them back to where they came from with their error message.
         if ($status == Password::PasswordReset) {
-            return to_route('login')->with('status', __($status));
+            return redirect()->intended('/profile')->with('status', __($status));
         }
 
         throw ValidationException::withMessages([


### PR DESCRIPTION
## Summary
- log the user in when their password is reset through the web controller and send them to the profile SPA route
- extend the password reset feature tests to cover the web form flow and ensure authentication & redirect behavior

## Testing
- ./vendor/bin/pest tests/Feature/Auth/PasswordResetTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cbd93ed3608331b27dc652bc476614