### PR TITLE
Ensure public storage symlink is created when needed

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -67,6 +67,18 @@ class AppServiceProvider extends ServiceProvider
         Gate::policy(Warehouse::class, WarehousePolicy::class);
         Gate::policy(Currency::class, CurrencyPolicy::class);
 
+        if (
+            Config::get('filesystems.disks.public.driver') === 'local'
+            && (! app()->runningInConsole() || app()->runningUnitTests())
+            && ! file_exists(public_path('storage'))
+        ) {
+            try {
+                app('files')->link(storage_path('app/public'), public_path('storage'));
+            } catch (\Throwable) {
+                // Immutable filesystems may not allow creating the link. That's fine.
+            }
+        }
+
         if (Config::get('scout.driver') === 'meilisearch') {
             Product::created(fn($p) => $p->searchable());
             Product::updated(fn($p) => $p->searchable());


### PR DESCRIPTION
## Summary
- ensure the local public disk automatically creates the storage symlink when it is missing
- skip link creation during console installs while still allowing unit tests to assert against the filesystem
- swallow link creation errors so immutable production filesystems are not blocked

## Testing
- php artisan test *(fails: missing vendor directory in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceee174cec8331aa8c7d3a7282fd79