### PR TITLE
Add Russian and Portuguese locale support

### DIFF
--- a/resources/js/shop/components/LanguageSwitcher.test.tsx
+++ b/resources/js/shop/components/LanguageSwitcher.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import LanguageSwitcher from './LanguageSwitcher';
+import LocaleProvider from '../i18n/LocaleProvider';
+import { SUPPORTED_LANGS, type Lang } from '../i18n/config';
+
+function stubLocation(url: string) {
+    const parsed = new URL(url);
+    const assign = vi.fn();
+    const locationMock = {
+        ancestorOrigins: {
+            length: 0,
+            item: () => null,
+            contains: () => false,
+        },
+        href: parsed.href,
+        origin: parsed.origin,
+        protocol: parsed.protocol,
+        host: parsed.host,
+        hostname: parsed.hostname,
+        port: parsed.port,
+        pathname: parsed.pathname,
+        search: parsed.search,
+        hash: parsed.hash,
+        assign,
+        reload: vi.fn(),
+        replace: vi.fn(),
+        toString: () => parsed.href,
+    } as unknown as Location;
+
+    vi.stubGlobal('location', locationMock);
+
+    return assign;
+}
+
+function renderSwitcher(initial: Lang) {
+    return render(
+        <LocaleProvider initial={initial}>
+            <LanguageSwitcher />
+        </LocaleProvider>
+    );
+}
+
+describe('LanguageSwitcher', () => {
+    beforeEach(() => {
+        stubLocation('http://localhost/uk/catalog');
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('renders language buttons in the configured order', () => {
+        renderSwitcher('uk');
+
+        const buttons = screen.getAllByRole('button');
+        const labels = buttons.map((button) => button.textContent);
+
+        expect(labels).toEqual(SUPPORTED_LANGS.map((lang) => lang.toUpperCase()));
+    });
+
+    it('replaces the language prefix in the current path', async () => {
+        const assignMock = stubLocation('http://localhost/en/catalog?foo=1#hash');
+        const user = userEvent.setup();
+
+        renderSwitcher('en');
+
+        await user.click(screen.getByRole('button', { name: 'RU' }));
+
+        expect(assignMock).toHaveBeenCalledWith('/ru/catalog?foo=1#hash');
+    });
+
+    it('inserts the language prefix when it is missing', async () => {
+        const assignMock = stubLocation('http://localhost/catalog');
+        const user = userEvent.setup();
+
+        renderSwitcher('uk');
+
+        await user.click(screen.getByRole('button', { name: 'PT' }));
+
+        expect(assignMock).toHaveBeenCalledWith('/pt/catalog');
+    });
+});
+

--- a/resources/js/shop/i18n/LocaleProvider.test.tsx
+++ b/resources/js/shop/i18n/LocaleProvider.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import LocaleProvider, { useLocale } from './LocaleProvider';
+import { SUPPORTED_LANGS } from './config';
+import { localeMessages } from './messages';
+
+function MessagesProbe() {
+    const { messages } = useLocale();
+    return <span>{messages.languageName}</span>;
+}
+
+describe('LocaleProvider', () => {
+    SUPPORTED_LANGS.forEach((lang) => {
+        it(`exposes translations for ${lang}`, () => {
+            render(
+                <LocaleProvider initial={lang}>
+                    <MessagesProbe />
+                </LocaleProvider>
+            );
+
+            expect(screen.getByText(localeMessages[lang].languageName)).toBeInTheDocument();
+        });
+    });
+});
+

--- a/resources/js/shop/i18n/LocaleProvider.tsx
+++ b/resources/js/shop/i18n/LocaleProvider.tsx
@@ -1,8 +1,13 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { DEFAULT_LANG, Lang, normalizeLang } from './config';
+import { getMessages, type Messages } from './messages';
 
-type Ctx = { lang: Lang; setLang: (l: Lang)=>void; };
-const LocaleCtx = createContext<Ctx>({ lang: DEFAULT_LANG, setLang: () => {} });
+type Ctx = { lang: Lang; setLang: (l: Lang) => void; messages: Messages };
+const LocaleCtx = createContext<Ctx>({
+    lang: DEFAULT_LANG,
+    setLang: () => {},
+    messages: getMessages(DEFAULT_LANG),
+});
 
 export function useLocale() { return useContext(LocaleCtx); }
 
@@ -16,11 +21,11 @@ export default function LocaleProvider({ initial, children }: { initial?: string
         }
         // cookie "lang" на рік
         try {
-            const exp = new Date(Date.now()+365*24*3600*1000).toUTCString();
+            const exp = new Date(Date.now() + 365 * 24 * 3600 * 1000).toUTCString();
             document.cookie = `lang=${lang}; path=/; expires=${exp}; SameSite=Lax`;
         } catch {}
     }, [lang]);
 
-    const value = useMemo(() => ({ lang, setLang }), [lang]);
+    const value = useMemo(() => ({ lang, setLang, messages: getMessages(lang) }), [lang]);
     return <LocaleCtx.Provider value={value}>{children}</LocaleCtx.Provider>;
 }

--- a/resources/js/shop/i18n/config.tsx
+++ b/resources/js/shop/i18n/config.tsx
@@ -1,4 +1,4 @@
-export const SUPPORTED_LANGS = ['uk','en'] as const;
+export const SUPPORTED_LANGS = ['uk', 'en', 'ru', 'pt'] as const;
 export type Lang = typeof SUPPORTED_LANGS[number];
 export const DEFAULT_LANG: Lang = 'uk';
 

--- a/resources/js/shop/i18n/messages/en.ts
+++ b/resources/js/shop/i18n/messages/en.ts
@@ -1,0 +1,6 @@
+const messages = {
+    languageName: 'English',
+} as const;
+
+export default messages;
+

--- a/resources/js/shop/i18n/messages/index.ts
+++ b/resources/js/shop/i18n/messages/index.ts
@@ -1,0 +1,20 @@
+import type { Lang } from '../config';
+
+import en from './en';
+import pt from './pt';
+import ru from './ru';
+import uk from './uk';
+
+export type Messages = typeof uk;
+
+export const localeMessages = {
+    uk,
+    en,
+    ru,
+    pt,
+} satisfies Record<Lang, Messages>;
+
+export function getMessages(lang: Lang): Messages {
+    return localeMessages[lang];
+}
+

--- a/resources/js/shop/i18n/messages/pt.ts
+++ b/resources/js/shop/i18n/messages/pt.ts
@@ -1,0 +1,6 @@
+const messages = {
+    languageName: 'Português',
+} as const;
+
+export default messages;
+

--- a/resources/js/shop/i18n/messages/ru.ts
+++ b/resources/js/shop/i18n/messages/ru.ts
@@ -1,0 +1,6 @@
+const messages = {
+    languageName: 'Русский',
+} as const;
+
+export default messages;
+

--- a/resources/js/shop/i18n/messages/uk.ts
+++ b/resources/js/shop/i18n/messages/uk.ts
@@ -1,0 +1,6 @@
+const messages = {
+    languageName: 'Українська',
+} as const;
+
+export default messages;
+


### PR DESCRIPTION
## Summary
- extend the language configuration to include Russian and Portuguese and expose locale dictionaries via the provider
- register message bundles for each locale and hook them into the LocaleProvider
- add unit tests covering the language switcher behaviour and message availability for all locales

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cbe01e76608331aa508eb2b240173b