### PR TITLE
Localize admin resource navigation groups and labels

### DIFF
--- a/app/Filament/Mine/Resources/Categories/CategoryResource.php
+++ b/app/Filament/Mine/Resources/Categories/CategoryResource.php
@@ -20,11 +20,11 @@ class CategoryResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
 
-    protected static ?string $recordTitleAttribute = 'Category';
+    protected static ?string $recordTitleAttribute = 'name';
 
 //    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
 
-    protected static string|null|\UnitEnum $navigationGroup = 'Catalog';
+    protected static string|null|\UnitEnum $navigationGroup = null;
     protected static bool $shouldRegisterNavigation = true;
 
 
@@ -57,5 +57,20 @@ class CategoryResource extends Resource
     public static function getNavigationBadge(): ?string
     {
         return (string) Category::count();
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('shop.admin.resources.categories.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('shop.admin.resources.categories.plural_label');
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('shop.admin.navigation.catalog');
     }
 }

--- a/app/Filament/Mine/Resources/Coupons/CouponResource.php
+++ b/app/Filament/Mine/Resources/Coupons/CouponResource.php
@@ -19,7 +19,7 @@ class CouponResource extends Resource
     protected static ?string $model = Coupon::class;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedTicket;
-    protected static string|null|\UnitEnum $navigationGroup = 'Marketing';
+    protected static string|null|\UnitEnum $navigationGroup = null;
     protected static ?string $recordTitleAttribute = 'code';
     protected static bool $shouldRegisterNavigation = true;
 
@@ -31,6 +31,21 @@ class CouponResource extends Resource
     public static function table(Table $table): Table
     {
         return CouponsTable::configure($table);
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('shop.admin.resources.coupons.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('shop.admin.resources.coupons.plural_label');
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('shop.admin.navigation.marketing');
     }
 
     public static function getPages(): array

--- a/app/Filament/Mine/Resources/Inventory/InventoryResource.php
+++ b/app/Filament/Mine/Resources/Inventory/InventoryResource.php
@@ -27,7 +27,7 @@ class InventoryResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCube;
 
-    protected static string|null|\UnitEnum $navigationGroup = 'Inventory';
+    protected static string|null|\UnitEnum $navigationGroup = null;
 
     protected static ?string $recordTitleAttribute = 'id';
 
@@ -149,6 +149,21 @@ class InventoryResource extends Resource
             'create' => CreateInventory::route('/create'),
             'edit' => EditInventory::route('/{record}/edit'),
         ];
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('shop.admin.resources.inventory.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('shop.admin.resources.inventory.plural_label');
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('shop.admin.navigation.inventory');
     }
 
     public static function getNavigationBadge(): ?string

--- a/app/Filament/Mine/Resources/Orders/OrderResource.php
+++ b/app/Filament/Mine/Resources/Orders/OrderResource.php
@@ -23,11 +23,11 @@ class OrderResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
 
-    protected static ?string $recordTitleAttribute = 'Order';
+    protected static ?string $recordTitleAttribute = 'number';
 
 //    protected static ?string $navigationIcon = 'heroicon-o-shopping-bag';
 
-    protected static string|null|\UnitEnum $navigationGroup = 'Sales';
+    protected static string|null|\UnitEnum $navigationGroup = null;
     protected static bool $shouldRegisterNavigation = true;
 
 
@@ -60,6 +60,21 @@ class OrderResource extends Resource
             RelationManagers\ItemsRelationManager::class,
             RelationManagers\LogsRelationManager::class,
         ];
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('shop.admin.resources.orders.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('shop.admin.resources.orders.plural_label');
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('shop.admin.navigation.sales');
     }
 
     public static function getPages(): array

--- a/app/Filament/Mine/Resources/Products/ProductResource.php
+++ b/app/Filament/Mine/Resources/Products/ProductResource.php
@@ -24,10 +24,10 @@ class ProductResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
 
-    protected static ?string $recordTitleAttribute = 'Product';
+    protected static ?string $recordTitleAttribute = 'name';
 
 //    protected static ?string $navigationIcon = 'heroicon-o-cube';
-    protected static string|null|\UnitEnum $navigationGroup = 'Catalog';
+    protected static string|null|\UnitEnum $navigationGroup = null;
     protected static bool $shouldRegisterNavigation = true;
 
     public static function form(Schema $schema): Schema
@@ -66,6 +66,21 @@ class ProductResource extends Resource
             'create' => CreateProduct::route('/create'),
             'edit' => EditProduct::route('/{record}/edit'),
         ];
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('shop.admin.resources.products.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('shop.admin.resources.products.plural_label');
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('shop.admin.navigation.catalog');
     }
 
     public static function getNavigationBadge(): ?string

--- a/app/Filament/Mine/Resources/Reviews/ReviewResource.php
+++ b/app/Filament/Mine/Resources/Reviews/ReviewResource.php
@@ -20,7 +20,7 @@ class ReviewResource extends Resource
 
     protected static ?string $recordTitleAttribute = 'id';
 
-    protected static string|null|\UnitEnum $navigationGroup = 'Content';
+    protected static string|null|\UnitEnum $navigationGroup = null;
     protected static bool $shouldRegisterNavigation = true;
 
     public static function form(Schema $schema): Schema
