### PR TITLE
Localize order chat component

### DIFF
--- a/resources/js/shop/components/__tests__/OrderChat.test.tsx
+++ b/resources/js/shop/components/__tests__/OrderChat.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import OrderChat from '../OrderChat';
+import LocaleProvider, { useLocale } from '../../i18n/LocaleProvider';
+
+const { authState, useAuthMock, listMessagesMock, sendMessageMock } = vi.hoisted(() => {
+    const authState = {
+        isAuthenticated: true,
+        isReady: true,
+        user: { id: 1, name: 'Customer' },
+    };
+
+    return {
+        authState,
+        useAuthMock: vi.fn(() => authState),
+        listMessagesMock: vi.fn(),
+        sendMessageMock: vi.fn(),
+    };
+});
+
+vi.mock('../../hooks/useAuth', () => ({
+    default: useAuthMock,
+}));
+
+vi.mock('../../api', () => ({
+    OrdersApi: {
+        listMessages: listMessagesMock,
+        sendMessage: sendMessageMock,
+    },
+}));
+
+function Testbed(props: React.ComponentProps<typeof OrderChat>) {
+    const { setLang } = useLocale();
+    return (
+        <>
+            <button type="button" data-testid="switch-lang" onClick={() => setLang('en')}>
+                Switch language
+            </button>
+            <OrderChat {...props} />
+        </>
+    );
+}
+
+describe('OrderChat', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        Object.assign(authState, {
+            isAuthenticated: true,
+            isReady: true,
+            user: { id: 1, name: 'Customer' },
+        });
+        listMessagesMock.mockResolvedValue([
+            {
+                id: 1,
+                order_id: 42,
+                user_id: 1,
+                body: 'Привіт',
+                created_at: '2024-01-01T00:00:00Z',
+                user: { id: 1, name: 'Customer' },
+                is_author: true,
+            },
+            {
+                id: 2,
+                order_id: 42,
+                user_id: 2,
+                body: 'Доброго дня',
+                created_at: '2024-01-01T00:01:00Z',
+                user: null,
+                is_author: false,
+            },
+        ]);
+        sendMessageMock.mockResolvedValue({
+            id: 3,
+            order_id: 42,
+            user_id: 1,
+            body: 'Test',
+            created_at: '2024-01-01T00:02:00Z',
+            user: { id: 1, name: 'Customer' },
+            is_author: true,
+        });
+    });
+
+    it('updates visible texts when the locale changes', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <MemoryRouter>
+                <LocaleProvider initial="uk">
+                    <Testbed orderId={42} orderNumber="A-001" />
+                </LocaleProvider>
+            </MemoryRouter>,
+        );
+
+        expect(await screen.findByRole('heading', { name: 'Чат з продавцем' })).toBeInTheDocument();
+        expect(screen.getByText('Замовлення A-001')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Оновити' })).toBeInTheDocument();
+        expect(screen.getByPlaceholderText('Ваше повідомлення продавцю…')).toBeInTheDocument();
+        expect(screen.getByText('До 2000 символів')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Надіслати' })).toBeInTheDocument();
+        expect(await screen.findByText('Ви')).toBeInTheDocument();
+        expect(screen.getByText('Продавець')).toBeInTheDocument();
+
+        await user.click(screen.getByTestId('switch-lang'));
+
+        expect(await screen.findByRole('heading', { name: 'Chat with the seller' })).toBeInTheDocument();
+        expect(screen.getByText('Order A-001')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
+        expect(await screen.findByPlaceholderText('Your message to the seller…')).toBeInTheDocument();
+        expect(screen.getByText('Up to 2000 characters')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Send' })).toBeInTheDocument();
+        expect(await screen.findByText('You')).toBeInTheDocument();
+        expect(screen.getByText('Seller')).toBeInTheDocument();
+    });
+});

--- a/resources/js/shop/i18n/messages/en.ts
+++ b/resources/js/shop/i18n/messages/en.ts
@@ -61,6 +61,34 @@ const messages = {
         },
         empty: 'Your cart is empty',
     },
