### PR TITLE
Add storage permission fix script for PHP containers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,6 +30,8 @@ app (php-fpm для artisan, web), horizon (черги), nginx (порт 8080), 
     docker compose exec app php artisan migrate --seed
 ```
 
+`app` і `horizon` автоматично виставляють права доступу до `storage/*` та `bootstrap/cache` під час старту контейнерів, тому додаткові `chown`/`mkdir` виконувати не потрібно.
+
 Vite hot reload для Laravel:    
 public/hot вказує на http://localhost:5173 (ми виставляли руками при потребі).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
             dockerfile: docker/php/Dockerfile
         image: shop-php:dev
         container_name: shop-app
+        command: sh -lc "/usr/local/bin/fix-storage-perms && php-fpm"
         volumes:
             - .:/var/www/html
         depends_on:
@@ -15,7 +16,7 @@ services:
     horizon:
         image: shop-php:dev
         container_name: shop-horizon
-        command: sh -lc "php artisan horizon"
+        command: sh -lc "/usr/local/bin/fix-storage-perms && php artisan horizon"
         working_dir: /var/www/html
         volumes:
             - .:/var/www/html

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -24,3 +24,6 @@ RUN apk del .build-deps
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 WORKDIR /var/www/html
+
+COPY docker/php/fix-storage-perms.sh /usr/local/bin/fix-storage-perms
+RUN chmod +x /usr/local/bin/fix-storage-perms

--- a/docker/php/fix-storage-perms.sh
+++ b/docker/php/fix-storage-perms.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+mkdir -p storage/logs bootstrap/cache
+chown -R www-data:www-data storage bootstrap/cache


### PR DESCRIPTION
## Summary
- add a shell helper that fixes storage and cache directory permissions
- copy the helper into the PHP image and call it from app and horizon commands
- document that storage permissions are now handled automatically during container startup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf01b4fd988331ac1d2517c59d57ed