### PR TITLE
Localize API responses

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -59,7 +59,7 @@ class AuthController extends Controller
 
         if (!$user) {
             return response()->json([
-                'message' => 'Unauthenticated.',
+                'message' => __('shop.api.auth.unauthenticated'),
             ], 401);
         }
 
@@ -68,7 +68,7 @@ class AuthController extends Controller
         }
 
         return response()->json([
-            'message' => 'Verification link sent.',
+            'message' => __('shop.api.auth.verification_link_sent'),
         ], 202);
     }
 
@@ -96,14 +96,14 @@ class AuthController extends Controller
         if ($twoFactor && $twoFactor->isConfirmed()) {
             if (empty($data['otp'])) {
                 return response()->json([
-                    'message' => 'Потрібен код двофакторної автентифікації.',
+                    'message' => __('shop.api.auth.two_factor_required'),
                     'two_factor_required' => true,
                 ], 409);
             }
 
             if (!$twoFactorService->verify($twoFactor->secret, $data['otp'])) {
                 throw ValidationException::withMessages([
-                    'otp' => ['Невірний код двофакторної автентифікації.'],
+                    'otp' => [__('shop.api.auth.invalid_two_factor_code')],
                 ]);
             }
         }
@@ -125,7 +125,7 @@ class AuthController extends Controller
 
         if (!$user) {
             return response()->json([
-                'message' => 'Unauthenticated.',
+                'message' => __('shop.api.auth.unauthenticated'),
             ], 401);
         }
 
@@ -141,7 +141,7 @@ class AuthController extends Controller
 
         if (!$user) {
             return response()->json([
-                'message' => 'Unauthenticated.',
+                'message' => __('shop.api.auth.unauthenticated'),
             ], 401);
         }
 

--- a/app/Http/Controllers/Api/CartController.php
+++ b/app/Http/Controllers/Api/CartController.php
@@ -51,7 +51,7 @@ class CartController extends Controller
             $product = Product::lockForUpdate()->findOrFail($data['product_id']);
 
             if ($qty > (int) $product->stock) {
-                return response()->json(['message' => 'Not enough stock'], 422);
+                return response()->json(['message' => __('shop.api.cart.not_enough_stock')], 422);
             }
 
             $item = CartItem::query()
