### PR TITLE
Extend locale middleware support

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -90,6 +90,7 @@ return [
     'locale' => 'uk',
     'fallback_locale' => env('APP_FALLBACK_LOCALE', 'en'),
     'faker_locale' => 'uk_UA',
+    'supported_locales' => ['uk', 'en', 'ru', 'pt'],
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/lang/uk/validation.php
+++ b/resources/lang/uk/validation.php
@@ -150,9 +150,9 @@ return [
     ],
 
     'attributes' => [
-        'email' => 'електронна адреса',
+        'email' => 'Електронна адреса',
         'name' => 'імʼя',
-        'password' => 'пароль',
-        'password_confirmation' => 'підтвердження пароля',
+        'password' => 'Пароль',
+        'password_confirmation' => 'Підтвердження пароля',
     ],
 ];

--- a/resources/views/shop.blade.php
+++ b/resources/views/shop.blade.php
@@ -16,6 +16,10 @@
 
 
     @viteReactRefresh
+    <script>
+        window.__APP_SUPPORTED_LOCALES__ = @json(config('app.supported_locales', ['uk', 'en', 'ru', 'pt']));
+        window.__APP_DEFAULT_LOCALE__ = @json(config('app.locale', 'uk'));
+    </script>
     @vite('resources/js/shop/main.tsx')
 </head>
 <body class="bg-gray-50 text-gray-900">

--- a/tests/Feature/SetLocaleFromRequestTest.php
+++ b/tests/Feature/SetLocaleFromRequestTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Http\Middleware\SetLocaleFromRequest;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Config;
+
+beforeEach(function () {
+    Config::set('app.supported_locales', ['uk', 'en', 'ru', 'pt']);
+    Config::set('app.fallback_locale', 'uk');
+    App::setLocale('uk');
+});
+
+it('sets locale from url prefix including normalized variants', function (string $path, string $expected) {
+    $request = Request::create($path, 'GET');
+    $middleware = new SetLocaleFromRequest();
+
+    $middleware->handle($request, fn () => null);
+
+    expect(App::getLocale())->toBe($expected);
+})->with([
+    ['/ru/products', 'ru'],
+    ['/pt-BR/catalog', 'pt'],
+]);
+
+it('sets locale from lang cookie with normalization', function (string $cookie, string $expected) {
+    $request = Request::create('/', 'GET');
+    $request->cookies->set('lang', $cookie);
+    $middleware = new SetLocaleFromRequest();
+
+    $middleware->handle($request, fn () => null);
+
+    expect(App::getLocale())->toBe($expected);
+})->with([
+    ['RU', 'ru'],
+    ['pt_BR', 'pt'],
+]);
+
+it('sets locale from accept language header with normalization', function (string $header, string $expected) {
+    $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT_LANGUAGE' => $header]);
+    $middleware = new SetLocaleFromRequest();
+
+    $middleware->handle($request, fn () => null);
+
+    expect(App::getLocale())->toBe($expected);
+})->with([
+    ['ru-RU,ru;q=0.8,en;q=0.5', 'ru'],
+    ['pt-BR,pt;q=0.9,en;q=0.8', 'pt'],
+]);


### PR DESCRIPTION
## Summary
- load supported locales and fallback from configuration in SetLocaleFromRequest middleware and normalize URL, cookie, and Accept-Language inputs for ru and pt
- expose supported locales and default locale to the frontend and consume them in the React i18n config so the list of languages comes from a single source
- register supported locales in app config, tweak Ukrainian validation attribute labels, and add feature tests covering middleware behaviour for ru and pt

## Testing
- php artisan test --testsuite=Feature

------
https://chatgpt.com/codex/tasks/task_e_68ccd888cf6c8331806ba8b69d381dc8