### PR TITLE
Localize inventory domain exceptions

### DIFF
--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -77,7 +77,10 @@ class OrderController extends Controller
 
             foreach ($cart->items as $item) {
                 if ($item->product->availableStock($warehouse->id) < $item->qty) {
-                    abort(422, __('shop.api.orders.insufficient_stock', ['product' => $item->product_id]));
+                    abort(422, __('shop.inventory.not_enough_stock', [
+                        'product_id' => $item->product_id,
+                        'warehouse_id' => $warehouse->id,
+                    ]));
                 }
             }
 
@@ -108,7 +111,7 @@ class OrderController extends Controller
                 try {
                     $item->product->reserveStock($item->qty, $warehouse->id);
                 } catch (DomainException $e) {
-                    abort(422, __('shop.api.orders.insufficient_stock', ['product' => $item->product_id]));
+                    abort(422, $e->getMessage());
                 }
             }
 

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -226,7 +226,13 @@ class Product extends Model
             $newQty = $stock->qty + $delta;
 
             if ($newQty < $stock->reserved) {
-                throw new \DomainException("Not enough stock for product {$this->id} at warehouse {$warehouseId}");
+                throw new \DomainException(__(
+                    'shop.inventory.not_enough_stock',
+                    [
+                        'product_id' => $this->id,
+                        'warehouse_id' => $warehouseId,
+                    ]
+                ));
             }
 
             $stock->qty = $newQty;
@@ -250,7 +256,13 @@ class Product extends Model
             $available = $stock->qty - $stock->reserved;
 
             if ($available < $qty) {
-                throw new \DomainException("Not enough stock for product {$this->id} at warehouse {$warehouseId}");
+                throw new \DomainException(__(
+                    'shop.inventory.not_enough_stock',
+                    [
+                        'product_id' => $this->id,
+                        'warehouse_id' => $warehouseId,
+                    ]
+                ));
             }
 
             $stock->reserved += $qty;
@@ -300,15 +312,33 @@ class Product extends Model
                 ->first();
 
             if (! $stock) {
-                throw new \DomainException("Not enough stock for product {$this->id} at warehouse {$warehouseId}");
+                throw new \DomainException(__(
+                    'shop.inventory.not_enough_stock',
+                    [
+                        'product_id' => $this->id,
+                        'warehouse_id' => $warehouseId,
+                    ]
+                ));
             }
 
             if ($stock->reserved < $qty) {
-                throw new \DomainException("Not enough reserved stock for product {$this->id} at warehouse {$warehouseId}");
+                throw new \DomainException(__(
+                    'shop.inventory.not_enough_reserved_stock',
+                    [
+                        'product_id' => $this->id,
+                        'warehouse_id' => $warehouseId,
+                    ]
+                ));
             }
 
             if ($stock->qty < $qty) {
-                throw new \DomainException("Not enough stock for product {$this->id} at warehouse {$warehouseId}");
+                throw new \DomainException(__(
+                    'shop.inventory.not_enough_stock',
+                    [
+                        'product_id' => $this->id,
+                        'warehouse_id' => $warehouseId,
+                    ]
+                ));
             }
 
             $stock->reserved -= $qty;

--- a/resources/lang/en/shop.php
+++ b/resources/lang/en/shop.php
@@ -126,6 +126,11 @@ return [
         ],
     ],
 
+    'inventory' => [
+        'not_enough_stock' => 'Not enough stock for product #:product_id at warehouse #:warehouse_id.',
+        'not_enough_reserved_stock' => 'Not enough reserved stock for product #:product_id at warehouse #:warehouse_id.',
+    ],
+
     'api' => [
         'common' => [
             'not_found' => 'Resource not found.',

--- a/resources/lang/pt/shop.php
+++ b/resources/lang/pt/shop.php
@@ -126,6 +126,11 @@ return [
         ],
     ],
 
+    'inventory' => [
+        'not_enough_stock' => 'Estoque insuficiente para o produto nº :product_id no depósito nº :warehouse_id.',
+        'not_enough_reserved_stock' => 'Estoque reservado insuficiente para o produto nº :product_id no depósito nº :warehouse_id.',
+    ],
+
     'api' => [
         'common' => [
             'not_found' => 'Recurso não encontrado.',

--- a/resources/lang/ru/shop.php
+++ b/resources/lang/ru/shop.php
@@ -126,6 +126,11 @@ return [
         ],
     ],
 
+    'inventory' => [
+        'not_enough_stock' => 'Недостаточно товара для продукта №:product_id на складе №:warehouse_id.',
+        'not_enough_reserved_stock' => 'Недостаточно зарезервированного товара для продукта №:product_id на складе №:warehouse_id.',
+    ],
+
     'api' => [
         'common' => [
             'not_found' => 'Ресурс не найден.',

--- a/resources/lang/uk/shop.php
+++ b/resources/lang/uk/shop.php
@@ -126,6 +126,11 @@ return [
         ],
     ],
 
+    'inventory' => [
+        'not_enough_stock' => 'Недостатньо товару для продукту №:product_id на складі №:warehouse_id.',
+        'not_enough_reserved_stock' => 'Недостатньо зарезервованого товару для продукту №:product_id на складі №:warehouse_id.',
+    ],
+
     'api' => [
         'common' => [
             'not_found' => 'Ресурс не знайдено.',


### PR DESCRIPTION
## Summary
- localize inventory-related DomainException messages in `Product` to use translation placeholders for product and warehouse identifiers
- add new `shop.inventory` translations across English, Ukrainian, Russian, and Portuguese locales
- ensure the order API surfaces localized inventory errors when validating stock and catching DomainExceptions

## Testing
- php artisan test --filter=OrderFlowTest

------
https://chatgpt.com/codex/tasks/task_e_68cd5aff539483318946ad3c95f553f5