### PR TITLE
Localize order status error messages

### DIFF
--- a/app/Services/Orders/OrderStateService.php
+++ b/app/Services/Orders/OrderStateService.php
@@ -11,8 +11,14 @@ class OrderStateService
 {
     public function markPaid(Order $order): void
     {
-        if ($order->status !== OrderStatus::New) {
-            throw new DomainException('Only "new" orders can be marked as paid.');
+        $currentStatus = $this->currentStatus($order);
+
+        if ($currentStatus !== OrderStatus::New) {
+            throw new DomainException(__('shop.orders.errors.only_new_can_be_marked_paid', [
+                'required' => $this->localizedStatus(OrderStatus::New),
+                'status' => $this->localizedStatus($currentStatus),
+                'number' => $this->orderNumber($order),
+            ]));
         }
 
         DB::transaction(function () use ($order) {
@@ -23,8 +29,14 @@ class OrderStateService
 
     public function markShipped(Order $order): void
     {
-        if ($order->status !== OrderStatus::Paid) {
-            throw new DomainException('Only "paid" orders can be marked as shipped.');
+        $currentStatus = $this->currentStatus($order);
+
+        if ($currentStatus !== OrderStatus::Paid) {
+            throw new DomainException(__('shop.orders.errors.only_paid_can_be_marked_shipped', [
+                'required' => $this->localizedStatus(OrderStatus::Paid),
+                'status' => $this->localizedStatus($currentStatus),
+                'number' => $this->orderNumber($order),
+            ]));
         }
 
         DB::transaction(function () use ($order) {
@@ -35,8 +47,14 @@ class OrderStateService
 
     public function cancel(Order $order, ?string $reason = null): void
     {
-        if (!in_array($order->status, [OrderStatus::New, OrderStatus::Paid], true)) {
-            throw new DomainException('Only "new" or "paid" orders can be cancelled.');
+        $currentStatus = $this->currentStatus($order);
+
+        if (! in_array($currentStatus, [OrderStatus::New, OrderStatus::Paid], true)) {
+            throw new DomainException(__('shop.orders.errors.only_new_or_paid_can_be_cancelled', [
+                'allowed' => $this->localizedAllowedCancellationStatuses(),
+                'status' => $this->localizedStatus($currentStatus),
+                'number' => $this->orderNumber($order),
+            ]));
         }
 
         DB::transaction(function () use ($order) {
@@ -44,5 +62,30 @@ class OrderStateService
 
             $order->update(['status' => OrderStatus::Cancelled]);
         });
+    }
+
+    private function currentStatus(Order $order): OrderStatus
+    {
+        return $order->status instanceof OrderStatus
+            ? $order->status
+            : OrderStatus::from((string) $order->status);
+    }
+
+    private function localizedStatus(OrderStatus $status): string
+    {
+        return __('shop.orders.statuses.' . $status->value);
+    }
+
+    private function localizedAllowedCancellationStatuses(): string
+    {
+        return implode(', ', [
+            $this->localizedStatus(OrderStatus::New),
+            $this->localizedStatus(OrderStatus::Paid),
+        ]);
+    }
+
+    private function orderNumber(Order $order): string
+    {
+        return (string) ($order->number ?? $order->id);
     }
 }

--- a/resources/lang/en/shop.php
+++ b/resources/lang/en/shop.php
@@ -113,6 +113,17 @@ return [
         'status_updated' => [
             'subject_line' => 'Your order #:number status was updated',
         ],
+        'statuses' => [
+            'new' => 'new',
+            'paid' => 'paid',
+            'shipped' => 'shipped',
+            'cancelled' => 'cancelled',
+        ],
+        'errors' => [
+            'only_new_can_be_marked_paid' => 'Only orders with the ":required" status can be marked as paid. Order #:number is currently ":status".',
+            'only_paid_can_be_marked_shipped' => 'Only orders with the ":required" status can be marked as shipped. Order #:number is currently ":status".',
+            'only_new_or_paid_can_be_cancelled' => 'Only orders with the following statuses can be cancelled: :allowed. Order #:number is currently ":status".',
+        ],
     ],
 
     'api' => [

--- a/resources/lang/pt/shop.php
+++ b/resources/lang/pt/shop.php
@@ -113,6 +113,17 @@ return [
         'status_updated' => [
             'subject_line' => 'Status do pedido nº :number atualizado',
         ],
+        'statuses' => [
+            'new' => 'novo',
+            'paid' => 'pago',
+            'shipped' => 'enviado',
+            'cancelled' => 'cancelado',
+        ],
+        'errors' => [
+            'only_new_can_be_marked_paid' => 'Apenas pedidos com o status ":required" podem ser marcados como pagos. O pedido nº:number está atualmente com o status ":status".',
+            'only_paid_can_be_marked_shipped' => 'Apenas pedidos com o status ":required" podem ser marcados como enviados. O pedido nº:number está atualmente com o status ":status".',
+            'only_new_or_paid_can_be_cancelled' => 'Apenas pedidos com os seguintes status podem ser cancelados: :allowed. O pedido nº:number está atualmente com o status ":status".',
+        ],
     ],
 
     'api' => [

--- a/resources/lang/ru/shop.php
+++ b/resources/lang/ru/shop.php
@@ -113,6 +113,17 @@ return [
         'status_updated' => [
             'subject_line' => 'Статус вашего заказа №:number обновлён',
         ],
+        'statuses' => [
+            'new' => 'новый',
+            'paid' => 'оплачен',
+            'shipped' => 'отправлен',
+            'cancelled' => 'отменён',
+        ],
+        'errors' => [
+            'only_new_can_be_marked_paid' => 'Отметить оплаченным можно только заказ со статусом ":required". Заказ №:number сейчас имеет статус ":status".',
+            'only_paid_can_be_marked_shipped' => 'Отметить отправленным можно только заказ со статусом ":required". Заказ №:number сейчас имеет статус ":status".',
+            'only_new_or_paid_can_be_cancelled' => 'Отменить можно только заказы со статусами: :allowed. Заказ №:number сейчас имеет статус ":status".',
+        ],
     ],
 
     'api' => [

--- a/resources/lang/uk/shop.php
+++ b/resources/lang/uk/shop.php
@@ -113,6 +113,17 @@ return [
         'status_updated' => [
             'subject_line' => 'Ваше замовлення №:number: статус оновлено',
         ],
+        'statuses' => [
+            'new' => 'нове',
+            'paid' => 'оплачене',
+            'shipped' => 'відправлене',
+            'cancelled' => 'скасоване',
+        ],
+        'errors' => [
+            'only_new_can_be_marked_paid' => 'Позначати оплаченим можна лише замовлення зі статусом ":required". Замовлення №:number зараз має статус ":status".',
+            'only_paid_can_be_marked_shipped' => 'Позначати відправленим можна лише замовлення зі статусом ":required". Замовлення №:number зараз має статус ":status".',
+            'only_new_or_paid_can_be_cancelled' => 'Скасувати можна лише замовлення зі статусами: :allowed. Замовлення №:number зараз має статус ":status".',
+        ],
     ],
 
     'api' => [


### PR DESCRIPTION
## Summary
- localize the order status transition exceptions in the model and service with translated placeholders
- add helpers for retrieving localized status labels when composing errors
- define reusable order status labels and error messages across English, Ukrainian, Russian, and Portuguese locales

## Testing
- vendor/bin/pest --filter=OrderStatusActionsTest
- vendor/bin/pest tests/Feature/OrderEmailsTest.php tests/Feature/OrderFlowTest.php tests/Feature/ProfileOrdersTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cd04a87d20833198f10a9734679f68