### PR TITLE
Translate product and category resources

### DIFF
--- a/app/Filament/Mine/Resources/Categories/Schemas/CategoryForm.php
+++ b/app/Filament/Mine/Resources/Categories/Schemas/CategoryForm.php
@@ -15,11 +15,13 @@ class CategoryForm
         return $schema
             ->components([
                 TextInput::make('name')
+                    ->label(__('shop.categories.fields.name'))
                     ->required(),
                 TextInput::make('slug')
+                    ->label(__('shop.categories.fields.slug'))
                     ->required(),
                 Select::make('parent_id')
-                    ->label('Parent category')
+                    ->label(__('shop.categories.fields.parent'))
                     ->relationship('parent', 'name')
                     ->searchable()
                     ->preload()

--- a/app/Filament/Mine/Resources/Categories/Tables/CategoriesTable.php
+++ b/app/Filament/Mine/Resources/Categories/Tables/CategoriesTable.php
@@ -15,21 +15,27 @@ class CategoriesTable
         return $table
             ->columns([
                 TextColumn::make('name')
+                    ->label(__('shop.categories.fields.name'))
                     ->searchable(),
                 TextColumn::make('slug')
+                    ->label(__('shop.categories.fields.slug'))
                     ->searchable(),
                 TextColumn::make('parent_id')
+                    ->label(__('shop.categories.fields.parent'))
                     ->numeric()
                     ->sortable(),
                 TextColumn::make('deleted_at')
+                    ->label(__('shop.categories.fields.deleted_at'))
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('created_at')
+                    ->label(__('shop.categories.fields.created_at'))
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('updated_at')
+                    ->label(__('shop.categories.fields.updated_at'))
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),

--- a/app/Filament/Mine/Resources/Products/Schemas/ProductForm.php
+++ b/app/Filament/Mine/Resources/Products/Schemas/ProductForm.php
@@ -20,21 +20,23 @@ class ProductForm
         return $schema
             ->components([
                 TextInput::make('name')
+                    ->label(__('shop.products.fields.name'))
                     ->required(),
                 TextInput::make('slug')
+                    ->label(__('shop.products.fields.slug'))
                     ->required(),
                 TextInput::make('sku')
-                    ->label('SKU')
+                    ->label(__('shop.products.fields.sku'))
                     ->required(),
                 Select::make('category_id')
-                    ->label('Category')
+                    ->label(__('shop.products.fields.category'))
                     ->relationship('category', 'name')
                     ->searchable()
                     ->preload()
                     ->native(false)
                     ->required(),
                 Select::make('vendor_id')
-                    ->label('Vendor')
+                    ->label(__('shop.products.fields.vendor'))
                     ->relationship(
                         name: 'vendor',
                         titleAttribute: 'name',
@@ -48,23 +50,26 @@ class ProductForm
                     ->disabled(fn () => Auth::user()?->vendor !== null)
                     ->dehydrated(fn () => Auth::user()?->vendor === null),
                 KeyValue::make('attributes')
-                    ->label('Attributes')
-                    ->keyLabel('Name')
-                    ->valueLabel('Value')
+                    ->label(__('shop.products.attributes.label'))
+                    ->keyLabel(__('shop.products.attributes.name'))
+                    ->valueLabel(__('shop.products.attributes.value'))
                     ->reorderable()
-                    ->addActionLabel('Add attribute')
+                    ->addActionLabel(__('shop.products.attributes.add'))
                     ->columnSpanFull(),
                 Placeholder::make('available_stock')
-                    ->label('Available stock')
+                    ->label(__('shop.products.placeholders.available_stock'))
                     ->content(fn (?Product $record): string => (string) ($record?->stock ?? 0))
                     ->columnSpanFull(),
                 TextInput::make('price')
+                    ->label(__('shop.products.fields.price'))
                     ->required()
                     ->numeric()
                     ->prefix(fn (?Product $record) => currencySymbol()),
                 TextInput::make('price_old')
+                    ->label(__('shop.products.fields.price_old'))
                     ->numeric(),
                 Toggle::make('is_active')
+                    ->label(__('shop.products.fields.is_active'))
                     ->required(),
             ]);
     }

--- a/app/Filament/Mine/Resources/Products/Tables/ProductsTable.php
+++ b/app/Filament/Mine/Resources/Products/Tables/ProductsTable.php
@@ -33,7 +33,7 @@ class ProductsTable
             })
             ->columns([
                 ImageColumn::make('preview')
-                    ->label('Preview')
+                    ->label(__('shop.products.fields.preview'))
                     // важливо: саме getStateUsing для ImageColumn
                     ->getStateUsing(fn (Product $record) => $record->preview_url)
                     ->circular()
@@ -41,7 +41,7 @@ class ProductsTable
 
                 // (за бажанням) дебаг-колонка з URL
                 TextColumn::make('preview_url_debug')
-                    ->label('url?')
+                    ->label(__('shop.products.fields.preview_url_debug'))
                     ->getStateUsing(fn (Product $r) => $r->preview_url ?? '—')
                     ->toggleable(isToggledHiddenByDefault: true),
 //                \Filament\Tables\Columns\ImageColumn::make('preview')
@@ -90,10 +90,13 @@ class ProductsTable
 //                    ->searchable(),
 
                 TextColumn::make('sku')
-                    ->label('SKU')
+                    ->label(__('shop.products.fields.sku'))
                     ->searchable(),
 
-                TextColumn::make('category.name')->label('Category')->toggleable()->sortable(),
+                TextColumn::make('category.name')
+                    ->label(__('shop.products.fields.category'))
+                    ->toggleable()
+                    ->sortable(),
 
 //                TextColumn::make('attributes')
 //                    ->label('Attrs')
@@ -109,7 +112,7 @@ class ProductsTable
 //                    ->tooltip(fn ($state) => is_array($state) ? json_encode($state, JSON_UNESCAPED_UNICODE) : (string) $state)
 //                    ->wrap(),
                 TextColumn::make('vendor.name')
-                    ->label('Vendor')
+                    ->label(__('shop.products.fields.vendor'))
                     ->sortable(query: fn (Builder $query, string $direction): Builder => $query
                         ->orderBy(
                             Vendor::query()
@@ -121,7 +124,7 @@ class ProductsTable
                     ->visible(fn () => Auth::user()?->vendor === null),
 
                 TextColumn::make('stock')
-                    ->label('Stock')
+                    ->label(__('shop.products.fields.stock'))
                     ->state(fn (Product $record): int => $record->relationLoaded('stocks')
                         ? (int) $record->stocks->sum('available')
                         : (int) $record->stock)
@@ -130,13 +133,13 @@ class ProductsTable
                     ->extraAttributes(['class' => 'text-right tabular-nums font-mono']),
 
                 TextColumn::make('price')
-                    ->label('Price')
+                    ->label(__('shop.products.fields.price'))
                     ->formatStateUsing(fn ($state): string => formatCurrency($state))
                     ->sortable()
                     ->extraAttributes(['class' => 'text-right tabular-nums font-mono']),
 
                 ToggleColumn::make('is_active')
-                    ->label('Active')
+                    ->label(__('shop.products.fields.is_active'))
                     ->sortable(),
 
 
@@ -161,14 +164,14 @@ class ProductsTable
             ])
             ->filters([
                 SelectFilter::make('category_id')
-                    ->label('Category')
+                    ->label(__('shop.products.filters.category'))
                     ->relationship('category', 'name')
                     ->preload()
                     ->searchable(),
                 TernaryFilter::make('is_active')
-                    ->label('Active')
-                    ->trueLabel('Active')
-                    ->falseLabel('Inactive')
+                    ->label(__('shop.products.filters.is_active.label'))
+                    ->trueLabel(__('shop.products.filters.is_active.true'))
+                    ->falseLabel(__('shop.products.filters.is_active.false'))
                     ->queries(
                         true: fn ($q) => $q->where('is_active', true),
                         false: fn ($q) => $q->where('is_active', false),

--- a/resources/lang/en/shop.php
+++ b/resources/lang/en/shop.php
@@ -193,6 +193,50 @@ return [
         ],
     ],
 
+    'products' => [
+        'fields' => [
+            'name' => 'Name',
+            'slug' => 'Slug',
+            'sku' => 'SKU',
+            'category' => 'Category',
+            'vendor' => 'Vendor',
+            'preview' => 'Preview',
+            'preview_url_debug' => 'URL?',
+            'stock' => 'Stock',
+            'price' => 'Price',
+            'price_old' => 'Old price',
+            'is_active' => 'Active',
+        ],
+        'attributes' => [
+            'label' => 'Attributes',
+            'name' => 'Name',
+            'value' => 'Value',
+            'add' => 'Add attribute',
+        ],
+        'placeholders' => [
+            'available_stock' => 'Available stock',
+        ],
+        'filters' => [
+            'category' => 'Category',
+            'is_active' => [
+                'label' => 'Active',
+                'true' => 'Active',
+                'false' => 'Inactive',
+            ],
+        ],
+    ],
+
+    'categories' => [
+        'fields' => [
+            'name' => 'Name',
+            'slug' => 'Slug',
+            'parent' => 'Parent category',
+            'deleted_at' => 'Deleted at',
+            'created_at' => 'Created at',
+            'updated_at' => 'Updated at',
+        ],
+    ],
+
     'security' => [
         'two_factor' => [
             'not_initialized' => 'Two-factor authentication is not initialized.',

--- a/resources/lang/pt/shop.php
+++ b/resources/lang/pt/shop.php
@@ -193,6 +193,50 @@ return [
         ],
     ],
 
+    'products' => [
+        'fields' => [
+            'name' => 'Nome',
+            'slug' => 'Slug',
+            'sku' => 'SKU',
+            'category' => 'Categoria',
+            'vendor' => 'Fornecedor',
+            'preview' => 'Pré-visualização',
+            'preview_url_debug' => 'URL?',
+            'stock' => 'Estoque',
+            'price' => 'Preço',
+            'price_old' => 'Preço antigo',
+            'is_active' => 'Ativo',
+        ],
+        'attributes' => [
+            'label' => 'Atributos',
+            'name' => 'Nome',
+            'value' => 'Valor',
+            'add' => 'Adicionar atributo',
+        ],
+        'placeholders' => [
+            'available_stock' => 'Estoque disponível',
+        ],
+        'filters' => [
+            'category' => 'Categoria',
+            'is_active' => [
+                'label' => 'Atividade',
+                'true' => 'Ativos',
+                'false' => 'Inativos',
+            ],
+        ],
+    ],
+
+    'categories' => [
+        'fields' => [
+            'name' => 'Nome',
+            'slug' => 'Slug',
+            'parent' => 'Categoria pai',
+            'deleted_at' => 'Excluído em',
+            'created_at' => 'Criado em',
+            'updated_at' => 'Atualizado em',
+        ],
+    ],
+
     'security' => [
         'two_factor' => [
             'not_initialized' => 'A autenticação em duas etapas não está configurada.',

--- a/resources/lang/ru/shop.php
+++ b/resources/lang/ru/shop.php
@@ -193,6 +193,50 @@ return [
         ],
     ],
 
+    'products' => [
+        'fields' => [
+            'name' => 'Название',
+            'slug' => 'Слаг',
+            'sku' => 'Артикул',
+            'category' => 'Категория',
+            'vendor' => 'Поставщик',
+            'preview' => 'Превью',
+            'preview_url_debug' => 'URL?',
+            'stock' => 'Остаток',
+            'price' => 'Цена',
+            'price_old' => 'Старая цена',
+            'is_active' => 'Активен',
+        ],
+        'attributes' => [
+            'label' => 'Атрибуты',
+            'name' => 'Название',
+            'value' => 'Значение',
+            'add' => 'Добавить атрибут',
+        ],
+        'placeholders' => [
+            'available_stock' => 'Доступный остаток',
+        ],
+        'filters' => [
+            'category' => 'Категория',
+            'is_active' => [
+                'label' => 'Активность',
+                'true' => 'Активные',
+                'false' => 'Неактивные',
+            ],
+        ],
+    ],
+
+    'categories' => [
+        'fields' => [
+            'name' => 'Название',
+            'slug' => 'Слаг',
+            'parent' => 'Родительская категория',
+            'deleted_at' => 'Удалено',
+            'created_at' => 'Создано',
+            'updated_at' => 'Обновлено',
+        ],
+    ],
+
     'security' => [
         'two_factor' => [
             'not_initialized' => 'Двухфакторная аутентификация не настроена.',

--- a/resources/lang/uk/shop.php
+++ b/resources/lang/uk/shop.php
@@ -193,6 +193,50 @@ return [
         ],
     ],
 
+    'products' => [
+        'fields' => [
+            'name' => 'Назва',
+            'slug' => 'Слаг',
+            'sku' => 'Артикул',
+            'category' => 'Категорія',
+            'vendor' => 'Постачальник',
+            'preview' => 'Зображення',
+            'preview_url_debug' => 'URL?',
+            'stock' => 'Залишок',
+            'price' => 'Ціна',
+            'price_old' => 'Стара ціна',
+            'is_active' => 'Активний',
+        ],
+        'attributes' => [
+            'label' => 'Атрибути',
+            'name' => 'Назва',
+            'value' => 'Значення',
+            'add' => 'Додати атрибут',
+        ],
+        'placeholders' => [
+            'available_stock' => 'Доступний залишок',
+        ],
+        'filters' => [
+            'category' => 'Категорія',
+            'is_active' => [
+                'label' => 'Активність',
+                'true' => 'Активні',
+                'false' => 'Неактивні',
+            ],
+        ],
+    ],
+
+    'categories' => [
+        'fields' => [
+            'name' => 'Назва',
+            'slug' => 'Слаг',
+            'parent' => 'Батьківська категорія',
+            'deleted_at' => 'Видалено',
+            'created_at' => 'Створено',
+            'updated_at' => 'Оновлено',
+        ],
+    ],
+
     'security' => [
         'two_factor' => [
             'not_initialized' => 'Двофакторну автентифікацію не налаштовано.',


### PR DESCRIPTION
## Summary
- Localized the product and category Filament forms and tables to pull labels and filter text from the `shop.*` translation namespace
- Added product and category translation strings for every supported locale to keep the UI consistent

## Testing
- php -l app/Filament/Mine/Resources/Products/Schemas/ProductForm.php
- php -l app/Filament/Mine/Resources/Products/Tables/ProductsTable.php
- php -l app/Filament/Mine/Resources/Categories/Schemas/CategoryForm.php
- php -l app/Filament/Mine/Resources/Categories/Tables/CategoriesTable.php
- php -l resources/lang/en/shop.php
- php -l resources/lang/uk/shop.php
- php -l resources/lang/ru/shop.php
- php -l resources/lang/pt/shop.php

------
https://chatgpt.com/codex/tasks/task_e_68ce4ac242c08331856afd551215d56d