### PR TITLE
Handle numeric category facets

### DIFF
--- a/resources/js/shop/api.tsx
+++ b/resources/js/shop/api.tsx
@@ -147,12 +147,16 @@ export type Cart = {
 };
 export type FacetEntry = {
     value: string;
-    label: string;
+    label?: string;
     count: number;
     translations?: Record<string, string | null> | null;
 };
 
-export type Facets = Record<string, Record<string, FacetEntry>>;
+export type CategoryFacetPayload = Record<string, FacetEntry | number> | FacetEntry[];
+
+export type Facets = Partial<
+    Record<string, Record<string, FacetEntry> | CategoryFacetPayload>
+>;
 
 export type PaginatedWithFacets<T> = Paginated<T> & {
     facets?: Facets;
@@ -439,7 +443,7 @@ export async function fetchProductFacets(params: { search?: string; category_id?
     const { data } = await api.get(`/products/facets?${sp.toString()}`);
     return data as {
         facets: {
-            ['category_id']?: Record<string, FacetEntry>;
+            ['category_id']?: CategoryFacetPayload;
             ['attrs.color']?: Record<string, FacetEntry>;
             ['attrs.size']?: Record<string, FacetEntry>;
         };

--- a/resources/js/shop/pages/Catalog.test.tsx
+++ b/resources/js/shop/pages/Catalog.test.tsx
@@ -208,6 +208,54 @@ describe('Catalog page', () => {
         expect(colorButtons[0]).toHaveTextContent('(7)');
     });
 
+    it('renders category facets provided as numeric counts', async () => {
+        const product = {
+            id: 404,
+            name: 'Категорійний товар',
+            slug: 'category-product',
+            price: 1099,
+            images: [],
+            stock: 3,
+        };
+
+        fetchCategoriesMock.mockResolvedValueOnce([
+            { id: 10, name: 'Кросівки' },
+            { id: 20, name: 'Сандалі' },
+        ]);
+        fetchProductsMock.mockResolvedValueOnce({
+            data: [product],
+            current_page: 1,
+            last_page: 1,
+            per_page: 12,
+            total: 1,
+            from: 1,
+            to: 1,
+            facets: {
+                category_id: {
+                    '10': 4,
+                    '20': 2,
+                    misc: 1,
+                },
+            },
+        });
+
+        render(
+            <MemoryRouter>
+                <Catalog />
+            </MemoryRouter>
+        );
+
+        const firstCategory = await screen.findByTestId('facet-cat-10');
+        expect(firstCategory).toHaveTextContent('Кросівки');
+        expect(firstCategory).toHaveTextContent('(4)');
+
+        const secondCategory = await screen.findByTestId('facet-cat-20');
+        expect(secondCategory).toHaveTextContent('Сандалі');
+        expect(secondCategory).toHaveTextContent('(2)');
+
+        expect(screen.queryByTestId('facet-cat-misc')).not.toBeInTheDocument();
+    });
+
     it('disables buying for products with zero stock', async () => {
         const user = userEvent.setup();
         fetchProductsMock.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- allow the API client to accept numeric category facet responses and optional labels
- normalize category facet entries in the catalog page and fall back to category names for labels
- extend catalog page tests to cover numeric category facet payloads

## Testing
- npm test -- Catalog

------
https://chatgpt.com/codex/tasks/task_e_68cd9fcf9d308331b71a3adb39d21d4f