### PR TITLE
Add localized pay order messaging

### DIFF
--- a/resources/js/shop/components/PayOrder.tsx
+++ b/resources/js/shop/components/PayOrder.tsx
@@ -3,6 +3,7 @@ import { loadStripe } from '@stripe/stripe-js';
 import { Elements, PaymentElement, useElements, useStripe } from '@stripe/react-stripe-js';
 import { Button } from '@/components/ui/button';
 import { useNotify } from '../ui/notify';
+import { useLocale } from '../i18n/LocaleProvider';
 
 function Inner({
     number,
@@ -13,7 +14,8 @@ function Inner({
 }) {
     const stripe = useStripe();
     const elements = useElements();
-    const { error: notifyError, success } = useNotify();
+    const { error: notifyError, success: notifySuccess } = useNotify();
+    const { t } = useLocale();
     const [submitting, setSubmitting] = useState(false);
 
     const origin = typeof window !== 'undefined' ? window.location.origin : '';
@@ -29,19 +31,19 @@ function Inner({
                 redirect: 'if_required',
             });
             if (error) {
-                notifyError({ title: error.message || 'Оплата не пройшла' });
+                notifyError({ title: error.message || t('checkout.payOrder.error') });
             } else {
                 const status = paymentIntent?.status;
                 const paymentIntentId = paymentIntent?.id;
                 if (status === 'succeeded') {
-                    success({ title: 'Оплата успішна' });
+                    notifySuccess({ title: t('checkout.payOrder.success') });
                     onPaid?.(status, paymentIntentId);
                 } else if (status === 'processing') {
-                    success({ title: 'Оплата обробляється…' });
+                    notifySuccess({ title: t('checkout.payOrder.processing') });
                     onPaid?.(status, paymentIntentId);
                 } else {
                     // якщо 3DS або редірект — Stripe сам обробить сценарій
-                    success({ title: 'Оплата обробляється…' });
+                    notifySuccess({ title: t('checkout.payOrder.processing') });
                 }
             }
         } finally {
@@ -53,7 +55,7 @@ function Inner({
         <div className="space-y-3" data-testid="payment-form">
             <PaymentElement data-testid="payment-element" />
             <Button onClick={handlePay} disabled={!stripe || submitting}>
-                {submitting ? 'Оплата…' : 'Сплатити'}
+                {submitting ? t('checkout.payOrder.submitting') : t('checkout.payOrder.submit')}
             </Button>
         </div>
     );

--- a/resources/js/shop/i18n/messages/en.ts
+++ b/resources/js/shop/i18n/messages/en.ts
@@ -425,6 +425,13 @@ const messages = {
             delivery: 'Delivery',
             payment: 'Payment',
         },
+        payOrder: {
+            error: 'Payment failed',
+            success: 'Payment successful',
+            processing: 'Payment processing…',
+            submit: 'Pay',
+            submitting: 'Paying…',
+        },
         notifications: {
             cartUnavailable: 'Your cart is empty or already checked out.',
             cartCheckFailed: 'We could not verify your cart.',

--- a/resources/js/shop/i18n/messages/messages.test.ts
+++ b/resources/js/shop/i18n/messages/messages.test.ts
@@ -192,6 +192,12 @@ const keys: Array<{ key: TranslationKey; params?: Record<string, any> }> = [
     { key: 'notify.cart.update.outOfStock' },
     { key: 'notify.cart.update.error' },
     { key: 'notify.cart.remove.success' },
+    // Checkout pay order
+    { key: 'checkout.payOrder.error' },
+    { key: 'checkout.payOrder.success' },
+    { key: 'checkout.payOrder.processing' },
+    { key: 'checkout.payOrder.submit' },
+    { key: 'checkout.payOrder.submitting' },
     // Profile navigation
     { key: 'profile.navigation.overview' },
     { key: 'profile.navigation.orders' },

--- a/resources/js/shop/i18n/messages/pt.ts
+++ b/resources/js/shop/i18n/messages/pt.ts
@@ -426,6 +426,13 @@ const messages = {
             delivery: 'Entrega',
             payment: 'Pagamento',
         },
+        payOrder: {
+            error: 'O pagamento falhou',
+            success: 'Pagamento concluído',
+            processing: 'O pagamento está a ser processado…',
+            submit: 'Pagar',
+            submitting: 'A pagar…',
+        },
         notifications: {
             cartUnavailable: 'O carrinho está vazio ou já foi finalizado.',
             cartCheckFailed: 'Não foi possível verificar o carrinho.',

--- a/resources/js/shop/i18n/messages/ru.ts
+++ b/resources/js/shop/i18n/messages/ru.ts
@@ -428,6 +428,13 @@ const messages = {
             delivery: 'Доставка',
             payment: 'Оплата',
         },
+        payOrder: {
+            error: 'Оплата не прошла',
+            success: 'Оплата успешна',
+            processing: 'Оплата обрабатывается…',
+            submit: 'Оплатить',
+            submitting: 'Оплата…',
+        },
         notifications: {
             cartUnavailable: 'Корзина пуста или уже оформлена.',
             cartCheckFailed: 'Не удалось проверить корзину.',

--- a/resources/js/shop/i18n/messages/uk.ts
+++ b/resources/js/shop/i18n/messages/uk.ts
@@ -426,6 +426,13 @@ const messages = {
             delivery: 'Доставка',
             payment: 'Оплата',
         },
+        payOrder: {
+            error: 'Оплата не пройшла',
+            success: 'Оплата успішна',
+            processing: 'Оплата обробляється…',
+            submit: 'Сплатити',
+            submitting: 'Оплата…',
+        },
         notifications: {
             cartUnavailable: 'Кошик порожній або вже оформлено.',
             cartCheckFailed: 'Не вдалося перевірити кошик.',


### PR DESCRIPTION
## Summary
- add checkout pay order translation keys for payment status texts across all locales
- use localized strings in the PayOrder component for toast messages and button label
- cover the new translations in the i18n messages test suite

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccce026ba883319fe81803185d7520