### PR TITLE
Localize Stripe webhook invalid signature response

### DIFF
--- a/app/Http/Controllers/StripeWebhookController.php
+++ b/app/Http/Controllers/StripeWebhookController.php
@@ -20,7 +20,7 @@ class StripeWebhookController extends Controller
             $event = Webhook::constructEvent($payload, $sigHeader, $secret);
         } catch (\Throwable $e) {
             Log::warning('Stripe webhook signature error: '.$e->getMessage());
-            return response()->json(['error' => 'invalid signature'], 400);
+            return response()->json(['error' => __('shop.api.payments.invalid_signature')], 400);
         }
 
         try {

--- a/resources/lang/en/shop.php
+++ b/resources/lang/en/shop.php
@@ -146,6 +146,7 @@ return [
         ],
         'payments' => [
             'missing_intent' => 'Payment intent is missing.',
+            'invalid_signature' => 'Invalid Stripe signature.',
         ],
     ],
 

--- a/resources/lang/pt/shop.php
+++ b/resources/lang/pt/shop.php
@@ -146,6 +146,7 @@ return [
         ],
         'payments' => [
             'missing_intent' => 'payment_intent ausente.',
+            'invalid_signature' => 'Assinatura do Stripe inválida.',
         ],
     ],
 

--- a/resources/lang/ru/shop.php
+++ b/resources/lang/ru/shop.php
@@ -146,6 +146,7 @@ return [
         ],
         'payments' => [
             'missing_intent' => 'Отсутствует payment_intent.',
+            'invalid_signature' => 'Недействительная подпись Stripe.',
         ],
     ],
 

--- a/resources/lang/uk/shop.php
+++ b/resources/lang/uk/shop.php
@@ -146,6 +146,7 @@ return [
         ],
         'payments' => [
             'missing_intent' => 'Відсутній payment_intent.',
+            'invalid_signature' => 'Недійсний підпис Stripe.',
         ],
     ],
 


### PR DESCRIPTION
## Summary
- return a localized message when the Stripe webhook signature validation fails
- add the new invalid signature translation to every supported language file

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccf2d3c2288331bea11bf4130f0097