### PR TITLE
Localize order management UI strings

### DIFF
--- a/app/Enums/ShipmentStatus.php
+++ b/app/Enums/ShipmentStatus.php
@@ -13,11 +13,11 @@ enum ShipmentStatus: string
     public function label(): string
     {
         return match ($this) {
-            self::Pending => 'Pending',
-            self::Processing => 'Processing',
-            self::Shipped => 'Shipped',
-            self::Delivered => 'Delivered',
-            self::Cancelled => 'Cancelled',
+            self::Pending => __('shop.orders.shipment_status.pending'),
+            self::Processing => __('shop.orders.shipment_status.processing'),
+            self::Shipped => __('shop.orders.shipment_status.shipped'),
+            self::Delivered => __('shop.orders.shipment_status.delivered'),
+            self::Cancelled => __('shop.orders.shipment_status.cancelled'),
         };
     }
 

--- a/app/Filament/Mine/Resources/Orders/Schemas/OrderForm.php
+++ b/app/Filament/Mine/Resources/Orders/Schemas/OrderForm.php
@@ -24,9 +24,9 @@ class OrderForm
     {
         return $schema
             ->components([
-                Section::make('General')->schema([
+                Section::make(__('shop.orders.sections.general'))->schema([
                     Select::make('user_id')
-                        ->label('User')
+                        ->label(__('shop.orders.fields.user'))
                         ->relationship('user', 'email')
                         ->searchable()
                         ->preload()
@@ -37,59 +37,56 @@ class OrderForm
                         }),
 
                     TextInput::make('email')
-                        ->label('Email')
+                        ->label(__('shop.common.email'))
                         ->email()
                         ->required(fn (Get $get) => blank($get('user_id')))
-                        ->helperText('Якщо вибрано користувача — поле підставиться автоматично.'),
+                        ->helperText(__('shop.orders.helpers.email_auto')),
 
                     Select::make('status')
-                        ->label('Status')
-                        ->options([
-                            OrderStatus::New->value     => 'New',
-                            OrderStatus::Paid->value    => 'Paid',
-                            OrderStatus::Shipped->value => 'Shipped',
-                            OrderStatus::Cancelled->value=> 'Cancelled',
-                        ])
+                        ->label(__('shop.common.status'))
+                        ->options(collect(OrderStatus::cases())->mapWithKeys(
+                            fn (OrderStatus $case) => [$case->value => __('shop.orders.statuses.' . $case->value)]
+                        )->all())
                         ->default(OrderStatus::New->value)
                         ->required(),
 
                     TextInput::make('number')
-                        ->label('Number')
+                        ->label(__('shop.orders.fields.number'))
                         ->disabled()
                         ->dehydrated(false)
-                        ->hint('Згенерується автоматично'),
+                        ->hint(__('shop.orders.hints.number_generated')),
 
                     TextInput::make('total')
-                        ->label('Total')
+                        ->label(__('shop.common.total'))
                         ->prefix(fn (?Order $record) => currencySymbol($record?->currency))
                         ->disabled()
                         ->dehydrated(false)
 
                 ])->columns(2),
 
-                Section::make('Shipping')->schema([
-                    Fieldset::make('Shipping address')->schema([
-                        TextInput::make('shipping_address.name')->label('Name'),
-                        TextInput::make('shipping_address.city')->label('City'),
-                        TextInput::make('shipping_address.addr')->label('Address'),
-                        TextInput::make('shipping_address.postal_code')->label('Postal code'),
-                        TextInput::make('shipping_address.phone')->label('Phone')->tel(),
+                Section::make(__('shop.orders.sections.shipping'))->schema([
+                    Fieldset::make(__('shop.orders.fieldsets.shipping_address'))->schema([
+                        TextInput::make('shipping_address.name')->label(__('shop.common.name')),
+                        TextInput::make('shipping_address.city')->label(__('shop.common.city')),
+                        TextInput::make('shipping_address.addr')->label(__('shop.common.address')),
+                        TextInput::make('shipping_address.postal_code')->label(__('shop.common.postal_code')),
+                        TextInput::make('shipping_address.phone')->label(__('shop.common.phone'))->tel(),
                     ])->columns(2),
 
-                    Fieldset::make('Billing address')->schema([
-                        TextInput::make('billing_address.name')->label('Name'),
-                        TextInput::make('billing_address.city')->label('City'),
-                        TextInput::make('billing_address.addr')->label('Address'),
-                        TextInput::make('billing_address.postal_code')->label('Postal code'),
-                        TextInput::make('billing_address.phone')->label('Phone')->tel(),
+                    Fieldset::make(__('shop.orders.fieldsets.billing_address'))->schema([
+                        TextInput::make('billing_address.name')->label(__('shop.common.name')),
+                        TextInput::make('billing_address.city')->label(__('shop.common.city')),
+                        TextInput::make('billing_address.addr')->label(__('shop.common.address')),
+                        TextInput::make('billing_address.postal_code')->label(__('shop.common.postal_code')),
+                        TextInput::make('billing_address.phone')->label(__('shop.common.phone'))->tel(),
                     ])->columns(2),
                 ])->columns(1),
 
-                TextInput::make('note')->label('Note')->columnSpanFull(),
+                TextInput::make('note')->label(__('shop.common.note'))->columnSpanFull(),
 
-                Section::make('Shipment')->schema([
+                Section::make(__('shop.orders.sections.shipment'))->schema([
                     TextInput::make('shipment_tracking_number')
-                        ->label('Tracking number')
+                        ->label(__('shop.common.tracking_number'))
                         ->maxLength(255)
                         ->afterStateHydrated(function (TextInput $component, ?Order $record) {
                             $component->state($record?->shipment?->tracking_number);
@@ -97,7 +94,7 @@ class OrderForm
                         ->dehydrateStateUsing(fn ($state) => blank($state) ? null : $state),
 
                     Select::make('shipment_status')
-                        ->label('Shipment status')
+                        ->label(__('shop.orders.fields.shipment_status'))
                         ->options(collect(ShipmentStatus::cases())->mapWithKeys(fn (ShipmentStatus $case) => [$case->value => $case->label()])->all())
                         ->default(ShipmentStatus::Pending->value)
                         ->native(false)
@@ -108,7 +105,7 @@ class OrderForm
                         ->dehydrateStateUsing(fn ($state) => $state ?? ShipmentStatus::Pending->value),
                 ])->columns(2),
 
-                Section::make('Summary')
+                Section::make(__('shop.orders.sections.summary'))
                     ->collapsible()
                     ->schema([
                         ViewField::make('orderSummary')

--- a/resources/lang/en/shop.php
+++ b/resources/lang/en/shop.php
@@ -58,6 +58,13 @@ return [
         'price' => 'Price',
         'sum' => 'Total',
         'items_subtotal' => 'Items subtotal',
+        'name' => 'Name',
+        'city' => 'City',
+        'address' => 'Address',
+        'postal_code' => 'Postal code',
+        'note' => 'Note',
+        'total' => 'Total',
+        'tracking_number' => 'Tracking number',
     ],
 
     'auth' => [
@@ -122,6 +129,52 @@ return [
         ],
         'status_updated' => [
             'subject_line' => 'Your order #:number status was updated',
+        ],
+        'sections' => [
+            'general' => 'General',
+            'shipping' => 'Shipping',
+            'shipment' => 'Shipment',
+            'summary' => 'Summary',
+        ],
+        'fieldsets' => [
+            'shipping_address' => 'Shipping address',
+            'billing_address' => 'Billing address',
+        ],
+        'fields' => [
+            'user' => 'User',
+            'number' => 'Number',
+            'shipment_status' => 'Shipment status',
+        ],
+        'helpers' => [
+            'email_auto' => 'If a user is selected, the email will be filled automatically.',
+        ],
+        'hints' => [
+            'number_generated' => 'Generated automatically',
+        ],
+        'actions' => [
+            'messages' => 'Messages',
+            'mark_paid' => 'Mark paid',
+            'mark_shipped' => 'Mark shipped',
+            'cancel' => 'Cancel',
+            'resend_confirmation' => 'Resend confirmation',
+        ],
+        'notifications' => [
+            'marked_paid' => 'Order marked as paid',
+            'marked_shipped' => 'Order marked as shipped',
+            'cancelled' => 'Order canceled',
+            'confirmation_resent' => 'Confirmation email resent',
+        ],
+        'summary' => [
+            'positions' => 'Positions',
+            'subtotal' => 'Subtotal',
+            'total_order' => 'Total (order)',
+        ],
+        'shipment_status' => [
+            'pending' => 'Pending',
+            'processing' => 'Processing',
+            'shipped' => 'Shipped',
+            'delivered' => 'Delivered',
+            'cancelled' => 'Cancelled',
         ],
         'statuses' => [
             'new' => 'new',

--- a/resources/lang/pt/shop.php
+++ b/resources/lang/pt/shop.php
@@ -58,6 +58,13 @@ return [
         'price' => 'Preço',
         'sum' => 'Total',
         'items_subtotal' => 'Subtotal dos itens',
+        'name' => 'Nome',
+        'city' => 'Cidade',
+        'address' => 'Endereço',
+        'postal_code' => 'CEP',
+        'note' => 'Observação',
+        'total' => 'Total',
+        'tracking_number' => 'Código de rastreamento',
     ],
 
     'auth' => [
@@ -122,6 +129,52 @@ return [
         ],
         'status_updated' => [
             'subject_line' => 'Status do pedido nº :number atualizado',
+        ],
+        'sections' => [
+            'general' => 'Geral',
+            'shipping' => 'Envio',
+            'shipment' => 'Remessa',
+            'summary' => 'Resumo',
+        ],
+        'fieldsets' => [
+            'shipping_address' => 'Endereço de entrega',
+            'billing_address' => 'Endereço de cobrança',
+        ],
+        'fields' => [
+            'user' => 'Usuário',
+            'number' => 'Número',
+            'shipment_status' => 'Status da remessa',
+        ],
+        'helpers' => [
+            'email_auto' => 'Se um usuário for selecionado, o e-mail será preenchido automaticamente.',
+        ],
+        'hints' => [
+            'number_generated' => 'Gerado automaticamente',
+        ],
+        'actions' => [
+            'messages' => 'Mensagens',
+            'mark_paid' => 'Marcar como pago',
+            'mark_shipped' => 'Marcar como enviado',
+            'cancel' => 'Cancelar',
+            'resend_confirmation' => 'Reenviar confirmação',
+        ],
+        'notifications' => [
+            'marked_paid' => 'Pedido marcado como pago',
+            'marked_shipped' => 'Pedido marcado como enviado',
+            'cancelled' => 'Pedido cancelado',
+            'confirmation_resent' => 'E-mail de confirmação reenviado',
+        ],
+        'summary' => [
+            'positions' => 'Itens',
+            'subtotal' => 'Subtotal',
+            'total_order' => 'Total (pedido)',
+        ],
+        'shipment_status' => [
+            'pending' => 'Pendente',
+            'processing' => 'Processando',
+            'shipped' => 'Enviado',
+            'delivered' => 'Entregue',
+            'cancelled' => 'Cancelado',
         ],
         'statuses' => [
             'new' => 'novo',

--- a/resources/lang/ru/shop.php
+++ b/resources/lang/ru/shop.php
@@ -58,6 +58,13 @@ return [
         'price' => 'Цена',
         'sum' => 'Итого',
         'items_subtotal' => 'Итого за товары',
+        'name' => 'Имя',
+        'city' => 'Город',
+        'address' => 'Адрес',
+        'postal_code' => 'Почтовый индекс',
+        'note' => 'Примечание',
+        'total' => 'Итого',
+        'tracking_number' => 'Номер отслеживания',
     ],
 
     'auth' => [
@@ -122,6 +129,52 @@ return [
         ],
         'status_updated' => [
             'subject_line' => 'Статус вашего заказа №:number обновлён',
+        ],
+        'sections' => [
+            'general' => 'Общее',
+            'shipping' => 'Доставка',
+            'shipment' => 'Отгрузка',
+            'summary' => 'Сводка',
+        ],
+        'fieldsets' => [
+            'shipping_address' => 'Адрес доставки',
+            'billing_address' => 'Платежный адрес',
+        ],
+        'fields' => [
+            'user' => 'Пользователь',
+            'number' => 'Номер',
+            'shipment_status' => 'Статус отгрузки',
+        ],
+        'helpers' => [
+            'email_auto' => 'Если выбран пользователь, адрес заполнится автоматически.',
+        ],
+        'hints' => [
+            'number_generated' => 'Сгенерируется автоматически',
+        ],
+        'actions' => [
+            'messages' => 'Сообщения',
+            'mark_paid' => 'Отметить оплаченным',
+            'mark_shipped' => 'Отметить отправленным',
+            'cancel' => 'Отменить',
+            'resend_confirmation' => 'Отправить подтверждение снова',
+        ],
+        'notifications' => [
+            'marked_paid' => 'Заказ отмечен как оплаченный',
+            'marked_shipped' => 'Заказ отмечен как отправленный',
+            'cancelled' => 'Заказ отменён',
+            'confirmation_resent' => 'Письмо-подтверждение отправлено повторно',
+        ],
+        'summary' => [
+            'positions' => 'Позиции',
+            'subtotal' => 'Промежуточный итог',
+            'total_order' => 'Итого (заказ)',
+        ],
+        'shipment_status' => [
+            'pending' => 'В ожидании',
+            'processing' => 'Обрабатывается',
+            'shipped' => 'Отправлено',
+            'delivered' => 'Доставлено',
+            'cancelled' => 'Отменено',
         ],
         'statuses' => [
             'new' => 'новый',

--- a/resources/lang/uk/shop.php
+++ b/resources/lang/uk/shop.php
@@ -58,6 +58,13 @@ return [
         'price' => 'Ціна',
         'sum' => 'Сума',
         'items_subtotal' => 'Разом за товари',
+        'name' => 'Імʼя',
+        'city' => 'Місто',
+        'address' => 'Адреса',
+        'postal_code' => 'Поштовий індекс',
+        'note' => 'Примітка',
+        'total' => 'Разом',
+        'tracking_number' => 'Номер відстеження',
     ],
 
     'auth' => [
@@ -122,6 +129,52 @@ return [
         ],
         'status_updated' => [
             'subject_line' => 'Ваше замовлення №:number: статус оновлено',
+        ],
+        'sections' => [
+            'general' => 'Загальне',
+            'shipping' => 'Доставка',
+            'shipment' => 'Відправлення',
+            'summary' => 'Підсумок',
+        ],
+        'fieldsets' => [
+            'shipping_address' => 'Адреса доставки',
+            'billing_address' => 'Платіжна адреса',
+        ],
+        'fields' => [
+            'user' => 'Користувач',
+            'number' => 'Номер',
+            'shipment_status' => 'Статус відправлення',
+        ],
+        'helpers' => [
+            'email_auto' => 'Якщо вибрано користувача, електронна адреса заповниться автоматично.',
+        ],
+        'hints' => [
+            'number_generated' => 'Згенерується автоматично',
+        ],
+        'actions' => [
+            'messages' => 'Повідомлення',
+            'mark_paid' => 'Позначити оплаченим',
+            'mark_shipped' => 'Позначити відправленим',
+            'cancel' => 'Скасувати',
+            'resend_confirmation' => 'Надіслати підтвердження ще раз',
+        ],
+        'notifications' => [
+            'marked_paid' => 'Замовлення позначене як оплачене',
+            'marked_shipped' => 'Замовлення позначене як відправлене',
+            'cancelled' => 'Замовлення скасовано',
+            'confirmation_resent' => 'Лист-підтвердження повторно надіслано',
+        ],
+        'summary' => [
+            'positions' => 'Позиції',
+            'subtotal' => 'Проміжна сума',
+            'total_order' => 'Разом (замовлення)',
+        ],
+        'shipment_status' => [
+            'pending' => 'Очікує',
+            'processing' => 'Опрацьовується',
+            'shipped' => 'Відправлено',
+            'delivered' => 'Доставлено',
+            'cancelled' => 'Скасовано',
         ],
         'statuses' => [
             'new' => 'нове',

--- a/resources/views/filament/orders/summary.blade.php
+++ b/resources/views/filament/orders/summary.blade.php
@@ -11,19 +11,19 @@
 
 <div class="rounded-xl border p-4 space-y-2" wire:poll.1500ms>
     <div class="flex items-center justify-between">
-        <div class="text-sm text-gray-500">Positions</div>
+        <div class="text-sm text-gray-500">{{ __('shop.orders.summary.positions') }}</div>
         <div class="font-medium">{{ $items->count() }}</div>
     </div>
 
     <div class="flex items-center justify-between">
-        <div class="text-sm text-gray-500">Subtotal</div>
+        <div class="text-sm text-gray-500">{{ __('shop.orders.summary.subtotal') }}</div>
         <div class="font-semibold">{{ formatCurrency($subtotal, $currency) }}</div>
     </div>
 
     <div class="border-t my-2"></div>
 
     <div class="flex items-center justify-between">
-        <div class="text-sm text-gray-500">Total (order)</div>
+        <div class="text-sm text-gray-500">{{ __('shop.orders.summary.total_order') }}</div>
         <div class="text-lg font-bold">{{ formatCurrency($total, $currency) }}</div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- replace order form sections, inputs, and helper texts with translation lookups
- localize order table labels, actions, notifications, and shipment status labels across locales
- update the order summary view to pull totals copy from shared translations

## Testing
- APP_FALLBACK_LOCALE=en php artisan test --filter LocalizationTest

------
https://chatgpt.com/codex/tasks/task_e_68ce4c5dfd3483318daa0b5d07588745