### PR TITLE
Enhance loyalty transaction localization

### DIFF
--- a/app/Filament/Mine/Resources/Users/RelationManagers/LoyaltyPointTransactionsRelationManager.php
+++ b/app/Filament/Mine/Resources/Users/RelationManagers/LoyaltyPointTransactionsRelationManager.php
@@ -32,6 +32,7 @@ class LoyaltyPointTransactionsRelationManager extends RelationManager
                     ->state(fn ($record) => formatCurrency($record->amount, $record->order?->currency))
                     ->toggleable(),
                 TextColumn::make('description')
+                    ->formatStateUsing(fn ($state, $record) => $record->localized_description ?: $state)
                     ->wrap()
                     ->toggleable(),
             ])

--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -187,24 +187,36 @@ class OrderController extends Controller
             }
 
             if ($cart->user_id && $totals->pointsUsed > 0) {
+                $meta = [
+                    'key' => 'shop.api.orders.points_redeemed_description',
+                    'number' => $order->number,
+                ];
+
                 LoyaltyPointTransaction::create([
                     'user_id' => $cart->user_id,
                     'order_id' => $order->id,
                     'type' => LoyaltyPointTransaction::TYPE_REDEEM,
                     'points' => -$totals->pointsUsed,
                     'amount' => $totals->pointsValue,
-                    'description' => __('shop.api.orders.points_redeemed_description', ['number' => $order->number]),
+                    'description' => __($meta['key'], $meta),
+                    'meta' => $meta,
                 ]);
             }
 
             if ($cart->user_id && $pointsEarned > 0) {
+                $meta = [
+                    'key' => 'shop.api.orders.points_earned_description',
+                    'number' => $order->number,
+                ];
+
                 LoyaltyPointTransaction::create([
                     'user_id' => $cart->user_id,
                     'order_id' => $order->id,
                     'type' => LoyaltyPointTransaction::TYPE_EARN,
                     'points' => $pointsEarned,
                     'amount' => $totals->total,
-                    'description' => __('shop.api.orders.points_earned_description', ['number' => $order->number]),
+                    'description' => __($meta['key'], $meta),
+                    'meta' => $meta,
                 ]);
             }
 

--- a/app/Http/Controllers/Api/ProfilePointsController.php
+++ b/app/Http/Controllers/Api/ProfilePointsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Models\LoyaltyPointTransaction;
 use Illuminate\Http\JsonResponse;
 
 class ProfilePointsController extends Controller
@@ -18,9 +19,25 @@ class ProfilePointsController extends Controller
         $totalEarned = (int) $transactions->sum(fn ($transaction) => max(0, (int) $transaction->points));
         $totalSpent = (int) $transactions->sum(fn ($transaction) => $transaction->points < 0 ? abs((int) $transaction->points) : 0);
 
+        $mappedTransactions = $transactions->map(function (LoyaltyPointTransaction $transaction) {
+            $meta = $transaction->meta;
+
+            return [
+                'id' => $transaction->id,
+                'order_id' => $transaction->order_id,
+                'type' => $transaction->type,
+                'points' => (int) $transaction->points,
+                'amount' => $transaction->amount,
+                'description' => $transaction->localized_description,
+                'meta' => $meta,
+                'created_at' => optional($transaction->created_at)?->toIso8601String(),
+                'updated_at' => optional($transaction->updated_at)?->toIso8601String(),
+            ];
+        });
+
         return response()->json([
             'balance' => $user->loyaltyPointsBalance(),
-            'transactions' => $transactions,
+            'transactions' => $mappedTransactions->values()->all(),
             'total_earned' => $totalEarned,
             'total_spent' => $totalSpent,
         ]);

--- a/app/Models/LoyaltyPointTransaction.php
+++ b/app/Models/LoyaltyPointTransaction.php
@@ -30,6 +30,21 @@ class LoyaltyPointTransaction extends Model
         'meta' => 'array',
     ];
 
+    public function getLocalizedDescriptionAttribute(): string
+    {
+        $meta = $this->meta;
+
+        if (is_array($meta) && isset($meta['key']) && is_string($meta['key']) && $meta['key'] !== '') {
+            $translation = __($meta['key'], $meta);
+
+            if ($translation !== $meta['key']) {
+                return $translation;
+            }
+        }
+
+        return (string) ($this->description ?? '');
+    }
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/database/factories/LoyaltyPointTransactionFactory.php
+++ b/database/factories/LoyaltyPointTransactionFactory.php
@@ -20,6 +20,7 @@ class LoyaltyPointTransactionFactory extends Factory
         $type = $points >= 0
             ? LoyaltyPointTransaction::TYPE_EARN
             : LoyaltyPointTransaction::TYPE_REDEEM;
