### PR TITLE
Use locale-aware timestamp formatting in OrderChat

### DIFF
--- a/resources/js/shop/components/OrderChat.tsx
+++ b/resources/js/shop/components/OrderChat.tsx
@@ -4,20 +4,9 @@ import { Link } from 'react-router-dom';
 import { OrdersApi, type OrderMessage } from '../api';
 import useAuth from '../hooks/useAuth';
 import { resolveErrorMessage } from '../lib/errors';
+import { formatDateTime } from '../lib/datetime';
 import { Button } from '@/components/ui/button';
 import { useLocale } from '../i18n/LocaleProvider';
-
-function formatTimestamp(value?: string | null) {
-    if (!value) return '';
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return '';
-    return date.toLocaleString('uk-UA', {
-        day: '2-digit',
-        month: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit',
-    });
-}
 
 type OrderChatProps = {
     orderId: number;
@@ -27,7 +16,7 @@ type OrderChatProps = {
 
 export default function OrderChat({ orderId, orderNumber, className }: OrderChatProps) {
     const { isAuthenticated, isReady, user } = useAuth();
-    const { t } = useLocale();
+    const { t, locale } = useLocale();
     const [messages, setMessages] = React.useState<OrderMessage[]>([]);
     const [loading, setLoading] = React.useState(true);
     const [loadError, setLoadError] = React.useState<string | null>(null);
@@ -164,7 +153,7 @@ export default function OrderChat({ orderId, orderNumber, className }: OrderChat
                         ) : (
                             messages.map((message) => {
                                 const isAuthor = message.is_author ?? (message.user_id === user?.id);
-                                const timestamp = formatTimestamp(message.created_at);
+                                const timestamp = formatDateTime(locale, message.created_at);
                                 return (
                                     <div
                                         key={message.id}
@@ -179,7 +168,11 @@ export default function OrderChat({ orderId, orderNumber, className }: OrderChat
                                             <span>
                                                 {isAuthor ? t('orderChat.you') : message.user?.name ?? t('orderChat.seller')}
                                             </span>
-                                            {timestamp && <span>{timestamp}</span>}
+                                            {timestamp && (
+                                                <span data-testid={`order-chat-message-timestamp-${message.id}`}>
+                                                    {timestamp}
+                                                </span>
+                                            )}
                                         </div>
                                         <p className="mt-1 whitespace-pre-wrap break-words text-sm leading-relaxed">
                                             {message.body}

--- a/resources/js/shop/components/__tests__/OrderChat.test.tsx
+++ b/resources/js/shop/components/__tests__/OrderChat.test.tsx
@@ -115,4 +115,29 @@ describe('OrderChat', () => {
         expect(await screen.findByText('You')).toBeInTheDocument();
         expect(screen.getByText('Seller')).toBeInTheDocument();
     });
+
+    it('formats timestamps according to locale', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <MemoryRouter>
+                <LocaleProvider initial="uk">
+                    <Testbed orderId={42} orderNumber="A-001" />
+                </LocaleProvider>
+            </MemoryRouter>,
+        );
+
+        const timestamp = await screen.findByTestId('order-chat-message-timestamp-1');
+        expect(timestamp).toHaveTextContent(/\d{2}\.\d{2}/);
+        const initialValue = timestamp.textContent;
+        expect(initialValue).not.toBeNull();
+        const initialText = initialValue ?? '';
+
+        await user.click(screen.getByTestId('switch-lang'));
+
+        await screen.findByRole('heading', { name: 'Chat with the seller' });
+        const updatedTimestamp = await screen.findByTestId('order-chat-message-timestamp-1');
+        expect(updatedTimestamp.textContent).not.toBe(initialText);
+        expect(updatedTimestamp).toHaveTextContent(/\//);
+    });
 });

--- a/resources/js/shop/lib/datetime.ts
+++ b/resources/js/shop/lib/datetime.ts
@@ -1,0 +1,12 @@
+export function formatDateTime(locale: string, value?: string | null) {
+    if (!value) return '';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '';
+
+    return date.toLocaleString(locale, {
+        day: '2-digit',
+        month: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+}


### PR DESCRIPTION
## Summary
- add a shared `formatDateTime` helper to format timestamps with a locale
- update `OrderChat` to use the active locale for message timestamps and expose a timestamp test id
- add a unit test that verifies the timestamp changes when switching locales

## Testing
- npm run test -- OrderChat

------
https://chatgpt.com/codex/tasks/task_e_68cc4c1745848331828ceec57e0e4e7f