### PR TITLE
Add localized filter facet tooltips

### DIFF
--- a/resources/js/shop/i18n/messages/en.ts
+++ b/resources/js/shop/i18n/messages/en.ts
@@ -156,6 +156,11 @@ const messages = {
                 categories: 'Categories',
                 colors: 'Color',
                 sizes: 'Size',
+                tooltip: {
+                    category: ({ value }: { value: string }) => `Filter by category: ${value}`,
+                    color: ({ value }: { value: string }) => `Filter by color: ${value}`,
+                    size: ({ value }: { value: string }) => `Filter by size: ${value}`,
+                },
                 empty: 'no data',
             },
         },

--- a/resources/js/shop/i18n/messages/pt.ts
+++ b/resources/js/shop/i18n/messages/pt.ts
@@ -156,6 +156,11 @@ const messages = {
                 categories: 'Categorias',
                 colors: 'Cor',
                 sizes: 'Tamanho',
+                tooltip: {
+                    category: ({ value }: { value: string }) => `Filtrar por categoria: ${value}`,
+                    color: ({ value }: { value: string }) => `Filtrar por cor: ${value}`,
+                    size: ({ value }: { value: string }) => `Filtrar por tamanho: ${value}`,
+                },
                 empty: 'sem dados',
             },
         },

--- a/resources/js/shop/i18n/messages/ru.ts
+++ b/resources/js/shop/i18n/messages/ru.ts
@@ -156,6 +156,11 @@ const messages = {
                 categories: 'Категории',
                 colors: 'Цвет',
                 sizes: 'Размер',
+                tooltip: {
+                    category: ({ value }: { value: string }) => `Фильтр по категории: ${value}`,
+                    color: ({ value }: { value: string }) => `Фильтр по цвету: ${value}`,
+                    size: ({ value }: { value: string }) => `Фильтр по размеру: ${value}`,
+                },
                 empty: 'нет данных',
             },
         },

--- a/resources/js/shop/i18n/messages/uk.ts
+++ b/resources/js/shop/i18n/messages/uk.ts
@@ -156,6 +156,11 @@ const messages = {
                 categories: 'Категорії',
                 colors: 'Колір',
                 sizes: 'Розмір',
+                tooltip: {
+                    category: ({ value }: { value: string }) => `Фільтр за категорією: ${value}`,
+                    color: ({ value }: { value: string }) => `Фільтр за кольором: ${value}`,
+                    size: ({ value }: { value: string }) => `Фільтр за розміром: ${value}`,
+                },
                 empty: 'нема даних',
             },
         },

--- a/resources/js/shop/pages/Catalog.tsx
+++ b/resources/js/shop/pages/Catalog.tsx
@@ -455,6 +455,7 @@ export default function Catalog() {
                         {categoryFacetEntries.map(([id, cnt]) => {
                             const c = catById.get(String(id));
                             const active = Number(categoryId) === Number(id);
+                            const label = c?.name ?? `#${id}`;
                             return (
                                 <button
                                     key={id}
@@ -467,9 +468,9 @@ export default function Catalog() {
                                         setPage(1);
                                     }}
                                     className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs ${active ? 'bg-black text-white' : ''}`}
-                                    title={`category_id=${id}`}
+                                    title={t('catalog.filters.facets.tooltip.category', { value: label })}
                                 >
-                                    {c?.name ?? `#${id}`} <span className="opacity-70">({cnt})</span>
+                                    {label} <span className="opacity-70">({cnt})</span>
                                 </button>
                             );
                         })}
@@ -492,7 +493,7 @@ export default function Catalog() {
                                     data-testid={`facet-color-${normalized}`}
                                     onClick={() => toggleColorFacet(normalized)}
                                     className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs ${active ? 'bg-black text-white' : ''}`}
-                                    title={`attrs.color=${value}`}
+                                    title={t('catalog.filters.facets.tooltip.color', { value: label })}
                                 >
                                     {label} <span className="opacity-70">({count})</span>
                                 </button>
@@ -517,7 +518,7 @@ export default function Catalog() {
                                     data-testid={`facet-size-${v}`}
                                     onClick={() => toggleListParam(v, selectedSizes, setSizesParam)}
                                     className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs ${active ? 'bg-black text-white' : ''}`}
-                                    title={`attrs.size=${v}`}
+                                    title={t('catalog.filters.facets.tooltip.size', { value: v })}
                                 >
                                     {v} <span className="opacity-70">({cnt})</span>
                                 </button>


### PR DESCRIPTION
## Summary
- add translation strings for filter facet tooltips across supported locales
- use the localized tooltip strings on catalog facet buttons

## Testing
- npm run test -- Catalog

------
https://chatgpt.com/codex/tasks/task_e_68ccd488d0c48331896011c02f8bce64