### PR TITLE
Use translations for Filament admin navigation

### DIFF
--- a/app/Providers/Filament/MinePanelProvider.php
+++ b/app/Providers/Filament/MinePanelProvider.php
@@ -48,12 +48,12 @@ class MinePanelProvider extends PanelProvider
                 OrderResource::class,
             ])
             ->navigationGroups([
-                'Catalog',
-                'Sales',
-                'Inventory',
-                'Settings',
+                __('shop.admin.navigation.catalog'),
+                __('shop.admin.navigation.sales'),
+                __('shop.admin.navigation.inventory'),
+                __('shop.admin.navigation.settings'),
             ])
-            ->brandName('Shop Admin')
+            ->brandName(__('shop.admin.brand'))
             ->discoverResources(in: app_path('Filament/Mine/Resources'), for: 'App\Filament\Mine\Resources')
             ->discoverPages(in: app_path('Filament/Mine/Pages'), for: 'App\Filament\Mine\Pages')
             ->pages([

--- a/resources/lang/en/shop.php
+++ b/resources/lang/en/shop.php
@@ -1,6 +1,16 @@
 <?php
 
 return [
+    'admin' => [
+        'brand' => 'Shop Admin',
+        'navigation' => [
+            'catalog' => 'Catalog',
+            'sales' => 'Sales',
+            'inventory' => 'Inventory',
+            'settings' => 'Settings',
+        ],
+    ],
+
     'navigation' => [
         'catalog' => 'Catalog',
         'cart' => 'Cart',

--- a/resources/lang/pt/shop.php
+++ b/resources/lang/pt/shop.php
@@ -1,6 +1,16 @@
 <?php
 
 return [
+    'admin' => [
+        'brand' => 'Administração da Loja',
+        'navigation' => [
+            'catalog' => 'Catálogo',
+            'sales' => 'Vendas',
+            'inventory' => 'Inventário',
+            'settings' => 'Configurações',
+        ],
+    ],
+
     'navigation' => [
         'catalog' => 'Catálogo',
         'cart' => 'Carrinho',

--- a/resources/lang/ru/shop.php
+++ b/resources/lang/ru/shop.php
@@ -1,6 +1,16 @@
 <?php
 
 return [
+    'admin' => [
+        'brand' => 'Панель магазина',
+        'navigation' => [
+            'catalog' => 'Каталог',
+            'sales' => 'Продажи',
+            'inventory' => 'Запасы',
+            'settings' => 'Настройки',
+        ],
+    ],
+
     'navigation' => [
         'catalog' => 'Каталог',
         'cart' => 'Корзина',

--- a/resources/lang/uk/shop.php
+++ b/resources/lang/uk/shop.php
@@ -1,6 +1,16 @@
 <?php
 
 return [
+    'admin' => [
+        'brand' => 'Панель магазину',
+        'navigation' => [
+            'catalog' => 'Каталог',
+            'sales' => 'Продажі',
+            'inventory' => 'Запаси',
+            'settings' => 'Налаштування',
+        ],
+    ],
+
     'navigation' => [
         'catalog' => 'Каталог',
         'cart' => 'Кошик',


### PR DESCRIPTION
## Summary
- localize the Filament Mine panel navigation groups and brand label using translation strings
- add matching shop.admin translation entries for English, Ukrainian, Russian, and Portuguese locales

## Testing
- php artisan tinker --execute="app()->setLocale('uk'); echo __('shop.admin.navigation.catalog');"

------
https://chatgpt.com/codex/tasks/task_e_68ce465a5c8883318d9eed939d43d9ab