+        $meta = $this->buildMeta($type, $points);
 
         return [
             'user_id' => User::factory(),
@@ -27,8 +28,8 @@ class LoyaltyPointTransactionFactory extends Factory
             'type' => $type,
             'points' => $points,
             'amount' => $this->amountForPoints($points),
-            'description' => $this->faker->sentence(),
-            'meta' => null,
+            'description' => __($meta['key'], $meta),
+            'meta' => $meta,
         ];
     }
 
@@ -37,10 +38,14 @@ class LoyaltyPointTransactionFactory extends Factory
         $value = abs($points ?? $this->faker->numberBetween(25, 200));
 
         return $this->state(function () use ($value) {
+            $meta = $this->buildMeta(LoyaltyPointTransaction::TYPE_EARN, $value);
+
             return [
                 'type' => LoyaltyPointTransaction::TYPE_EARN,
                 'points' => $value,
                 'amount' => $this->amountForPoints($value),
+                'description' => __($meta['key'], $meta),
+                'meta' => $meta,
             ];
         });
     }
@@ -50,10 +55,14 @@ class LoyaltyPointTransactionFactory extends Factory
         $value = abs($points ?? $this->faker->numberBetween(25, 150));
 
         return $this->state(function () use ($value) {
+            $meta = $this->buildMeta(LoyaltyPointTransaction::TYPE_REDEEM, -$value);
+
             return [
                 'type' => LoyaltyPointTransaction::TYPE_REDEEM,
                 'points' => -$value,
                 'amount' => $this->amountForPoints(-$value),
+                'description' => __($meta['key'], $meta),
+                'meta' => $meta,
             ];
         });
     }
@@ -64,10 +73,14 @@ class LoyaltyPointTransactionFactory extends Factory
         $value = $value === 0 ? 10 : $value;
 
         return $this->state(function () use ($value) {
+            $meta = $this->buildMeta(LoyaltyPointTransaction::TYPE_ADJUST, $value);
+
             return [
                 'type' => LoyaltyPointTransaction::TYPE_ADJUST,
                 'points' => $value,
                 'amount' => $this->amountForPoints($value),
+                'description' => __($meta['key'], $meta),
+                'meta' => $meta,
             ];
         });
     }
@@ -77,5 +90,23 @@ class LoyaltyPointTransactionFactory extends Factory
         $ratio = (float) config('shop.loyalty.redeem_value', 0.1);
 
         return round($points * $ratio, 2);
+    }
+
+    private function buildMeta(string $type, int $points): array
+    {
+        return match ($type) {
+            LoyaltyPointTransaction::TYPE_EARN => [
+                'key' => 'shop.loyalty.transaction.earn',
+                'points' => abs($points),
+            ],
+            LoyaltyPointTransaction::TYPE_REDEEM => [
+                'key' => 'shop.loyalty.transaction.redeem',
+                'points' => abs($points),
+            ],
+            default => [
+                'key' => 'shop.loyalty.transaction.adjustment',
+                'points' => $points,
+            ],
+        };
     }
 }

--- a/database/seeders/FullDemoSeeder.php
+++ b/database/seeders/FullDemoSeeder.php
@@ -442,25 +442,36 @@ class FullDemoSeeder extends Seeder
                 'factory' => LoyaltyPointTransaction::factory()->earn(180),
                 'user' => $users->get('repeat'),
                 'order' => $orders->get('paid'),
-                'description' => 'Points earned for paying order '.($orders->get('paid')?->number ?? ''),
+                'meta' => [
+                    'key' => 'shop.api.orders.points_earned_description',
+                    'number' => $orders->get('paid')?->number,
+                ],
             ],
             [
                 'factory' => LoyaltyPointTransaction::factory()->redeem(200),
                 'user' => $users->get('repeat'),
                 'order' => $orders->get('paid'),
-                'description' => 'Redeemed during checkout',
+                'meta' => [
+                    'key' => 'shop.loyalty.demo.checkout_redeem',
+                    'number' => $orders->get('paid')?->number,
+                ],
             ],
             [
                 'factory' => LoyaltyPointTransaction::factory()->earn(250),
                 'user' => $users->get('vip'),
                 'order' => $orders->get('shipped'),
-                'description' => 'Bonus for shipped order '.($orders->get('shipped')?->number ?? ''),
+                'meta' => [
+                    'key' => 'shop.loyalty.demo.shipped_bonus',
+                    'number' => $orders->get('shipped')?->number,
+                ],
             ],
             [
                 'factory' => LoyaltyPointTransaction::factory()->adjustment(-80),
                 'user' => $users->get('buyer'),
                 'order' => $orders->get('cancelled'),
-                'description' => 'Points returned after cancellation',
+                'meta' => [
+                    'key' => 'shop.loyalty.demo.cancellation_return',
+                ],
             ],
         ];
 
@@ -475,8 +486,12 @@ class FullDemoSeeder extends Seeder
                 $factory = $factory->for($order);
             }
 
