### PR TITLE
Prevent duplicate inventory combinations in Filament resource

### DIFF
--- a/app/Filament/Mine/Resources/Inventory/InventoryResource.php
+++ b/app/Filament/Mine/Resources/Inventory/InventoryResource.php
@@ -18,6 +18,8 @@ use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\Rule;
 
 class InventoryResource extends Resource
 {
@@ -40,6 +42,23 @@ class InventoryResource extends Resource
                 ->preload()
                 ->native(false)
                 ->required()
+                ->live(onBlur: true)
+                ->rule(function (callable $get, ?Model $record) {
+                    $warehouseId = $get('warehouse_id');
+
+                    if (! $warehouseId) {
+                        return null;
+                    }
+
+                    $rule = Rule::unique('product_stocks', 'product_id')
+                        ->where(fn ($query) => $query->where('warehouse_id', $warehouseId));
+
+                    if ($record) {
+                        $rule->ignore($record->getKey());
+                    }
+
+                    return $rule;
+                })
                 ->disabledOn('edit'),
             Select::make('warehouse_id')
                 ->relationship('warehouse', 'name')
@@ -47,6 +66,23 @@ class InventoryResource extends Resource
                 ->preload()
                 ->native(false)
                 ->required()
+                ->live(onBlur: true)
+                ->rule(function (callable $get, ?Model $record) {
+                    $productId = $get('product_id');
+
+                    if (! $productId) {
+                        return null;
+                    }
+
+                    $rule = Rule::unique('product_stocks', 'warehouse_id')
+                        ->where(fn ($query) => $query->where('product_id', $productId));
+
+                    if ($record) {
+                        $rule->ignore($record->getKey());
+                    }
+
+                    return $rule;
+                })
                 ->disabledOn('edit'),
             TextInput::make('qty')
                 ->label('Quantity')

--- a/tests/Feature/Filament/Mine/Inventory/CreateInventoryTest.php
+++ b/tests/Feature/Filament/Mine/Inventory/CreateInventoryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Filament\Mine\Resources\Inventory\Pages\CreateInventory;
+use App\Models\Product;
+use App\Models\User;
+use App\Models\Warehouse;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Livewire\Livewire;
+
+it('validates unique product and warehouse combination when creating inventory', function () {
+    $user = User::factory()->create();
+    $product = Product::factory()->create();
+    $warehouse = Warehouse::getDefault();
+
+    $this->actingAs($user);
+
+    $component = null;
+
+    expect(function () use (&$component, $product, $warehouse) {
+        $component = Livewire::test(CreateInventory::class)
+            ->fillForm([
+                'product_id' => $product->getKey(),
+                'warehouse_id' => $warehouse->getKey(),
+                'qty' => 5,
+                'reserved' => 0,
+            ])
+            ->call('create');
+    })->not->toThrow(UniqueConstraintViolationException::class);
+
+    $component->assertHasErrors(['data.product_id']);
+
+    expect($product->stocks()->count())->toBe(1);
+});


### PR DESCRIPTION
## Summary
- enforce live validation on the inventory form so a product/warehouse pair cannot be selected more than once
- add a feature test that exercises the Filament create page and confirms duplicates are rejected via validation rather than a database exception

## Testing
- vendor/bin/pest tests/Feature/Filament/Mine/Inventory/CreateInventoryTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cf9aa3c1bc8331a10b90c8872eed43