### PR TITLE
Guard attribute translation hydration

### DIFF
--- a/app/Filament/Mine/Resources/Products/Schemas/ProductForm.php
+++ b/app/Filament/Mine/Resources/Products/Schemas/ProductForm.php
@@ -107,12 +107,14 @@ class ProductForm
                             ->required()
                             ->live(onBlur: true)
                             ->afterStateHydrated(function (TextInput $component, $state, Set $set, Get $get) use ($primaryLocale): void {
-                                if (filled($state) && blank($get("translations.{$primaryLocale}"))) {
+                                if (blank($get("translations.{$primaryLocale}")) && filled($state)) {
                                     $set("translations.{$primaryLocale}", $state);
                                 }
                             })
-                            ->afterStateUpdated(function (Set $set, $state) use ($primaryLocale): void {
-                                $set("translations.{$primaryLocale}", $state);
+                            ->afterStateUpdated(function (Set $set, Get $get, $state) use ($primaryLocale): void {
+                                if (blank($get("translations.{$primaryLocale}"))) {
+                                    $set("translations.{$primaryLocale}", $state);
+                                }
                             }),
                         Fieldset::make('translations')
                             ->schema(
@@ -121,7 +123,7 @@ class ProductForm
                                         ->label(strtoupper($locale))
                                         ->live(onBlur: true)
                                         ->afterStateHydrated(function (TextInput $component, $state, Set $set, Get $get) use ($locale, $primaryLocale): void {
-                                            if ($locale === $primaryLocale && blank($state)) {
+                                            if ($locale === $primaryLocale && blank($get("translations.{$locale}")) && blank($state)) {
                                                 $value = $get('value');
                                                 if (filled($value)) {
                                                     $set("translations.{$locale}", $value);


### PR DESCRIPTION
## Summary
- guard repeater value hydration to only seed the primary locale when empty
- mirror the guard within translation inputs to prevent overwriting user edits

## Testing
- `php artisan test` *(fails: vendor dependencies not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceec80c4b8833193a6b3db7b2d23a7