### PR TITLE
Adjust language paths for default locale

### DIFF
--- a/resources/js/shop/components/LanguageSwitcher.test.tsx
+++ b/resources/js/shop/components/LanguageSwitcher.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import LanguageSwitcher from './LanguageSwitcher';
+import LanguageSwitcher, { swapLangInPath } from './LanguageSwitcher';
 import LocaleProvider from '../i18n/LocaleProvider';
 import { SUPPORTED_LANGS, type Lang } from '../i18n/config';
 
@@ -83,6 +83,29 @@ describe('LanguageSwitcher', () => {
         await user.click(screen.getByRole('button', { name: 'PT' }));
 
         expect(assignMock).toHaveBeenCalledWith('/pt/catalog');
+    });
+});
+
+describe('swapLangInPath', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('removes the language segment when switching to Ukrainian', () => {
+        stubLocation('http://localhost/en/catalog');
+
+        expect(swapLangInPath('uk')).toBe('/catalog');
+    });
+
+    it('adds or replaces the language segment for non-default languages', () => {
+        stubLocation('http://localhost/catalog');
+
+        expect(swapLangInPath('ru')).toBe('/ru/catalog');
+
+        stubLocation('http://localhost/pt/catalog');
+
+        expect(swapLangInPath('en')).toBe('/en/catalog');
     });
 });
 

--- a/resources/js/shop/components/LanguageSwitcher.tsx
+++ b/resources/js/shop/components/LanguageSwitcher.tsx
@@ -1,12 +1,19 @@
 import { useLocale } from '../i18n/LocaleProvider';
-import { SUPPORTED_LANGS, Lang } from '../i18n/config';
+import { SUPPORTED_LANGS, Lang, DEFAULT_LANG } from '../i18n/config';
 
-function swapLangInPath(next: Lang) {
+export function swapLangInPath(next: Lang) {
     const u = new URL(window.location.href);
     const parts = u.pathname.split('/').filter(Boolean);
-    // якщо перший сегмент — мова, замінити; інакше вставити
-    if (SUPPORTED_LANGS.includes(parts[0] as any)) parts[0] = next;
-    else parts.unshift(next);
+    const hasLang = SUPPORTED_LANGS.includes(parts[0] as any);
+
+    if (next === DEFAULT_LANG) {
+        if (hasLang) parts.shift();
+    } else if (hasLang) {
+        parts[0] = next;
+    } else {
+        parts.unshift(next);
+    }
+
     u.pathname = '/' + parts.join('/');
     return u.pathname + u.search + u.hash;
 }


### PR DESCRIPTION
## Summary
- update `swapLangInPath` so switching to the default language removes the locale prefix while other languages keep it
- export the helper and add tests covering default and non-default language path handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc465022248331a3fa9a66e9329b57