### PR TITLE
Add translation support for catalog entities

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasTranslations;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,18 +11,27 @@ use Illuminate\Support\Facades\Cache;
 
 class Category extends Model
 {
-
     use HasFactory;
+    use HasTranslations {
+        HasTranslations::initializeHasTranslations as protected initializeTranslationsTrait;
+    }
 
     public const CACHE_KEY_FLAT = 'categories:index:flat';
     public const CACHE_KEY_TREE = 'categories:index:tree';
 
-    protected $fillable = ['name', 'slug', 'parent_id', 'is_active'];
+    protected $fillable = ['name', 'name_translations', 'slug', 'parent_id', 'is_active'];
 
     protected $casts = [
         'is_active' => 'boolean',
         'parent_id' => 'integer',
+        'name_translations' => 'array',
     ];
+
+    public function initializeHasTranslations(): void
+    {
+        $this->translatable = ['name'];
+        $this->initializeTranslationsTrait();
+    }
 
     protected static function booted(): void
     {

--- a/app/Models/Concerns/HasTranslations.php
+++ b/app/Models/Concerns/HasTranslations.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Models\Concerns;
+
+trait HasTranslations
+{
+    protected array $translatable = [];
+
+    public function initializeHasTranslations(): void
+    {
+        foreach ($this->getTranslatableAttributes() as $attribute) {
+            $column = $this->getTranslationColumn($attribute);
+            if (! array_key_exists($column, $this->casts)) {
+                $this->casts[$column] = 'array';
+            }
+        }
+    }
+
+    public function getAttribute($key)
+    {
+        if ($this->isTranslatableAttribute($key)) {
+            $translations = parent::getAttribute($this->getTranslationColumn($key));
+
+            if (is_array($translations)) {
+                $locale = app()->getLocale();
+                if ($this->hasTranslationValue($translations, $locale)) {
+                    return $translations[$locale];
+                }
+
+                $fallback = config('app.fallback_locale');
+                if ($fallback && $this->hasTranslationValue($translations, $fallback)) {
+                    return $translations[$fallback];
+                }
+            }
+        }
+
+        return parent::getAttribute($key);
+    }
+
+    public function setAttribute($key, $value)
+    {
+        if ($this->isTranslatableAttribute($key)) {
+            $column = $this->getTranslationColumn($key);
+            $translations = parent::getAttribute($column);
+            if (! is_array($translations)) {
+                $translations = [];
+            }
+
+            if (is_array($value)) {
+                foreach ($value as $locale => $text) {
+                    if ($text === null) {
+                        unset($translations[$locale]);
+                    } else {
+                        $translations[$locale] = $text;
+                    }
+                }
+            } else {
+                $translations[app()->getLocale()] = $value;
+            }
+
+            parent::setAttribute($column, $translations);
+
+            $baseLocale = config('app.locale');
+            $fallbackLocale = config('app.fallback_locale');
+
+            $baseValue = $translations[$baseLocale] ?? null;
+            if ($baseValue === null && $fallbackLocale) {
+                $baseValue = $translations[$fallbackLocale] ?? null;
+            }
+
+            if ($baseValue === null && ! is_array($value)) {
+                $baseValue = $value;
+            }
+
+            return parent::setAttribute($key, $baseValue);
+        }
+
+        return parent::setAttribute($key, $value);
+    }
+
+    protected function getTranslationColumn(string $attribute): string
+    {
+        return $attribute . '_translations';
+    }
+
+    protected function isTranslatableAttribute(string $attribute): bool
+    {
+        return in_array($attribute, $this->getTranslatableAttributes(), true);
+    }
+
+    protected function getTranslatableAttributes(): array
+    {
+        return $this->translatable ?? [];
+    }
+
+    protected function hasTranslationValue(array $translations, string $locale): bool
+    {
+        return array_key_exists($locale, $translations)
+            && $translations[$locale] !== null
+            && $translations[$locale] !== '';
+    }
+}

--- a/app/Models/Coupon.php
+++ b/app/Models/Coupon.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\OrderStatus;
+use App\Models\Concerns\HasTranslations;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -13,6 +14,9 @@ use Illuminate\Support\Carbon;
 class Coupon extends Model
 {
     use HasFactory;
+    use HasTranslations {
+        HasTranslations::initializeHasTranslations as protected initializeTranslationsTrait;
+    }
 
     public const TYPE_FIXED = 'fixed';
     public const TYPE_PERCENT = 'percent';
@@ -20,7 +24,9 @@ class Coupon extends Model
     protected $fillable = [
         'code',
         'name',
+        'name_translations',
         'description',
+        'description_translations',
         'type',
         'value',
         'min_cart_total',
@@ -45,7 +51,15 @@ class Coupon extends Model
         'expires_at' => 'datetime',
         'is_active' => 'boolean',
         'meta' => 'array',
+        'name_translations' => 'array',
+        'description_translations' => 'array',
     ];
+
+    public function initializeHasTranslations(): void
+    {
+        $this->translatable = ['name', 'description'];
+        $this->initializeTranslationsTrait();
+    }
 
     public function scopeActive(Builder $builder): Builder
     {

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasTranslations;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -14,12 +15,17 @@ use Illuminate\Support\Facades\DB;
 
 class Product extends Model
 {
-    use HasFactory, Searchable;
+    use HasFactory;
+    use HasTranslations {
+        HasTranslations::initializeHasTranslations as protected initializeTranslationsTrait;
+    }
+    use Searchable;
 
     public const FACETS_CACHE_VERSION_KEY = 'products:facets:version';
 
     protected $fillable = [
         'name',
+        'name_translations',
         'slug',
         'sku',
         'category_id',
@@ -42,7 +48,14 @@ class Product extends Model
         'price_old' => 'decimal:2',
         'reviews_count' => 'integer',
         'rating' => 'decimal:2',
+        'name_translations' => 'array',
     ];
+
+    public function initializeHasTranslations(): void
+    {
+        $this->translatable = ['name'];
+        $this->initializeTranslationsTrait();
+    }
 
 
     protected static function boot()
@@ -323,6 +336,7 @@ class Product extends Model
         return [
             'id' => $this->id,
             'name' => $this->name,
+            'name_translations' => $this->name_translations,
             'slug' => $this->slug,
             'sku' => $this->sku,
             'category_id' => $this->category_id,

--- a/app/Models/ProductImage.php
+++ b/app/Models/ProductImage.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasTranslations;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -12,14 +13,24 @@ use Illuminate\Support\Facades\Storage;
 class ProductImage extends Model
 {
     use HasFactory;
+    use HasTranslations {
+        HasTranslations::initializeHasTranslations as protected initializeTranslationsTrait;
+    }
 
     protected $appends = ['url'];
 
-    protected $fillable = ['product_id', 'disk', 'path', 'alt','sort','is_primary'];
+    protected $fillable = ['product_id', 'disk', 'path', 'alt','alt_translations','sort','is_primary'];
 
     protected $casts = [
         'sort' => 'integer',
+        'alt_translations' => 'array',
     ];
+
+    public function initializeHasTranslations(): void
+    {
+        $this->translatable = ['alt'];
+        $this->initializeTranslationsTrait();
+    }
 
     protected static function booted(): void
     {

--- a/app/Models/Vendor.php
+++ b/app/Models/Vendor.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasTranslations;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -11,15 +12,31 @@ use Illuminate\Database\Eloquent\Builder;
 class Vendor extends Model
 {
     use HasFactory;
+    use HasTranslations {
+        HasTranslations::initializeHasTranslations as protected initializeTranslationsTrait;
+    }
 
     protected $fillable = [
         'user_id',
         'name',
+        'name_translations',
         'slug',
         'contact_email',
         'contact_phone',
         'description',
+        'description_translations',
     ];
+
+    protected $casts = [
+        'name_translations' => 'array',
+        'description_translations' => 'array',
+    ];
+
+    public function initializeHasTranslations(): void
+    {
+        $this->translatable = ['name', 'description'];
+        $this->initializeTranslationsTrait();
+    }
 
     public function user(): BelongsTo
     {

--- a/app/Models/Warehouse.php
+++ b/app/Models/Warehouse.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasTranslations;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -9,12 +10,28 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Warehouse extends Model
 {
     use HasFactory;
+    use HasTranslations {
+        HasTranslations::initializeHasTranslations as protected initializeTranslationsTrait;
+    }
 
     protected $fillable = [
         'code',
         'name',
+        'name_translations',
         'description',
+        'description_translations',
     ];
+
+    protected $casts = [
+        'name_translations' => 'array',
+        'description_translations' => 'array',
+    ];
+
+    public function initializeHasTranslations(): void
+    {
+        $this->translatable = ['name', 'description'];
+        $this->initializeTranslationsTrait();
+    }
 
     public function stocks(): HasMany
     {
@@ -27,6 +44,8 @@ class Warehouse extends Model
             ?? static::create([
                 'code' => 'MAIN',
                 'name' => 'Main Warehouse',
+                'name_translations' => [config('app.locale') => 'Main Warehouse'],
+                'description_translations' => [],
             ]);
     }
 }

--- a/app/Observers/ProductObserver.php
+++ b/app/Observers/ProductObserver.php
@@ -15,7 +15,7 @@ class ProductObserver
 
     public function updated(Product $product): void
     {
-        if ($product->wasChanged(['name','slug','sku','category_id','price','stock','is_active','attributes'])) {
+        if ($product->wasChanged(['name','name_translations','slug','sku','category_id','price','stock','is_active','attributes'])) {
             $product->shouldBeSearchable()
                 ? $product->searchable()
                 : $product->unsearchable();

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -19,9 +19,11 @@ class CategoryFactory extends Factory
     public function definition(): array
     {
         $name = $this->faker->unique()->words(mt_rand(1, 2), true);
+        $locale = config('app.locale');
 
         return [
             'name' => $name,
+            'name_translations' => [$locale => $name],
             'slug' => Str::slug($name) . '-' . Str::lower(Str::random(6)),
             'parent_id' => null,
             'is_active' => true,

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -40,6 +40,7 @@ class ProductFactory extends Factory
     {
         $name = ucfirst($this->faker->unique()->words(3, true));
         $price = $this->faker->randomFloat(2, 10, 500);
+        $locale = config('app.locale');
 
         $colors = [
             'чорний',
@@ -58,6 +59,7 @@ class ProductFactory extends Factory
 
         return [
             'name' => $name,
+            'name_translations' => [$locale => $name],
             'slug' => Str::slug($name) . '-' . Str::lower(Str::random(6)),
             'sku' => Str::upper(Str::random(10)),
             'category_id' => Category::factory(),

--- a/database/factories/ProductImageFactory.php
+++ b/database/factories/ProductImageFactory.php
@@ -20,9 +20,13 @@ class ProductImageFactory extends Factory
      */
     public function definition(): array
     {
+        $locale = config('app.locale');
+        $alt = fake()->words(3, true);
+
         return [
             'path'       => 'products/tmp/'.fake()->uuid().'.png', // справжній шлях виставимо в сідері
-            'alt'        => fake()->words(3, true),
+            'alt'        => $alt,
+            'alt_translations' => [$locale => $alt],
             'disk'       => 'public',
             'sort'       => 0,
             'is_primary' => false,

--- a/database/factories/VendorFactory.php
+++ b/database/factories/VendorFactory.php
@@ -17,14 +17,18 @@ class VendorFactory extends Factory
     public function definition(): array
     {
         $name = $this->faker->unique()->company();
+        $locale = config('app.locale');
+        $description = $this->faker->optional()->sentence(10);
 
         return [
             'user_id' => User::factory(),
             'name' => $name,
+            'name_translations' => [$locale => $name],
             'slug' => Str::slug($name) . '-' . Str::lower(Str::random(5)),
             'contact_email' => $this->faker->unique()->companyEmail(),
             'contact_phone' => $this->faker->phoneNumber(),
-            'description' => $this->faker->optional()->sentence(10),
+            'description' => $description,
+            'description_translations' => $description !== null ? [$locale => $description] : [],
         ];
     }
 }

--- a/database/factories/WarehouseFactory.php
+++ b/database/factories/WarehouseFactory.php
@@ -12,10 +12,16 @@ class WarehouseFactory extends Factory
 
     public function definition(): array
     {
+        $locale = config('app.locale');
+        $name = $this->faker->unique()->company . ' Warehouse';
+        $description = $this->faker->optional()->sentence();
+
         return [
             'code' => Str::upper('WH-' . $this->faker->unique()->lexify('????')),
-            'name' => $this->faker->unique()->company . ' Warehouse',
-            'description' => $this->faker->optional()->sentence(),
+            'name' => $name,
+            'name_translations' => [$locale => $name],
+            'description' => $description,
+            'description_translations' => $description !== null ? [$locale => $description] : [],
         ];
     }
 }

--- a/database/migrations/2025_10_08_000200_add_translations_to_catalog.php
+++ b/database/migrations/2025_10_08_000200_add_translations_to_catalog.php
@@ -1,0 +1,104 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $locale = config('app.locale');
+
+        Schema::table('categories', function (Blueprint $table) {
+            $table->json('name_translations')->nullable()->after('name');
+        });
+
+        Schema::table('products', function (Blueprint $table) {
+            $table->json('name_translations')->nullable()->after('name');
+        });
+
+        Schema::table('vendors', function (Blueprint $table) {
+            $table->json('name_translations')->nullable()->after('name');
+            $table->json('description_translations')->nullable()->after('description');
+        });
+
+        Schema::table('warehouses', function (Blueprint $table) {
+            $table->json('name_translations')->nullable()->after('name');
+            $table->json('description_translations')->nullable()->after('description');
+        });
+
+        Schema::table('coupons', function (Blueprint $table) {
+            $table->json('name_translations')->nullable()->after('name');
+            $table->json('description_translations')->nullable()->after('description');
+        });
+
+        Schema::table('product_images', function (Blueprint $table) {
+            $table->json('alt_translations')->nullable()->after('alt');
+        });
+
+        $this->copyExistingValues('categories', 'name', 'name_translations', $locale);
+        $this->copyExistingValues('products', 'name', 'name_translations', $locale);
+        $this->copyExistingValues('vendors', 'name', 'name_translations', $locale);
+        $this->copyExistingValues('vendors', 'description', 'description_translations', $locale);
+        $this->copyExistingValues('warehouses', 'name', 'name_translations', $locale);
+        $this->copyExistingValues('warehouses', 'description', 'description_translations', $locale);
+        $this->copyExistingValues('coupons', 'name', 'name_translations', $locale);
+        $this->copyExistingValues('coupons', 'description', 'description_translations', $locale);
+        $this->copyExistingValues('product_images', 'alt', 'alt_translations', $locale);
+    }
+
+    public function down(): void
+    {
+        Schema::table('product_images', function (Blueprint $table) {
+            $table->dropColumn('alt_translations');
+        });
+
+        Schema::table('coupons', function (Blueprint $table) {
+            $table->dropColumn(['name_translations', 'description_translations']);
+        });
+
+        Schema::table('warehouses', function (Blueprint $table) {
+            $table->dropColumn(['name_translations', 'description_translations']);
+        });
+
+        Schema::table('vendors', function (Blueprint $table) {
+            $table->dropColumn(['name_translations', 'description_translations']);
+        });
+
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('name_translations');
+        });
+
+        Schema::table('categories', function (Blueprint $table) {
+            $table->dropColumn('name_translations');
+        });
+    }
+
+    protected function copyExistingValues(string $table, string $sourceColumn, string $targetColumn, string $locale): void
+    {
+        if (! Schema::hasColumn($table, $sourceColumn)) {
+            return;
+        }
+
+        DB::table($table)
+            ->select('id', $sourceColumn)
+            ->orderBy('id')
+            ->chunkById(100, function ($rows) use ($table, $sourceColumn, $targetColumn, $locale) {
+                foreach ($rows as $row) {
+                    $value = $row->{$sourceColumn};
+
+                    if ($value === null) {
+                        continue;
+                    }
+
+                    DB::table($table)
+                        ->where('id', $row->id)
+                        ->update([
+                            $targetColumn => json_encode([$locale => $value], JSON_UNESCAPED_UNICODE),
+                        ]);
+                }
+            });
+    }
+};

--- a/tests/Feature/CategoriesCacheTest.php
+++ b/tests/Feature/CategoriesCacheTest.php
@@ -2,9 +2,12 @@
 
 use App\Models\Category;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
 
 beforeEach(function () {
     Cache::flush();
+    app()->setLocale(config('app.locale'));
+    Config::set('app.fallback_locale', 'en');
 });
 
 it('returns categories from cache', function () {
@@ -37,4 +40,24 @@ it('clears cached categories on changes', function () {
 
     expect(Cache::has(Category::CACHE_KEY_FLAT))->toBeFalse();
     expect(Cache::has(Category::CACHE_KEY_TREE))->toBeFalse();
+});
+
+it('returns localized category names for different locales from cache', function () {
+    $category = Category::factory()->create([
+        'name' => 'Категорії',
+        'name_translations' => [
+            'uk' => 'Категорії',
+            'en' => 'Categories',
+        ],
+    ]);
+
+    $this->getJson('/api/categories')
+        ->assertOk()
+        ->assertJsonPath('0.name', 'Категорії');
+
+    app()->setLocale('en');
+
+    $this->getJson('/api/categories')
+        ->assertOk()
+        ->assertJsonPath('0.name', 'Categories');
 });

--- a/tests/Feature/ProductTranslationsTest.php
+++ b/tests/Feature/ProductTranslationsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Models\Product;
+use Illuminate\Support\Facades\Config;
+
+beforeEach(function () {
+    app()->setLocale(config('app.locale'));
+    Config::set('app.fallback_locale', 'en');
+});
+
+it('returns localized names with fallback to configured fallback locale', function () {
+    $product = Product::factory()->create([
+        'name' => 'Ноутбук',
+        'name_translations' => [
+            'uk' => 'Ноутбук',
+            'en' => 'Laptop',
+        ],
+    ]);
+
+    app()->setLocale('uk');
+    expect($product->fresh()->name)->toBe('Ноутбук');
+
+    app()->setLocale('en');
+    expect($product->fresh()->name)->toBe('Laptop');
+
+    app()->setLocale('pl');
+    expect($product->fresh()->name)->toBe('Laptop');
+});
+
+it('falls back to legacy attribute when translations are missing', function () {
+    $product = Product::factory()->create([
+        'name' => 'Стара назва',
+        'name_translations' => null,
+    ]);
+
+    app()->setLocale('en');
+
+    expect($product->fresh()->name)->toBe('Стара назва');
+});
+
+it('saves translations for the current locale when assigning attributes', function () {
+    $product = Product::factory()->create([
+        'name' => 'Ноутбук',
+        'name_translations' => [
+            'uk' => 'Ноутбук',
+        ],
+    ]);
+
+    app()->setLocale('en');
+    $product->name = 'Laptop';
+    $product->save();
+
+    $product->refresh();
+
+    expect($product->name_translations)->toHaveKey('en', 'Laptop');
+
+    app()->setLocale('en');
+    expect($product->fresh()->name)->toBe('Laptop');
+
+    app()->setLocale('uk');
+    expect($product->fresh()->name)->toBe('Ноутбук');
+});


### PR DESCRIPTION
## Summary
- add a translation trait that handles localized getters/setters with locale fallback
- add migration that introduces *_translations columns and backfills existing values
- update catalog models, factories, and observers to work with JSON translations and add feature coverage for product translations and cached categories

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68cd097eaa6c8331aa098efeb9867a81