### PR TITLE
Handle wishlist deletions without product model

### DIFF
--- a/app/Http/Controllers/Api/WishlistController.php
+++ b/app/Http/Controllers/Api/WishlistController.php
@@ -44,11 +44,11 @@ class WishlistController extends Controller
         return response()->json($this->presentProduct($product));
     }
 
-    public function destroy(Request $request, Product $product): Response
+    public function destroy(Request $request, int $productId): Response
     {
         Wishlist::query()
             ->where('user_id', $request->user()->id)
-            ->where('product_id', $product->id)
+            ->where('product_id', $productId)
             ->delete();
 
         return response()->noContent();

--- a/routes/api.php
+++ b/routes/api.php
@@ -85,7 +85,8 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::apiResource('profile/addresses', AddressController::class);
     Route::get('profile/wishlist', [WishlistController::class, 'index']);
     Route::post('profile/wishlist/{product}', [WishlistController::class, 'store']);
-    Route::delete('profile/wishlist/{product}', [WishlistController::class, 'destroy']);
+    Route::delete('profile/wishlist/{productId}', [WishlistController::class, 'destroy'])
+        ->whereNumber('productId');
     Route::get('profile/points', [ProfilePointsController::class, 'index']);
     Route::get('orders/{order}/messages', [OrderMessageController::class, 'index']);
     Route::post('orders/{order}/messages', [OrderMessageController::class, 'store']);


### PR DESCRIPTION
## Summary
- update wishlist API destroy endpoint to operate on product IDs directly
- constrain the wishlist delete route to numeric IDs
- cover deleting wishlist entries when the product record has been removed

## Testing
- php artisan test --filter=WishlistApiTest

------
https://chatgpt.com/codex/tasks/task_e_68cc51c7cf208331afd231e6d1968746