### PR TITLE
Add client-side password length validation for registration

### DIFF
--- a/resources/js/shop/i18n/messages/en.ts
+++ b/resources/js/shop/i18n/messages/en.ts
@@ -636,6 +636,7 @@ const messages = {
             submit: 'Create account',
             haveAccount: 'Already have an account?',
             signInLink: 'Sign in',
+            passwordTooShort: 'Password must be at least 8 characters.',
             passwordMismatch: 'Passwords do not match.',
             errorFallback: 'Could not sign up. Please try again.',
         },

--- a/resources/js/shop/i18n/messages/messages.test.ts
+++ b/resources/js/shop/i18n/messages/messages.test.ts
@@ -100,6 +100,7 @@ const keys: Array<{ key: TranslationKey; params?: Record<string, any> }> = [
     { key: 'auth.register.submit' },
     { key: 'auth.register.haveAccount' },
     { key: 'auth.register.signInLink' },
+    { key: 'auth.register.passwordTooShort' },
     { key: 'auth.register.passwordMismatch' },
     { key: 'auth.register.errorFallback' },
     { key: 'auth.login.title' },

--- a/resources/js/shop/i18n/messages/pt.ts
+++ b/resources/js/shop/i18n/messages/pt.ts
@@ -637,6 +637,7 @@ const messages = {
             submit: 'Criar conta',
             haveAccount: 'Já tem conta?',
             signInLink: 'Iniciar sessão',
+            passwordTooShort: 'A palavra-passe deve ter pelo menos 8 caracteres.',
             passwordMismatch: 'As palavras-passe não coincidem.',
             errorFallback: 'Não foi possível concluir o registo. Tente novamente.',
         },

--- a/resources/js/shop/i18n/messages/ru.ts
+++ b/resources/js/shop/i18n/messages/ru.ts
@@ -639,6 +639,7 @@ const messages = {
             submit: 'Создать аккаунт',
             haveAccount: 'Уже есть аккаунт?',
             signInLink: 'Войти',
+            passwordTooShort: 'Пароль должен содержать минимум 8 символов.',
             passwordMismatch: 'Пароли не совпадают.',
             errorFallback: 'Не удалось зарегистрироваться. Попробуйте ещё раз.',
         },

--- a/resources/js/shop/i18n/messages/uk.ts
+++ b/resources/js/shop/i18n/messages/uk.ts
@@ -637,6 +637,7 @@ const messages = {
             submit: 'Створити акаунт',
             haveAccount: 'Вже є акаунт?',
             signInLink: 'Увійти',
+            passwordTooShort: 'Пароль має містити щонайменше 8 символів.',
             passwordMismatch: 'Паролі не співпадають.',
             errorFallback: 'Не вдалося зареєструватися. Спробуйте ще раз.',
         },

--- a/resources/js/shop/pages/Register.tsx
+++ b/resources/js/shop/pages/Register.tsx
@@ -23,6 +23,11 @@ export default function RegisterPage() {
     const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         if (submitting) return;
+        const trimmedPassword = password.trim();
+        if (trimmedPassword.length < 8) {
+            setError(t('auth.register.passwordTooShort'));
+            return;
+        }
         if (password !== passwordConfirmation) {
             setError(t('auth.register.passwordMismatch'));
             return;


### PR DESCRIPTION
## Summary
- add a trimmed password length check to the registration form to block too-short submissions before contacting the server
- add the localized "password too short" message to the English, Ukrainian, Russian, and Portuguese catalogs
- cover the new translation key in the localization test suite

## Testing
- npm run test -- messages

------
https://chatgpt.com/codex/tasks/task_e_68cce9bb93cc83319aa288f1f3f8ca92