### PR TITLE
Preserve primary locale translations on hydration

### DIFF
--- a/app/Filament/Mine/Resources/Categories/Schemas/CategoryForm.php
+++ b/app/Filament/Mine/Resources/Categories/Schemas/CategoryForm.php
@@ -27,9 +27,15 @@ class CategoryForm
                     ->label(__('shop.categories.fields.name'))
                     ->required()
                     ->hidden()
-                    ->afterStateHydrated(function (TextInput $component, $state, Set $set) use ($primaryLocale): void {
-                        if (filled($state)) {
-                            $set("name_translations.{$primaryLocale}", $state);
+                    ->afterStateHydrated(function (TextInput $component, $state, Set $set, Get $get) use ($primaryLocale): void {
+                        if (filled($get("name_translations.{$primaryLocale}"))) {
+                            return;
+                        }
+
+                        $rawName = $component->getRecord()?->getRawOriginal('name');
+
+                        if (filled($rawName)) {
+                            $set("name_translations.{$primaryLocale}", $rawName);
                         }
                     })
                     ->dehydrateStateUsing(fn ($state, Get $get) => $get('name_translations.' . $primaryLocale) ?? $state),

--- a/app/Filament/Mine/Resources/Coupons/Schemas/CouponForm.php
+++ b/app/Filament/Mine/Resources/Coupons/Schemas/CouponForm.php
@@ -33,9 +33,15 @@ class CouponForm
             TextInput::make('name')
                 ->maxLength(255)
                 ->hidden()
-                ->afterStateHydrated(function (TextInput $component, $state, Set $set) use ($primaryLocale): void {
-                    if (filled($state)) {
-                        $set("name_translations.{$primaryLocale}", $state);
+                ->afterStateHydrated(function (TextInput $component, $state, Set $set, Get $get) use ($primaryLocale): void {
+                    if (filled($get("name_translations.{$primaryLocale}"))) {
+                        return;
+                    }
+
+                    $rawName = $component->getRecord()?->getRawOriginal('name');
+
+                    if (filled($rawName)) {
+                        $set("name_translations.{$primaryLocale}", $rawName);
                     }
                 })
                 ->dehydrateStateUsing(fn ($state, Get $get) => $get('name_translations.' . $primaryLocale) ?? $state),
@@ -43,9 +49,15 @@ class CouponForm
                 ->rows(3)
                 ->columnSpanFull()
                 ->hidden()
-                ->afterStateHydrated(function (Textarea $component, $state, Set $set) use ($primaryLocale): void {
-                    if (filled($state)) {
-                        $set("description_translations.{$primaryLocale}", $state);
+                ->afterStateHydrated(function (Textarea $component, $state, Set $set, Get $get) use ($primaryLocale): void {
+                    if (filled($get("description_translations.{$primaryLocale}"))) {
+                        return;
+                    }
+
+                    $rawDescription = $component->getRecord()?->getRawOriginal('description');
+
+                    if (filled($rawDescription)) {
+                        $set("description_translations.{$primaryLocale}", $rawDescription);
                     }
                 })
                 ->dehydrateStateUsing(fn ($state, Get $get) => $get('description_translations.' . $primaryLocale) ?? $state),

--- a/app/Filament/Mine/Resources/Products/Schemas/ProductForm.php
+++ b/app/Filament/Mine/Resources/Products/Schemas/ProductForm.php
@@ -34,9 +34,15 @@ class ProductForm
                     ->label(__('shop.products.fields.name'))
                     ->required()
                     ->hidden()
-                    ->afterStateHydrated(function (TextInput $component, $state, Set $set) use ($primaryLocale): void {
-                        if (filled($state)) {
-                            $set("name_translations.{$primaryLocale}", $state);
+                    ->afterStateHydrated(function (TextInput $component, $state, Set $set, Get $get) use ($primaryLocale): void {
+                        if (filled($get("name_translations.{$primaryLocale}"))) {
+                            return;
+                        }
+
+                        $rawName = $component->getRecord()?->getRawOriginal('name');
+
+                        if (filled($rawName)) {
+                            $set("name_translations.{$primaryLocale}", $rawName);
                         }
                     })
                     ->dehydrateStateUsing(fn ($state, Get $get) => $get('name_translations.' . $primaryLocale) ?? $state),
@@ -44,9 +50,15 @@ class ProductForm
                     ->label(__('shop.products.fields.description'))
                     ->columnSpanFull()
                     ->hidden()
-                    ->afterStateHydrated(function (Textarea $component, $state, Set $set) use ($primaryLocale): void {
-                        if (filled($state)) {
-                            $set("description_translations.{$primaryLocale}", $state);
+                    ->afterStateHydrated(function (Textarea $component, $state, Set $set, Get $get) use ($primaryLocale): void {
+                        if (filled($get("description_translations.{$primaryLocale}"))) {
+                            return;
+                        }
+
+                        $rawDescription = $component->getRecord()?->getRawOriginal('description');
+
+                        if (filled($rawDescription)) {
+                            $set("description_translations.{$primaryLocale}", $rawDescription);
                         }
                     })
                     ->dehydrateStateUsing(fn ($state, Get $get) => $get('description_translations.' . $primaryLocale) ?? $state),

--- a/app/Filament/Mine/Resources/Vendors/Schemas/VendorForm.php
+++ b/app/Filament/Mine/Resources/Vendors/Schemas/VendorForm.php
@@ -36,9 +36,15 @@ class VendorForm
                     ->required()
                     ->maxLength(255)
                     ->hidden()
-                    ->afterStateHydrated(function (TextInput $component, $state, Set $set) use ($primaryLocale): void {
-                        if (filled($state)) {
-                            $set("name_translations.{$primaryLocale}", $state);
+                    ->afterStateHydrated(function (TextInput $component, $state, Set $set, Get $get) use ($primaryLocale): void {
+                        if (filled($get("name_translations.{$primaryLocale}"))) {
+                            return;
+                        }
+
+                        $rawName = $component->getRecord()?->getRawOriginal('name');
+
+                        if (filled($rawName)) {
+                            $set("name_translations.{$primaryLocale}", $rawName);
                         }
                     })
                     ->dehydrateStateUsing(fn ($state, Get $get) => $get('name_translations.' . $primaryLocale) ?? $state),
@@ -57,9 +63,15 @@ class VendorForm
                     ->rows(4)
                     ->columnSpanFull()
                     ->hidden()
-                    ->afterStateHydrated(function (Textarea $component, $state, Set $set) use ($primaryLocale): void {
-                        if (filled($state)) {
-                            $set("description_translations.{$primaryLocale}", $state);
+                    ->afterStateHydrated(function (Textarea $component, $state, Set $set, Get $get) use ($primaryLocale): void {
+                        if (filled($get("description_translations.{$primaryLocale}"))) {
+                            return;
+                        }
+
+                        $rawDescription = $component->getRecord()?->getRawOriginal('description');
+
+                        if (filled($rawDescription)) {
+                            $set("description_translations.{$primaryLocale}", $rawDescription);
                         }
                     })
                     ->dehydrateStateUsing(fn ($state, Get $get) => $get('description_translations.' . $primaryLocale) ?? $state),

--- a/app/Filament/Mine/Resources/Warehouses/WarehouseResource.php
+++ b/app/Filament/Mine/Resources/Warehouses/WarehouseResource.php
@@ -52,18 +52,30 @@ class WarehouseResource extends Resource
                 ->required()
                 ->maxLength(255)
                 ->hidden()
-                ->afterStateHydrated(function (TextInput $component, $state, SchemaSet $set) use ($primaryLocale): void {
-                    if (filled($state)) {
-                        $set("name_translations.{$primaryLocale}", $state);
+                ->afterStateHydrated(function (TextInput $component, $state, SchemaSet $set, SchemaGet $get) use ($primaryLocale): void {
+                    if (filled($get("name_translations.{$primaryLocale}"))) {
+                        return;
+                    }
+
+                    $rawName = $component->getRecord()?->getRawOriginal('name');
+
+                    if (filled($rawName)) {
+                        $set("name_translations.{$primaryLocale}", $rawName);
                     }
                 })
                 ->dehydrateStateUsing(fn ($state, SchemaGet $get) => $get('name_translations.' . $primaryLocale) ?? $state),
             Textarea::make('description')
                 ->columnSpanFull()
                 ->hidden()
-                ->afterStateHydrated(function (Textarea $component, $state, SchemaSet $set) use ($primaryLocale): void {
-                    if (filled($state)) {
-                        $set("description_translations.{$primaryLocale}", $state);
+                ->afterStateHydrated(function (Textarea $component, $state, SchemaSet $set, SchemaGet $get) use ($primaryLocale): void {
+                    if (filled($get("description_translations.{$primaryLocale}"))) {
+                        return;
+                    }
+
+                    $rawDescription = $component->getRecord()?->getRawOriginal('description');
+
+                    if (filled($rawDescription)) {
+                        $set("description_translations.{$primaryLocale}", $rawDescription);
                     }
                 })
                 ->dehydrateStateUsing(fn ($state, SchemaGet $get) => $get('description_translations.' . $primaryLocale) ?? $state),


### PR DESCRIPTION
## Summary
- prevent overwriting primary-locale translations when hydrating hidden name and description fields
- backfill missing translations from the record's raw values across product, vendor, warehouse, coupon, and category forms

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68ced241d5ac83319824f862404682de