### PR TITLE
Localize RecentlyViewed component strings

### DIFF
--- a/resources/js/shop/components/RecentlyViewed.test.tsx
+++ b/resources/js/shop/components/RecentlyViewed.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { describe, beforeEach, afterEach, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import RecentlyViewed from './RecentlyViewed';
+import LocaleProvider, { useLocale } from '../i18n/LocaleProvider';
+
+type RecentlyViewedProps = React.ComponentProps<typeof RecentlyViewed>;
+
+const SWITCH_BUTTON_ID = 'switch-lang';
+
+function renderRecentlyViewed(props: RecentlyViewedProps = {}) {
+    function Testbed() {
+        const { setLang } = useLocale();
+        return (
+            <MemoryRouter>
+                <button type="button" data-testid={SWITCH_BUTTON_ID} onClick={() => setLang('uk')}>
+                    Switch language
+                </button>
+                <RecentlyViewed {...props} />
+            </MemoryRouter>
+        );
+    }
+
+    return render(
+        <LocaleProvider initial="en">
+            <Testbed />
+        </LocaleProvider>,
+    );
+}
+
+describe('RecentlyViewed', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        localStorage.clear();
+    });
+
+    it('renders localized texts for the empty state when language changes', async () => {
+        const user = userEvent.setup();
+
+        renderRecentlyViewed();
+
+        expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Recently viewed');
+        expect(await screen.findByTestId('recently-empty')).toHaveTextContent('You haven’t viewed any products yet.');
+
+        await user.click(screen.getByTestId(SWITCH_BUTTON_ID));
+
+        expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Ви нещодавно переглядали');
+        expect(await screen.findByText('Ще не переглядали жодного товару.')).toBeInTheDocument();
+    });
+
+    it('renders localized placeholder for items without images when language changes', async () => {
+        localStorage.setItem(
+            'recently_viewed',
+            JSON.stringify([
+                { id: 1, slug: 'demo', name: 'Demo product', price: 10, preview_url: null },
+            ]),
+        );
+
+        const user = userEvent.setup();
+
+        renderRecentlyViewed();
+
+        expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Recently viewed');
+        expect(await screen.findByText('No photo')).toBeInTheDocument();
+
+        await user.click(screen.getByTestId(SWITCH_BUTTON_ID));
+
+        expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Ви нещодавно переглядали');
+        expect(await screen.findByText('без фото')).toBeInTheDocument();
+    });
+});

--- a/resources/js/shop/components/RecentlyViewed.tsx
+++ b/resources/js/shop/components/RecentlyViewed.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Card } from '@/components/ui/card';
+import { useLocale } from '../i18n/LocaleProvider';
 import { formatPrice } from '../ui/format';
 
 type RVItem = {
@@ -27,9 +28,12 @@ function readFromStorage(): RVItem[] {
     }
 }
 
-export default function RecentlyViewed({ excludeSlug, limit = 4, title = 'Ви нещодавно переглядали' }: Props) {
+export default function RecentlyViewed({ excludeSlug, limit = 4, title }: Props) {
     const [items, setItems] = React.useState<RVItem[]>([]);
     const [loading, setLoading] = React.useState(true);
+    const { t } = useLocale();
+
+    const heading = title ?? t('recentlyViewed.title');
 
     React.useEffect(() => {
         // миттєве читання з localStorage + мікрозатримка, щоб уникнути миготіння
@@ -42,7 +46,7 @@ export default function RecentlyViewed({ excludeSlug, limit = 4, title = 'Ви �
 
     return (
         <section className="mt-10" data-testid="recently-section">
-            <h2 className="mb-3 text-lg font-semibold">{title}</h2>
+            <h2 className="mb-3 text-lg font-semibold">{heading}</h2>
 
             {loading ? (
                 <div className="grid grid-cols-2 gap-4 sm:grid-cols-4" data-testid="recently-skel">
@@ -56,7 +60,7 @@ export default function RecentlyViewed({ excludeSlug, limit = 4, title = 'Ви �
                 </div>
             ) : items.length === 0 ? (
                 <div className="text-sm text-muted-foreground" data-testid="recently-empty">
-                    Ще не переглядали жодного товару.
+                    {t('recentlyViewed.empty')}
                 </div>
             ) : (
                 <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
@@ -67,7 +71,9 @@ export default function RecentlyViewed({ excludeSlug, limit = 4, title = 'Ви �
                                     {p.preview_url ? (
                                         <img src={p.preview_url} alt={p.name} className="h-full w-full object-cover" />
                                     ) : (
-                                        <div className="flex h-full items-center justify-center text-sm text-muted-foreground">без фото</div>
+                                        <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                                            {t('recentlyViewed.noImage')}
+                                        </div>
                                     )}
                                 </div>
                                 <div className="p-3">

--- a/resources/js/shop/i18n/messages/en.ts
+++ b/resources/js/shop/i18n/messages/en.ts
@@ -61,6 +61,11 @@ const messages = {
         },
         empty: 'Your cart is empty',
     },
+    recentlyViewed: {
+        title: 'Recently viewed',
+        empty: 'You haven’t viewed any products yet.',
+        noImage: 'No photo',
+    },
     orderChat: {
         title: 'Chat with the seller',
         orderLabel: ({ number }: { number: string | number }) => `Order ${number}`,

--- a/resources/js/shop/i18n/messages/pt.ts
+++ b/resources/js/shop/i18n/messages/pt.ts
@@ -61,6 +61,11 @@ const messages = {
         },
         empty: 'O carrinho está vazio',
     },
+    recentlyViewed: {
+        title: 'Vistos recentemente',
+        empty: 'Você ainda não visualizou nenhum produto.',
+        noImage: 'sem foto',
+    },
     orderChat: {
         title: 'Chat com o vendedor',
         orderLabel: ({ number }: { number: string | number }) => `Pedido ${number}`,

--- a/resources/js/shop/i18n/messages/ru.ts
+++ b/resources/js/shop/i18n/messages/ru.ts
@@ -61,6 +61,11 @@ const messages = {
         },
         empty: 'Корзина пуста',
     },
+    recentlyViewed: {
+        title: 'Вы недавно смотрели',
+        empty: 'Вы ещё не просмотрели ни одного товара.',
+        noImage: 'без фото',
+    },
     orderChat: {
         title: 'Чат с продавцом',
         orderLabel: ({ number }: { number: string | number }) => `Заказ ${number}`,

--- a/resources/js/shop/i18n/messages/uk.ts
+++ b/resources/js/shop/i18n/messages/uk.ts
@@ -61,6 +61,11 @@ const messages = {
         },
         empty: 'Кошик порожній',
     },
+    recentlyViewed: {
+        title: 'Ви нещодавно переглядали',
+        empty: 'Ще не переглядали жодного товару.',
+        noImage: 'без фото',
+    },
     orderChat: {
         title: 'Чат з продавцем',
         orderLabel: ({ number }: { number: string | number }) => `Замовлення ${number}`,


### PR DESCRIPTION
## Summary
- integrate the RecentlyViewed component with the locale provider and use translation keys for the heading, empty state, and image placeholder
- extend the English, Ukrainian, Russian, and Portuguese dictionaries with the recentlyViewed section
- cover RecentlyViewed with tests that assert translations update after switching the active language

## Testing
- npm run test -- RecentlyViewed

------
https://chatgpt.com/codex/tasks/task_e_68cc57d2127c8331afdd209cc355342a