@@ -31,6 +31,21 @@ class ReviewResource extends Resource
     public static function table(Table $table): Table
     {
         return ReviewsTable::configure($table);
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('shop.admin.resources.reviews.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('shop.admin.resources.reviews.plural_label');
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('shop.admin.navigation.content');
     }
 
     public static function getRelations(): array

--- a/app/Filament/Mine/Resources/Users/UserResource.php
+++ b/app/Filament/Mine/Resources/Users/UserResource.php
@@ -19,7 +19,7 @@ class UserResource extends Resource
     protected static ?string $model = User::class;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedUsers;
-    protected static string|null|\UnitEnum $navigationGroup = 'Customers';
+    protected static string|null|\UnitEnum $navigationGroup = null;
     protected static ?string $recordTitleAttribute = 'name';
     protected static bool $shouldRegisterNavigation = true;
 
@@ -46,6 +46,21 @@ class UserResource extends Resource
             'index' => ListUsers::route('/'),
             'view' => ViewUser::route('/{record}'),
         ];
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('shop.admin.resources.users.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('shop.admin.resources.users.plural_label');
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('shop.admin.navigation.customers');
     }
 
     public static function getEloquentQuery(): Builder

--- a/app/Filament/Mine/Resources/Vendors/VendorResource.php
+++ b/app/Filament/Mine/Resources/Vendors/VendorResource.php
@@ -22,7 +22,9 @@ class VendorResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedBuildingStorefront;
 
-    protected static string|null|\UnitEnum $navigationGroup = 'Catalog';
+    protected static string|null|\UnitEnum $navigationGroup = null;
+
+    protected static ?string $recordTitleAttribute = 'name';
 
     public static function form(Schema $schema): Schema
     {
@@ -54,6 +56,21 @@ class VendorResource extends Resource
             'create' => CreateVendor::route('/create'),
             'edit' => EditVendor::route('/{record}/edit'),
         ];
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('shop.admin.resources.vendors.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('shop.admin.resources.vendors.plural_label');
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('shop.admin.navigation.catalog');
     }
 
     public static function getNavigationBadge(): ?string

--- a/app/Filament/Mine/Resources/Warehouses/WarehouseResource.php
+++ b/app/Filament/Mine/Resources/Warehouses/WarehouseResource.php
@@ -29,7 +29,7 @@ class WarehouseResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedBuildingOffice;
 
-    protected static string|null|\UnitEnum $navigationGroup = 'Inventory';
+    protected static string|null|\UnitEnum $navigationGroup = null;
 
     protected static ?string $recordTitleAttribute = 'name';
 
@@ -134,6 +134,21 @@ class WarehouseResource extends Resource
             'create' => CreateWarehouse::route('/create'),
             'edit' => EditWarehouse::route('/{record}/edit'),
         ];
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('shop.admin.resources.warehouses.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('shop.admin.resources.warehouses.plural_label');
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('shop.admin.navigation.inventory');
     }
 
     public static function getNavigationBadge(): ?string

--- a/resources/lang/en/shop.php
+++ b/resources/lang/en/shop.php
@@ -7,7 +7,48 @@ return [
             'catalog' => 'Catalog',
             'sales' => 'Sales',
             'inventory' => 'Inventory',
+            'marketing' => 'Marketing',
+            'content' => 'Content',
+            'customers' => 'Customers',
             'settings' => 'Settings',
+        ],
+        'resources' => [
+            'products' => [
+                'label' => 'Product',
+                'plural_label' => 'Products',
+            ],
+            'categories' => [
+                'label' => 'Category',
+                'plural_label' => 'Categories',
+            ],
+            'orders' => [
+                'label' => 'Order',
+                'plural_label' => 'Orders',
+            ],
+            'vendors' => [
+                'label' => 'Vendor',
+                'plural_label' => 'Vendors',
+            ],
+            'inventory' => [
+                'label' => 'Inventory item',
+                'plural_label' => 'Inventory',
+            ],
+            'coupons' => [
+                'label' => 'Coupon',
+                'plural_label' => 'Coupons',
+            ],
+            'reviews' => [
+                'label' => 'Review',
+                'plural_label' => 'Reviews',
+            ],
+            'users' => [
+                'label' => 'Customer',
+                'plural_label' => 'Customers',
+            ],
+            'warehouses' => [
+                'label' => 'Warehouse',
+                'plural_label' => 'Warehouses',
+            ],
         ],
     ],
 

--- a/resources/lang/uk/shop.php
+++ b/resources/lang/uk/shop.php
@@ -7,7 +7,48 @@ return [
             'catalog' => 'Каталог',
             'sales' => 'Продажі',
             'inventory' => 'Запаси',
+            'marketing' => 'Маркетинг',
+            'content' => 'Контент',
+            'customers' => 'Клієнти',
             'settings' => 'Налаштування',
+        ],
+        'resources' => [
+            'products' => [
+                'label' => 'Товар',
+                'plural_label' => 'Товари',
+            ],
+            'categories' => [
+                'label' => 'Категорія',
+                'plural_label' => 'Категорії',
+            ],
+            'orders' => [
+                'label' => 'Замовлення',
+                'plural_label' => 'Замовлення',
+            ],
+            'vendors' => [
+                'label' => 'Продавець',
+                'plural_label' => 'Продавці',
+            ],
+            'inventory' => [
+                'label' => 'Позиція запасів',
+                'plural_label' => 'Запаси',
+            ],
+            'coupons' => [
+                'label' => 'Купон',
+                'plural_label' => 'Купони',
+            ],
+            'reviews' => [
+                'label' => 'Відгук',
+                'plural_label' => 'Відгуки',
+            ],
+            'users' => [
+                'label' => 'Клієнт',
+                'plural_label' => 'Клієнти',
+            ],
+            'warehouses' => [
+                'label' => 'Склад',
+                'plural_label' => 'Склади',
+            ],
         ],
     ],
 


### PR DESCRIPTION
## Summary
- switch Filament admin resources to translated navigation groups and localized model labels
- add shared translation strings for resource labels in both English and Ukrainian

## Testing
- composer test *(fails: missing vendor/autoload.php in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa114c344833181067f2a223aa2b1