### PR TITLE
Set Accept-Language header for shop API locale

### DIFF
--- a/resources/js/shop/api.tsx
+++ b/resources/js/shop/api.tsx
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { normalizeLang, resolveLocale, type Lang } from './i18n/config';
 import type { WishItem } from './ui/wishlist';
 
 const API_BASE = (import.meta as any).env?.VITE_API_URL || 'http://localhost:8080/api';
@@ -7,6 +8,23 @@ export const api = axios.create({
     baseURL: API_BASE,
     withCredentials: true, // потрібні cookie (cart_id)
 });
+
+export function setApiLocale(lang: Lang) {
+    const locale = resolveLocale(lang);
+
+    api.defaults.headers.common['Accept-Language'] = locale;
+
+    const headers = api.defaults.headers as typeof api.defaults.headers & { set?: (name: string, value: string) => void };
+    headers.set?.('Accept-Language', locale);
+}
+
+const initialDocumentLang = typeof document !== 'undefined' ? document.documentElement.getAttribute('lang') : '';
+const initialNavigatorLang = typeof navigator !== 'undefined' ? navigator.language : '';
+const initialLangCandidate = initialDocumentLang || initialNavigatorLang;
+
+if (initialLangCandidate) {
+    setApiLocale(normalizeLang(initialLangCandidate));
+}
 
 /* ==================== TYPES ==================== */
 export type AuthUser = {

--- a/resources/js/shop/i18n/LocaleProvider.tsx
+++ b/resources/js/shop/i18n/LocaleProvider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { DEFAULT_LANG, Lang, normalizeLang, resolveLocale } from './config';
+import { setApiLocale } from '../api';
 import { createTranslator, getMessages, type Messages, type Translator } from './messages';
 
 type Ctx = { lang: Lang; locale: string; setLang: (l: Lang) => void; messages: Messages; t: Translator };
@@ -24,6 +25,8 @@ export default function LocaleProvider({ initial, children }: { initial?: string
     }, [initial]);
 
     useEffect(() => {
+        setApiLocale(lang);
+
         // <html lang="...">
         if (typeof document !== 'undefined') {
             document.documentElement.setAttribute('lang', lang);


### PR DESCRIPTION
## Summary
- add a helper to synchronize the axios Accept-Language header with the active language
- initialize the API locale from the document/navigator language and update it when the locale provider changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cda8f79fc88331aa3a5d7542b74b47