### PR TITLE
Allow Accept-Language to select English locale

### DIFF
--- a/app/Http/Middleware/SetLocaleFromRequest.php
+++ b/app/Http/Middleware/SetLocaleFromRequest.php
@@ -58,7 +58,7 @@ class SetLocaleFromRequest
             $first = Str::of((string) $first)->before(';')->value();
             $candidate = $this->normalize($first);
 
-            if ($candidate && ! ($candidate === 'en' && $this->fallback === 'uk')) {
+            if ($candidate) {
                 $locale = $candidate;
             }
         }

--- a/tests/Feature/SetLocaleFromRequestTest.php
+++ b/tests/Feature/SetLocaleFromRequestTest.php
@@ -57,4 +57,5 @@ it('sets locale from accept language header with normalization', function (strin
 })->with([
     ['ru-RU,ru;q=0.8,en;q=0.5', 'ru'],
     ['pt-BR,pt;q=0.9,en;q=0.8', 'pt'],
+    ['en-US,en;q=0.9', 'en'],
 ]);


### PR DESCRIPTION
## Summary
- remove the guard that blocked Accept-Language from selecting English when fallback was Ukrainian
- extend the locale middleware feature test to cover an English Accept-Language header

## Testing
- php artisan test tests/Feature/SetLocaleFromRequestTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cd78ab80788331ac87842c6bf347e0