### PR TITLE
Refactor shop view locale config usage

### DIFF
--- a/resources/views/shop.blade.php
+++ b/resources/views/shop.blade.php
@@ -16,9 +16,11 @@
 
 
     @viteReactRefresh
+    @php($supportedLocales = config('app.supported_locales', ['uk', 'en', 'ru', 'pt']))
+    @php($defaultLocale = config('app.locale', 'uk'))
     <script>
-        window.__APP_SUPPORTED_LOCALES__ = @json(config('app.supported_locales', ['uk', 'en', 'ru', 'pt']));
-        window.__APP_DEFAULT_LOCALE__ = @json(config('app.locale', 'uk'));
+        window.__APP_SUPPORTED_LOCALES__ = @js($supportedLocales);
+        window.__APP_DEFAULT_LOCALE__ = @js($defaultLocale);
     </script>
     @vite('resources/js/shop/main.tsx')
 </head>


### PR DESCRIPTION
## Summary
- cache locale configuration values in shop view before usage
- expose cached values to the window using Blade's @js helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cce6eeb484833184556519f6d17e30