### PR TITLE
Guard cart GA analytics against missing cart

### DIFF
--- a/resources/js/shop/pages/Cart.tsx
+++ b/resources/js/shop/pages/Cart.tsx
@@ -12,13 +12,15 @@ export default function CartPage() {
 
     const brand = t('header.brand');
 
+    useEffect(() => {
+        if (!cart) return;
+
+        GA.view_cart(cart);
+    }, [cart]);
+
     if (!cart) return <div className="max-w-4xl mx-auto p-6">{t('cart.loading')}</div>
 
     const currency = cart.currency ?? 'EUR';
-
-    useEffect(() => {
-        GA.view_cart(cart);
-    }, [cart]);
 
     return (
         <div className="max-w-4xl mx-auto p-6 space-y-6">


### PR DESCRIPTION
## Summary
- move the cart page analytics effect ahead of the early loading return so it runs on every render
- guard the GA view_cart call until the cart data is available to avoid undefined accesses

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: php artisan wayfinder:generate --with-form)*

------
https://chatgpt.com/codex/tasks/task_e_68ce2f0c0dd48331a0a5d71d1b10639b