@@ -87,7 +87,7 @@ class CartController extends Controller
         ]);
 
         if ($item->cart_id !== $id) {
-            abort(404);
+            abort(404, __('shop.api.common.not_found'));
         }
 
         return DB::transaction(function () use ($data, $item) {
@@ -116,7 +116,7 @@ class CartController extends Controller
     public function removeItem(string $id, CartItem $item): JsonResponse
     {
         if ($item->cart_id !== $id) {
-            abort(404);
+            abort(404, __('shop.api.common.not_found'));
         }
 
         $item->delete();
@@ -150,7 +150,7 @@ class CartController extends Controller
 
         if (! $coupon) {
             throw ValidationException::withMessages([
-                'code' => ['Coupon not found.'],
+                'code' => [__('shop.api.cart.coupon_not_found')],
             ]);
         }
 
@@ -158,7 +158,7 @@ class CartController extends Controller
 
         if (! $totals->coupon) {
             throw ValidationException::withMessages([
-                'code' => ['Coupon cannot be applied to this cart.'],
+                'code' => [__('shop.api.cart.coupon_not_applicable')],
             ]);
         }
 
@@ -178,7 +178,7 @@ class CartController extends Controller
 
         if (! $cart->user_id) {
             throw ValidationException::withMessages([
-                'points' => ['Only authenticated users can redeem loyalty points.'],
+                'points' => [__('shop.api.cart.points_auth_required')],
             ]);
         }
 

--- a/app/Http/Controllers/Api/CartItemController.php
+++ b/app/Http/Controllers/Api/CartItemController.php
@@ -19,7 +19,7 @@ class CartItemController extends Controller
             $product = Product::lockForUpdate()->findOrFail($data['product_id']);
 
             if ($product->stock < $data['qty']) {
-                return response()->json(['message' => 'Not enough stock'], 422);
+                return response()->json(['message' => __('shop.api.cart.not_enough_stock')], 422);
             }
 
             /** @var CartItem $item */

--- a/app/Http/Controllers/Api/PaymentController.php
+++ b/app/Http/Controllers/Api/PaymentController.php
@@ -67,7 +67,7 @@ class PaymentController extends Controller
         $piId  = (string) ($r->input('payment_intent') ?: $order->payment_intent_id);
 
         if (!$piId) {
-            return response()->json(['ok' => false, 'error' => 'No payment_intent'], 400);
+            return response()->json(['ok' => false, 'error' => __('shop.api.payments.missing_intent')], 400);
         }
 
         $stripe = new StripeClient(config('services.stripe.secret'));

--- a/app/Http/Controllers/Api/ReviewController.php
+++ b/app/Http/Controllers/Api/ReviewController.php
@@ -33,7 +33,7 @@ class ReviewController extends Controller
 
         $user = $request->user();
 
-        abort_if($user === null, 401);
+        abort_if($user === null, 401, __('shop.api.auth.unauthenticated'));
 
         $validated = $request->validate([
             'rating' => ['required', 'integer', 'min:1', 'max:5'],
@@ -49,7 +49,7 @@ class ReviewController extends Controller
 
         return response()->json([
             'data' => $review->load('user:id,name'),
-            'message' => 'Review submitted for moderation.',
+            'message' => __('shop.api.reviews.submitted'),
         ], 201);
     }
 }

--- a/app/Http/Controllers/Api/VerifyEmailController.php
+++ b/app/Http/Controllers/Api/VerifyEmailController.php
@@ -17,15 +17,15 @@ class VerifyEmailController extends Controller
         $user = User::query()->find($id);
 
         if (! $user) {
-            abort(404);
+            abort(404, __('shop.api.common.not_found'));
         }
 
         if (! hash_equals(sha1($user->getEmailForVerification()), $hash)) {
-            abort(403, 'Недійсний підпис для підтвердження електронної адреси.');
+            abort(403, __('shop.api.verify_email.invalid_signature'));
         }
 
         if ($user->hasVerifiedEmail()) {
-            return $this->respond($request, 'Електронна адреса вже підтверджена.', true);
+            return $this->respond($request, __('shop.api.verify_email.already_verified'), true);
         }
 
         $user->forceFill([
@@ -34,7 +34,7 @@ class VerifyEmailController extends Controller
 
         event(new Verified($user));
 
-        return $this->respond($request, 'Електронну адресу підтверджено.');
+        return $this->respond($request, __('shop.api.verify_email.verified'));
     }
 
     private function respond(Request $request, string $message, bool $alreadyVerified = false): JsonResponse|RedirectResponse

--- a/resources/lang/en/shop.php
+++ b/resources/lang/en/shop.php
@@ -111,6 +111,44 @@ return [
         ],
     ],
 
+    'api' => [
+        'common' => [
+            'not_found' => 'Resource not found.',
+        ],
+        'auth' => [
+            'unauthenticated' => 'Unauthenticated.',
+            'verification_link_sent' => 'Verification link sent.',
+            'two_factor_required' => 'Two-factor authentication code required.',
+            'invalid_two_factor_code' => 'Invalid two-factor authentication code.',
+        ],
+        'verify_email' => [
+            'invalid_signature' => 'Invalid signature for email verification.',
+            'already_verified' => 'Email address already verified.',
+            'verified' => 'Email address verified.',
+        ],
+        'cart' => [
+            'not_enough_stock' => 'Not enough stock',
+            'coupon_not_found' => 'Coupon not found.',
+            'coupon_not_applicable' => 'Coupon cannot be applied to this cart.',
+            'points_auth_required' => 'Only authenticated users can redeem loyalty points.',
+        ],
+        'orders' => [
+            'cart_empty' => 'Cart is empty',
+            'insufficient_stock' => 'Insufficient stock for product #:product',
+            'coupon_unavailable' => 'Coupon is no longer available.',
+            'coupon_usage_limit_reached' => 'Coupon usage limit reached.',
+            'not_enough_points' => 'Not enough loyalty points to redeem the requested amount.',
+            'points_redeemed_description' => 'Points redeemed for order :number',
+            'points_earned_description' => 'Points earned from order :number',
+        ],
+        'reviews' => [
+            'submitted' => 'Review submitted for moderation.',
+        ],
+        'payments' => [
+            'missing_intent' => 'Payment intent is missing.',
+        ],
+    ],
+
     'security' => [
         'two_factor' => [
             'not_initialized' => 'Two-factor authentication is not initialized.',

--- a/resources/lang/pt/shop.php
+++ b/resources/lang/pt/shop.php
@@ -111,6 +111,44 @@ return [
         ],
     ],
 
+    'api' => [
+        'common' => [
+            'not_found' => 'Recurso não encontrado.',
+        ],
+        'auth' => [
+            'unauthenticated' => 'Não autenticado.',
+            'verification_link_sent' => 'Link de verificação enviado.',
+            'two_factor_required' => 'É necessário o código de autenticação em duas etapas.',
+            'invalid_two_factor_code' => 'Código de autenticação em duas etapas inválido.',
+        ],
+        'verify_email' => [
+            'invalid_signature' => 'Assinatura inválida para verificação de e-mail.',
+            'already_verified' => 'E-mail já verificado.',
+            'verified' => 'E-mail verificado.',
+        ],
+        'cart' => [
+            'not_enough_stock' => 'Estoque insuficiente',
+            'coupon_not_found' => 'Cupom não encontrado.',
+            'coupon_not_applicable' => 'O cupom não pode ser aplicado a este carrinho.',
+            'points_auth_required' => 'Apenas usuários autenticados podem resgatar pontos de fidelidade.',
+        ],
+        'orders' => [
+            'cart_empty' => 'Carrinho vazio',
+            'insufficient_stock' => 'Estoque insuficiente para o produto nº :product',
+            'coupon_unavailable' => 'O cupom não está mais disponível.',
+            'coupon_usage_limit_reached' => 'Limite de uso do cupom atingido.',
+            'not_enough_points' => 'Pontos de fidelidade insuficientes para resgatar o valor solicitado.',
+            'points_redeemed_description' => 'Pontos resgatados para o pedido :number',
+            'points_earned_description' => 'Pontos acumulados no pedido :number',
+        ],
+        'reviews' => [
+            'submitted' => 'Avaliação enviada para moderação.',
+        ],
+        'payments' => [
+            'missing_intent' => 'payment_intent ausente.',
+        ],
+    ],
+
     'security' => [
         'two_factor' => [
             'not_initialized' => 'A autenticação em duas etapas não está configurada.',

--- a/resources/lang/ru/shop.php
+++ b/resources/lang/ru/shop.php
@@ -111,6 +111,44 @@ return [
         ],
     ],
 
+    'api' => [
+        'common' => [
+            'not_found' => 'Ресурс не найден.',
+        ],
+        'auth' => [
+            'unauthenticated' => 'Пользователь не авторизован.',
+            'verification_link_sent' => 'Ссылка для подтверждения отправлена.',
+            'two_factor_required' => 'Требуется код двухфакторной аутентификации.',
+            'invalid_two_factor_code' => 'Неверный код двухфакторной аутентификации.',
+        ],
+        'verify_email' => [
+            'invalid_signature' => 'Недействительная подпись для подтверждения электронной почты.',
+            'already_verified' => 'Электронная почта уже подтверждена.',
+            'verified' => 'Электронная почта подтверждена.',
+        ],
+        'cart' => [
+            'not_enough_stock' => 'Недостаточно товара на складе',
+            'coupon_not_found' => 'Купон не найден.',
+            'coupon_not_applicable' => 'Купон нельзя применить к этой корзине.',
+            'points_auth_required' => 'Только авторизованные пользователи могут использовать бонусные баллы.',
+        ],
+        'orders' => [
+            'cart_empty' => 'Корзина пуста',
+            'insufficient_stock' => 'Недостаточно товара для продукта №:product',
+            'coupon_unavailable' => 'Купон больше недоступен.',
+            'coupon_usage_limit_reached' => 'Достигнут лимит использования купона.',
+            'not_enough_points' => 'Недостаточно бонусных баллов для списания запрошенной суммы.',
+            'points_redeemed_description' => 'Баллы списаны за заказ :number',
+            'points_earned_description' => 'Баллы начислены за заказ :number',
+        ],
+        'reviews' => [
+            'submitted' => 'Отзыв отправлен на модерацию.',
+        ],
+        'payments' => [
+            'missing_intent' => 'Отсутствует payment_intent.',
+        ],
+    ],
+
     'security' => [
         'two_factor' => [
             'not_initialized' => 'Двухфакторная аутентификация не настроена.',

--- a/resources/lang/uk/shop.php
+++ b/resources/lang/uk/shop.php
@@ -111,6 +111,44 @@ return [
         ],
     ],
 
+    'api' => [
+        'common' => [
+            'not_found' => 'Ресурс не знайдено.',
+        ],
+        'auth' => [
+            'unauthenticated' => 'Користувач не авторизований.',
+            'verification_link_sent' => 'Посилання для підтвердження надіслано.',
+            'two_factor_required' => 'Потрібен код двофакторної автентифікації.',
+            'invalid_two_factor_code' => 'Невірний код двофакторної автентифікації.',
+        ],
+        'verify_email' => [
+            'invalid_signature' => 'Недійсний підпис для підтвердження електронної адреси.',
+            'already_verified' => 'Електронна адреса вже підтверджена.',
+            'verified' => 'Електронну адресу підтверджено.',
+        ],
+        'cart' => [
+            'not_enough_stock' => 'Недостатньо товару на складі',
+            'coupon_not_found' => 'Купон не знайдено.',
+            'coupon_not_applicable' => 'Купон не можна застосувати до цього кошика.',
+            'points_auth_required' => 'Лише авторизовані користувачі можуть використати бонусні бали.',
+        ],
+        'orders' => [
+            'cart_empty' => 'Кошик порожній',
+            'insufficient_stock' => 'Недостатньо товару для продукту №:product',
+            'coupon_unavailable' => 'Купон більше недоступний.',
+            'coupon_usage_limit_reached' => 'Перевищено ліміт використання купона.',
+            'not_enough_points' => 'Недостатньо бонусних балів для списання запитаної кількості.',
+            'points_redeemed_description' => 'Бали списано за замовлення :number',
+            'points_earned_description' => 'Бали нараховано за замовлення :number',
+        ],
+        'reviews' => [
+            'submitted' => 'Відгук надіслано на модерацію.',
+        ],
+        'payments' => [
+            'missing_intent' => 'Відсутній payment_intent.',
+        ],
+    ],
+
     'security' => [
         'two_factor' => [
             'not_initialized' => 'Двофакторну автентифікацію не налаштовано.',

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -77,7 +77,7 @@ it('resends the verification email for authenticated users', function () {
 
     $this->postJson('/api/email/resend')
         ->assertStatus(202)
-        ->assertJson(['message' => 'Verification link sent.']);
+        ->assertJson(['message' => __('shop.api.auth.verification_link_sent')]);
 
     Mail::assertQueued(VerifyEmailMail::class, function (VerifyEmailMail $mail) use ($user) {
         expect($mail->displayUrl)->toBe(expectedDisplayUrl($mail->verificationUrl));
@@ -124,7 +124,7 @@ it('verifies the email address via the API endpoint', function () {
 
     $this->getJson($verificationUrl)
         ->assertOk()
-        ->assertJson(['message' => 'Електронну адресу підтверджено.']);
+        ->assertJson(['message' => __('shop.api.verify_email.verified')]);
 
     expect($user->fresh()->hasVerifiedEmail())->toBeTrue();
 });


### PR DESCRIPTION
## Summary
- add localized API message translations across English, Ukrainian, Russian and Portuguese shop resources
- update API controllers to return translated messages and adjust tests to assert translation keys

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68ccdb9fdcf48331b7924d2f18c37b17