### PR TITLE
Add description field translation for products

### DIFF
--- a/resources/lang/en/shop.php
+++ b/resources/lang/en/shop.php
@@ -250,6 +250,7 @@ return [
         'fields' => [
             'name' => 'Name',
             'slug' => 'Slug',
+            'description' => 'Description',
             'sku' => 'SKU',
             'category' => 'Category',
             'vendor' => 'Vendor',

--- a/resources/lang/pt/shop.php
+++ b/resources/lang/pt/shop.php
@@ -250,6 +250,7 @@ return [
         'fields' => [
             'name' => 'Nome',
             'slug' => 'Slug',
+            'description' => 'Descrição',
             'sku' => 'SKU',
             'category' => 'Categoria',
             'vendor' => 'Fornecedor',

--- a/resources/lang/ru/shop.php
+++ b/resources/lang/ru/shop.php
@@ -250,6 +250,7 @@ return [
         'fields' => [
             'name' => 'Название',
             'slug' => 'Слаг',
+            'description' => 'Описание',
             'sku' => 'Артикул',
             'category' => 'Категория',
             'vendor' => 'Поставщик',

--- a/resources/lang/uk/shop.php
+++ b/resources/lang/uk/shop.php
@@ -250,6 +250,7 @@ return [
         'fields' => [
             'name' => 'Назва',
             'slug' => 'Слаг',
+            'description' => 'Опис',
             'sku' => 'Артикул',
             'category' => 'Категорія',
             'vendor' => 'Постачальник',


### PR DESCRIPTION
## Summary
- add a description field label to the product form translations for English, Russian, Portuguese, and Ukrainian

## Testing
- php artisan cache:clear *(fails: vendor directory missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceafbc1ff083319723a5d0762b7965