+            $meta = array_filter($entry['meta'], fn ($value) => $value !== null && $value !== '');
+            $meta['key'] = $entry['meta']['key'];
+
             $factory->create([
-                'description' => $entry['description'],
+                'description' => __($meta['key'], $meta),
+                'meta' => $meta,
             ]);
         }
     }

--- a/resources/js/shop/api.tsx
+++ b/resources/js/shop/api.tsx
@@ -261,6 +261,7 @@ export type LoyaltyPointTransaction = {
     points: number | string;
     amount?: number | string | null;
     description?: string | null;
+    meta?: Record<string, unknown> | null;
     created_at?: string | null;
     updated_at?: string | null;
 };

--- a/resources/lang/en/shop.php
+++ b/resources/lang/en/shop.php
@@ -149,6 +149,19 @@ return [
         ],
     ],
 
+    'loyalty' => [
+        'transaction' => [
+            'earn' => 'Earned :points loyalty points.',
+            'redeem' => 'Redeemed :points loyalty points.',
+            'adjustment' => 'Points adjusted by :points.',
+        ],
+        'demo' => [
+            'checkout_redeem' => 'Redeemed during checkout',
+            'shipped_bonus' => 'Bonus for shipped order :number',
+            'cancellation_return' => 'Points returned after cancellation',
+        ],
+    ],
+
     'security' => [
         'two_factor' => [
             'not_initialized' => 'Two-factor authentication is not initialized.',

--- a/resources/lang/pt/shop.php
+++ b/resources/lang/pt/shop.php
@@ -149,6 +149,19 @@ return [
         ],
     ],
 
+    'loyalty' => [
+        'transaction' => [
+            'earn' => 'Acumulados :points pontos de fidelidade.',
+            'redeem' => 'Resgatados :points pontos de fidelidade.',
+            'adjustment' => 'Saldo ajustado em :points.',
+        ],
+        'demo' => [
+            'checkout_redeem' => 'Pontos resgatados no checkout',
+            'shipped_bonus' => 'Bônus pelo pedido enviado :number',
+            'cancellation_return' => 'Pontos devolvidos após cancelamento',
+        ],
+    ],
+
     'security' => [
         'two_factor' => [
             'not_initialized' => 'A autenticação em duas etapas não está configurada.',

--- a/resources/lang/ru/shop.php
+++ b/resources/lang/ru/shop.php
@@ -149,6 +149,19 @@ return [
         ],
     ],
 
+    'loyalty' => [
+        'transaction' => [
+            'earn' => 'Начислено :points баллов лояльности.',
+            'redeem' => 'Списано :points баллов лояльности.',
+            'adjustment' => 'Баланс изменён на :points.',
+        ],
+        'demo' => [
+            'checkout_redeem' => 'Баллы списаны при оформлении заказа',
+            'shipped_bonus' => 'Бонус за отправленный заказ :number',
+            'cancellation_return' => 'Баллы возвращены после отмены',
+        ],
+    ],
+
     'security' => [
         'two_factor' => [
             'not_initialized' => 'Двухфакторная аутентификация не настроена.',

--- a/resources/lang/uk/shop.php
+++ b/resources/lang/uk/shop.php
@@ -149,6 +149,19 @@ return [
         ],
     ],
 
+    'loyalty' => [
+        'transaction' => [
+            'earn' => 'Нараховано :points балів лояльності.',
+            'redeem' => 'Списано :points балів лояльності.',
+            'adjustment' => 'Баланс змінено на :points.',
+        ],
+        'demo' => [
+            'checkout_redeem' => 'Бали списано під час оформлення замовлення',
+            'shipped_bonus' => 'Бонус за відправлене замовлення :number',
+            'cancellation_return' => 'Бали повернено після скасування',
+        ],
+    ],
+
     'security' => [
         'two_factor' => [
             'not_initialized' => 'Двофакторну автентифікацію не налаштовано.',

--- a/tests/Feature/ProfilePointsTest.php
+++ b/tests/Feature/ProfilePointsTest.php
@@ -50,6 +50,8 @@ it('returns loyalty point summary for authenticated user', function () {
     $response->assertJsonCount(4, 'transactions');
 
     expect($response->json('transactions.0.id'))->toBe($latest->id);
+    expect($response->json('transactions.0.description'))->toBe(__($latest->meta['key'], $latest->meta));
+    expect($response->json('transactions.0.meta'))->toMatchArray($latest->meta);
 });
 
 it('requires authentication to view loyalty point summary', function () {


### PR DESCRIPTION
## Summary
- store translation metadata when creating loyalty transactions and expose localized descriptions in the API and Filament UI
- update factories, seed data, and translations to provide demo-friendly localized loyalty messaging
- adjust loyalty points feature tests to validate translated descriptions and metadata

## Testing
- ./vendor/bin/pest tests/Feature/LoyaltyPointsTest.php tests/Feature/ProfilePointsTest.php

------
https://chatgpt.com/codex/tasks/task_e_68ccddf33d388331abaae7cc3a4f5983