### PR TITLE
Add locale middleware to Mine panel

### DIFF
--- a/app/Providers/Filament/MinePanelProvider.php
+++ b/app/Providers/Filament/MinePanelProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers\Filament;
 
 use App\Filament\Mine\Widgets\OrdersStats;
+use App\Http\Middleware\SetLocaleFromRequest;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -68,6 +69,7 @@ class MinePanelProvider extends PanelProvider
             ->renderHook('panels::user-menu.after', fn () => view('filament.mine.components.language-switcher'))
             ->middleware([
                 EncryptCookies::class,
+                SetLocaleFromRequest::class,
                 AddQueuedCookiesToResponse::class,
                 StartSession::class,
                 AuthenticateSession::class,


### PR DESCRIPTION
## Summary
- import the SetLocaleFromRequest middleware in the Mine panel provider
- register SetLocaleFromRequest immediately after EncryptCookies so the locale is set from the decrypted lang cookie

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfabdb16e48331afa493bef5a3dcf4