### PR TITLE
Apply locale middleware to API requests

### DIFF
--- a/app/Http/Middleware/SetLocaleFromRequest.php
+++ b/app/Http/Middleware/SetLocaleFromRequest.php
@@ -35,8 +35,12 @@ class SetLocaleFromRequest
         $locale = null;
 
         // 1) prefix /{locale}/...
-        $seg1 = trim($request->segment(1) ?? '', '/');
-        $locale = $this->normalize($seg1);
+        $segment = $request->segment(1);
+        if ($segment === 'api') {
+            $segment = $request->segment(2);
+        }
+
+        $locale = $this->normalize(is_string($segment) ? trim($segment, '/') : null);
 
         // 2) cookie "lang"
         if (!$locale) {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,8 @@
 
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\SetLocaleFromRequest;
+use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -16,11 +18,22 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
-        $middleware->web(append: [
-            HandleAppearance::class,
-            HandleInertiaRequests::class,
-            AddLinkHeadersForPreloadedAssets::class,
+
+        $middleware->api(prepend: [
+            EncryptCookies::class,
+            SetLocaleFromRequest::class,
         ]);
+
+        $middleware->web(
+            prepend: [
+                SetLocaleFromRequest::class,
+            ],
+            append: [
+                HandleAppearance::class,
+                HandleInertiaRequests::class,
+                AddLinkHeadersForPreloadedAssets::class,
+            ],
+        );
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/tests/Feature/SetLocaleFromRequestTest.php
+++ b/tests/Feature/SetLocaleFromRequestTest.php
@@ -1,35 +1,47 @@
 <?php
 
-use App\Http\Middleware\SetLocaleFromRequest;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
 
 beforeEach(function () {
     Config::set('app.supported_locales', ['uk', 'en', 'ru', 'pt']);
     Config::set('app.fallback_locale', 'uk');
     App::setLocale('uk');
+
+    if (! Route::has('testing.locale.api.simple')) {
+        Route::prefix('api')->middleware('api')->group(function () {
+            Route::get('/test-locale', fn () => response()->json([
+                'locale' => app()->getLocale(),
+                'fallback' => config('app.fallback_locale'),
+            ]))
+                ->name('testing.locale.api.simple');
+
+            Route::get('/{locale}/test-locale', fn () => response()->json([
+                'locale' => app()->getLocale(),
+                'fallback' => config('app.fallback_locale'),
+            ]))
+                ->name('testing.locale.api.prefixed');
+        });
+    }
 });
 
 it('sets locale from url prefix including normalized variants', function (string $path, string $expected) {
-    $request = Request::create($path, 'GET');
-    $middleware = new SetLocaleFromRequest();
+    $response = $this->getJson($path);
 
-    $middleware->handle($request, fn () => null);
-
+    $response->assertOk();
+    expect($response->json('locale'))->toBe($expected);
     expect(App::getLocale())->toBe($expected);
 })->with([
-    ['/ru/products', 'ru'],
-    ['/pt-BR/catalog', 'pt'],
+    ['/api/ru/test-locale', 'ru'],
+    ['/api/pt-BR/test-locale', 'pt'],
 ]);
 
 it('sets locale from lang cookie with normalization', function (string $cookie, string $expected) {
-    $request = Request::create('/', 'GET');
-    $request->cookies->set('lang', $cookie);
-    $middleware = new SetLocaleFromRequest();
+    $response = $this->withCredentials()->withCookie('lang', $cookie)->getJson('/api/test-locale');
 
-    $middleware->handle($request, fn () => null);
-
+    $response->assertOk();
+    expect($response->json('locale'))->toBe($expected);
     expect(App::getLocale())->toBe($expected);
 })->with([
     ['RU', 'ru'],
@@ -37,11 +49,10 @@ it('sets locale from lang cookie with normalization', function (string $cookie, 
 ]);
 
 it('sets locale from accept language header with normalization', function (string $header, string $expected) {
-    $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT_LANGUAGE' => $header]);
-    $middleware = new SetLocaleFromRequest();
+    $response = $this->getJson('/api/test-locale', ['Accept-Language' => $header]);
 
-    $middleware->handle($request, fn () => null);
-
+    $response->assertOk();
+    expect($response->json('locale'))->toBe($expected);
     expect(App::getLocale())->toBe($expected);
 })->with([
     ['ru-RU,ru;q=0.8,en;q=0.5', 'ru'],


### PR DESCRIPTION
## Summary
- add SetLocaleFromRequest and cookie encryption to the API middleware stack and ensure the web stack also runs the resolver
- teach the locale middleware to recognize locale prefixes that follow the /api segment
- convert the SetLocaleFromRequest feature tests to issue HTTP requests against API routes that cover prefix, cookie, and Accept-Language scenarios

## Testing
- php artisan test --filter=SetLocaleFromRequestTest

------
https://chatgpt.com/codex/tasks/task_e_68ccf6760798833194af32366ebf4d9c