### PR TITLE
Ensure product images use public storage disk

### DIFF
--- a/app/Filament/Mine/Resources/Products/RelationManagers/ImagesRelationManager.php
+++ b/app/Filament/Mine/Resources/Products/RelationManagers/ImagesRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Mine\Resources\Products\RelationManagers;
 
+use App\Models\ProductImage;
 use Filament\Forms;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Hidden;
@@ -12,7 +13,6 @@ use Filament\Tables;
 use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Columns\ToggleColumn;
-use Illuminate\Support\Facades\Storage;
 use Filament\Actions\CreateAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\DeleteAction;
@@ -28,7 +28,7 @@ class ImagesRelationManager extends RelationManager
         return $schema->schema([
             FileUpload::make('path')
                 ->label('Image')
-                ->disk('public')
+                ->disk(config('filesystems.default', 'public'))
                 ->directory(fn () => 'products/' . $this->getOwnerRecord()->id)
                 ->image()
                 ->imageEditor()
@@ -37,7 +37,7 @@ class ImagesRelationManager extends RelationManager
                 ->required(),
 
             TextInput::make('alt')->maxLength(255),
-            Hidden::make('disk')->default('public'),
+            Hidden::make('disk')->default(fn () => config('filesystems.default', 'public')),
             TextInput::make('sort')->numeric()->default(0),
             Toggle::make('is_primary')
                 ->label('Primary')
@@ -53,7 +53,7 @@ class ImagesRelationManager extends RelationManager
             ->columns([
                 ImageColumn::make('path')
                     ->label('Preview')
-                    ->disk('public')
+                    ->disk(fn (ProductImage $record) => $record->disk ?: config('filesystems.default', 'public'))
                     ->circular(),
                 ToggleColumn::make('is_primary')
                     ->label('Primary')

--- a/app/Models/ProductImage.php
+++ b/app/Models/ProductImage.php
@@ -35,6 +35,10 @@ class ProductImage extends Model
     protected static function booted(): void
     {
         static::saving(function (self $image) {
+            $image->disk = $image->disk ?: config('filesystems.default', 'public');
+        });
+
+        static::saving(function (self $image) {
             if ($image->is_primary) {
                 static::where('product_id', $image->product_id)
                     ->when($image->exists, fn ($q) => $q->whereKeyNot($image->getKey()))
@@ -48,7 +52,9 @@ class ProductImage extends Model
 
     public function getUrlAttribute(): string
     {
-        return Storage::disk('public')->url($this->path);
+        $disk = $this->disk ?: config('filesystems.default', 'public');
+
+        return Storage::disk($disk)->url($this->path);
     }
 
     public function product(): BelongsTo

--- a/database/migrations/2025_10_09_020000_update_product_image_disk_default.php
+++ b/database/migrations/2025_10_09_020000_update_product_image_disk_default.php
@@ -1,0 +1,117 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $defaultDisk = 'public';
+
+        $driver = DB::getDriverName();
+
+        if ($driver === 'sqlite') {
+            Schema::table('product_images', function (Blueprint $table) use ($defaultDisk) {
+                $table->string('disk_tmp')->default($defaultDisk);
+            });
+
+            DB::table('product_images')->update([
+                'disk_tmp' => DB::raw("CASE WHEN disk IS NULL OR disk = '' THEN '{$defaultDisk}' ELSE disk END"),
+            ]);
+
+            Schema::table('product_images', function (Blueprint $table) {
+                $table->dropColumn('disk');
+            });
+
+            Schema::table('product_images', function (Blueprint $table) {
+                $table->renameColumn('disk_tmp', 'disk');
+            });
+        } else {
+            match ($driver) {
+                'pgsql' => DB::statement("ALTER TABLE product_images ALTER COLUMN disk SET DEFAULT '{$defaultDisk}'"),
+                'mysql' => DB::statement("ALTER TABLE product_images MODIFY disk VARCHAR(255) NOT NULL DEFAULT '{$defaultDisk}'"),
+                'sqlsrv' => DB::unprepared(<<<'SQL'
+DECLARE @constraintName NVARCHAR(200);
+SELECT @constraintName = df.name
+FROM sys.default_constraints df
+    INNER JOIN sys.columns c ON df.parent_object_id = c.object_id AND df.parent_column_id = c.column_id
+    INNER JOIN sys.tables t ON df.parent_object_id = t.object_id
+WHERE t.name = 'product_images' AND c.name = 'disk';
+
+IF @constraintName IS NOT NULL
+    EXEC('ALTER TABLE product_images DROP CONSTRAINT ' + QUOTENAME(@constraintName));
+
+ALTER TABLE product_images ADD CONSTRAINT DF_product_images_disk DEFAULT 'public' FOR disk;
+SQL),
+                default => null,
+            };
+        }
+
+        DB::table('product_images')
+            ->where('disk', 's3')
+            ->update(['disk' => $defaultDisk]);
+
+        DB::table('product_images')
+            ->where(function ($query) {
+                $query->whereNull('disk')->orWhere('disk', '');
+            })
+            ->update(['disk' => $defaultDisk]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $defaultDisk = 's3';
+
+        $driver = DB::getDriverName();
+
+        if ($driver === 'sqlite') {
+            Schema::table('product_images', function (Blueprint $table) use ($defaultDisk) {
+                $table->string('disk_tmp')->default($defaultDisk);
+            });
+
+            DB::table('product_images')->update([
+                'disk_tmp' => DB::raw("CASE WHEN disk IS NULL OR disk = '' THEN '{$defaultDisk}' ELSE disk END"),
+            ]);
+
+            Schema::table('product_images', function (Blueprint $table) {
+                $table->dropColumn('disk');
+            });
+
+            Schema::table('product_images', function (Blueprint $table) {
+                $table->renameColumn('disk_tmp', 'disk');
+            });
+        } else {
+            match ($driver) {
+                'pgsql' => DB::statement("ALTER TABLE product_images ALTER COLUMN disk SET DEFAULT '{$defaultDisk}'"),
+                'mysql' => DB::statement("ALTER TABLE product_images MODIFY disk VARCHAR(255) NOT NULL DEFAULT '{$defaultDisk}'"),
+                'sqlsrv' => DB::unprepared(<<<'SQL'
+DECLARE @constraintName NVARCHAR(200);
+SELECT @constraintName = df.name
+FROM sys.default_constraints df
+    INNER JOIN sys.columns c ON df.parent_object_id = c.object_id AND df.parent_column_id = c.column_id
+    INNER JOIN sys.tables t ON df.parent_object_id = t.object_id
+WHERE t.name = 'product_images' AND c.name = 'disk';
+
+IF @constraintName IS NOT NULL
+    EXEC('ALTER TABLE product_images DROP CONSTRAINT ' + QUOTENAME(@constraintName));
+
+ALTER TABLE product_images ADD CONSTRAINT DF_product_images_disk DEFAULT 's3' FOR disk;
+SQL),
+                default => null,
+            };
+        }
+
+        DB::table('product_images')
+            ->where('disk', 'public')
+            ->update(['disk' => $defaultDisk]);
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration that changes the `product_images.disk` default to `public` and rewrites legacy rows
- ensure `ProductImage` always falls back to the configured upload disk and uses it when building URLs
- configure the Filament product images relation to store and render files from the configured disk

## Testing
- php artisan test *(fails: Tests\\Feature\\Auth\\RegistrationTest::it sends verification and welcome mails when registering, Tests\\Feature\\LocalizationTest::it falls back to english when locale has no translation, Tests\\Feature\\Mail\\OrderEmailsTest::order paid mail contains key information)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6fa39cb48331ae9e12db800b2f8f