+    orderChat: {
+        title: 'Chat with the seller',
+        orderLabel: ({ number }: { number: string | number }) => `Order ${number}`,
+        actions: {
+            refresh: 'Refresh',
+            send: 'Send',
+            sending: 'Sending…',
+        },
+        loading: 'Loading messages…',
+        empty: 'No messages yet. Be the first to write!',
+        you: 'You',
+        seller: 'Seller',
+        inputPlaceholder: 'Your message to the seller…',
+        inputHint: {
+            maxLength: ({ limit }: { limit: number }) => `Up to ${limit} characters`,
+        },
+        guestPrompt: {
+            prefix: 'To message the seller,',
+            login: 'sign in',
+            or: 'or',
+            register: 'sign up',
+            suffix: '.',
+        },
+        errors: {
+            load: 'Failed to load messages.',
+            send: 'Failed to send the message.',
+        },
+    },
     catalog: {
         seo: {
             listName: ({ category }: { category?: string }) => category ? `Catalog — ${category}` : 'Catalog',

--- a/resources/js/shop/i18n/messages/pt.ts
+++ b/resources/js/shop/i18n/messages/pt.ts
@@ -61,6 +61,34 @@ const messages = {
         },
         empty: 'O carrinho está vazio',
     },
+    orderChat: {
+        title: 'Chat com o vendedor',
+        orderLabel: ({ number }: { number: string | number }) => `Pedido ${number}`,
+        actions: {
+            refresh: 'Atualizar',
+            send: 'Enviar',
+            sending: 'Enviando…',
+        },
+        loading: 'A carregar mensagens…',
+        empty: 'Ainda não há mensagens. Seja o primeiro a escrever!',
+        you: 'Você',
+        seller: 'Vendedor',
+        inputPlaceholder: 'A sua mensagem para o vendedor…',
+        inputHint: {
+            maxLength: ({ limit }: { limit: number }) => `Até ${limit} caracteres`,
+        },
+        guestPrompt: {
+            prefix: 'Para enviar uma mensagem ao vendedor,',
+            login: 'entre',
+            or: 'ou',
+            register: 'cadastre-se',
+            suffix: '.',
+        },
+        errors: {
+            load: 'Não foi possível carregar as mensagens.',
+            send: 'Não foi possível enviar a mensagem.',
+        },
+    },
     catalog: {
         seo: {
             listName: ({ category }: { category?: string }) => category ? `Catálogo — ${category}` : 'Catálogo',

--- a/resources/js/shop/i18n/messages/ru.ts
+++ b/resources/js/shop/i18n/messages/ru.ts
@@ -61,6 +61,34 @@ const messages = {
         },
         empty: 'Корзина пуста',
     },
+    orderChat: {
+        title: 'Чат с продавцом',
+        orderLabel: ({ number }: { number: string | number }) => `Заказ ${number}`,
+        actions: {
+            refresh: 'Обновить',
+            send: 'Отправить',
+            sending: 'Отправка…',
+        },
+        loading: 'Загрузка сообщений…',
+        empty: 'Сообщений пока нет. Напишите первым!',
+        you: 'Вы',
+        seller: 'Продавец',
+        inputPlaceholder: 'Ваше сообщение продавцу…',
+        inputHint: {
+            maxLength: ({ limit }: { limit: number }) => `До ${limit} символов`,
+        },
+        guestPrompt: {
+            prefix: 'Чтобы написать продавцу,',
+            login: 'войдите',
+            or: 'или',
+            register: 'зарегистрируйтесь',
+            suffix: '.',
+        },
+        errors: {
+            load: 'Не удалось загрузить сообщения.',
+            send: 'Не удалось отправить сообщение.',
+        },
+    },
     catalog: {
         seo: {
             listName: ({ category }: { category?: string }) => category ? `Каталог — ${category}` : 'Каталог',

--- a/resources/js/shop/i18n/messages/uk.ts
+++ b/resources/js/shop/i18n/messages/uk.ts
@@ -61,6 +61,34 @@ const messages = {
         },
         empty: 'Кошик порожній',
     },
+    orderChat: {
+        title: 'Чат з продавцем',
+        orderLabel: ({ number }: { number: string | number }) => `Замовлення ${number}`,
+        actions: {
+            refresh: 'Оновити',
+            send: 'Надіслати',
+            sending: 'Надсилання…',
+        },
+        loading: 'Завантаження повідомлень…',
+        empty: 'Повідомлень ще немає. Напишіть першим!',
+        you: 'Ви',
+        seller: 'Продавець',
+        inputPlaceholder: 'Ваше повідомлення продавцю…',
+        inputHint: {
+            maxLength: ({ limit }: { limit: number }) => `До ${limit} символів`,
+        },
+        guestPrompt: {
+            prefix: 'Щоб написати продавцю,',
+            login: 'увійдіть',
+            or: 'або',
+            register: 'зареєструйтесь',
+            suffix: '.',
+        },
+        errors: {
+            load: 'Не вдалося завантажити повідомлення.',
+            send: 'Не вдалося надіслати повідомлення.',
+        },
+    },
     catalog: {
         seo: {
             listName: ({ category }: { category?: string }) => category ? `Каталог — ${category}` : 'Каталог',

--- a/resources/js/shop/lib/errors.ts
+++ b/resources/js/shop/lib/errors.ts
@@ -1,5 +1,11 @@
-export function resolveErrorMessage(error: unknown, fallback = 'Сталася помилка. Спробуйте ще раз.') {
-    if (!error) return fallback;
+type Fallback = string | (() => string);
+
+function resolveFallback(fallback: Fallback) {
+    return typeof fallback === 'function' ? fallback() : fallback;
+}
+
+export function resolveErrorMessage(error: unknown, fallback: Fallback = 'Сталася помилка. Спробуйте ще раз.') {
+    if (!error) return resolveFallback(fallback);
 
     const maybeResponse = (error as { response?: { data?: unknown } })?.response?.data;
 
@@ -36,5 +42,5 @@ export function resolveErrorMessage(error: unknown, fallback = 'Сталася �
         return error.message;
     }
 
-    return fallback;
+    return resolveFallback(fallback);
 }


### PR DESCRIPTION
## Summary
- hook OrderChat into the locale provider and replace hardcoded strings with dictionary lookups
- extend resolveErrorMessage to accept functional fallbacks and add orderChat messages for uk/en/ru/pt locales
- cover locale switching with a dedicated OrderChat translation test

## Testing
- npm run test -- OrderChat

------
https://chatgpt.com/codex/tasks/task_e_68cc48934c88833199ce871766089f24