### PR TITLE
Translate currency resource labels

### DIFF
--- a/app/Filament/Mine/Resources/Currencies/CurrencyResource.php
+++ b/app/Filament/Mine/Resources/Currencies/CurrencyResource.php
@@ -24,8 +24,6 @@ class CurrencyResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedBanknotes;
 
-    protected static string|null|\UnitEnum $navigationGroup = 'Settings';
-
     protected static ?string $recordTitleAttribute = 'code';
 
     protected static bool $shouldRegisterNavigation = true;
@@ -42,7 +40,7 @@ class CurrencyResource extends Resource
                 ->afterStateUpdated(fn (Set $set, ?string $state) => $set('code', strtoupper((string) $state)))
                 ->rule('alpha:ascii'),
             TextInput::make('rate')
-                ->label('Rate (vs base)')
+                ->label(__('shop.currencies.rate_vs_base'))
                 ->numeric()
                 ->required()
                 ->minValue(0.00000001)
@@ -55,16 +53,16 @@ class CurrencyResource extends Resource
         return $table
             ->columns([
                 TextColumn::make('code')
-                    ->label('Code')
+                    ->label(__('shop.currencies.code'))
                     ->searchable()
                     ->sortable()
                     ->formatStateUsing(fn (string $state) => Str::upper($state)),
                 TextColumn::make('rate')
-                    ->label('Rate')
+                    ->label(__('shop.currencies.rate'))
                     ->numeric(precision: 8)
                     ->sortable(),
                 TextColumn::make('updated_at')
-                    ->label('Updated')
+                    ->label(__('shop.currencies.updated'))
                     ->dateTime()
                     ->sortable(),
             ])
@@ -87,6 +85,11 @@ class CurrencyResource extends Resource
             'create' => CreateCurrency::route('/create'),
             'edit' => EditCurrency::route('/{record}/edit'),
         ];
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('shop.currencies.navigation_group');
     }
 
     public static function getNavigationBadge(): ?string

--- a/resources/lang/en/shop.php
+++ b/resources/lang/en/shop.php
@@ -290,6 +290,14 @@ return [
         ],
     ],
 
+    'currencies' => [
+        'navigation_group' => 'Settings',
+        'code' => 'Code',
+        'rate' => 'Rate',
+        'rate_vs_base' => 'Rate (vs base)',
+        'updated' => 'Updated',
+    ],
+
     'security' => [
         'two_factor' => [
             'not_initialized' => 'Two-factor authentication is not initialized.',

--- a/resources/lang/pt/shop.php
+++ b/resources/lang/pt/shop.php
@@ -290,6 +290,14 @@ return [
         ],
     ],
 
+    'currencies' => [
+        'navigation_group' => 'Configurações',
+        'code' => 'Código',
+        'rate' => 'Taxa',
+        'rate_vs_base' => 'Taxa (vs base)',
+        'updated' => 'Atualizado',
+    ],
+
     'security' => [
         'two_factor' => [
             'not_initialized' => 'A autenticação em duas etapas não está configurada.',

--- a/resources/lang/ru/shop.php
+++ b/resources/lang/ru/shop.php
@@ -290,6 +290,14 @@ return [
         ],
     ],
 
+    'currencies' => [
+        'navigation_group' => 'Настройки',
+        'code' => 'Код',
+        'rate' => 'Курс',
+        'rate_vs_base' => 'Курс (к базовой)',
+        'updated' => 'Обновлено',
+    ],
+
     'security' => [
         'two_factor' => [
             'not_initialized' => 'Двухфакторная аутентификация не настроена.',

--- a/resources/lang/uk/shop.php
+++ b/resources/lang/uk/shop.php
@@ -290,6 +290,14 @@ return [
         ],
     ],
 
+    'currencies' => [
+        'navigation_group' => 'Налаштування',
+        'code' => 'Код',
+        'rate' => 'Курс',
+        'rate_vs_base' => 'Курс (до базової)',
+        'updated' => 'Оновлено',
+    ],
+
     'security' => [
         'two_factor' => [
             'not_initialized' => 'Двофакторну автентифікацію не налаштовано.',


### PR DESCRIPTION
## Summary
- localize the Filament currency resource labels and navigation group via translation strings
- add currency translation entries for English, Portuguese, Russian, and Ukrainian locales

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce4ee30a988331b303d3cb2066ed83