### PR TITLE
Add missing admin translations for ru and pt

### DIFF
--- a/resources/lang/pt/shop.php
+++ b/resources/lang/pt/shop.php
@@ -7,11 +7,52 @@ return [
             'catalog' => 'Catálogo',
             'sales' => 'Vendas',
             'inventory' => 'Inventário',
+            'marketing' => 'Marketing',
+            'content' => 'Conteúdo',
+            'customers' => 'Clientes',
             'settings' => 'Configurações',
         ],
         'language_switcher' => [
             'label' => 'Idioma da interface',
             'help' => 'Altera o idioma do painel após recarregar a página.',
+        ],
+        'resources' => [
+            'products' => [
+                'label' => 'Produto',
+                'plural_label' => 'Produtos',
+            ],
+            'categories' => [
+                'label' => 'Categoria',
+                'plural_label' => 'Categorias',
+            ],
+            'orders' => [
+                'label' => 'Pedido',
+                'plural_label' => 'Pedidos',
+            ],
+            'vendors' => [
+                'label' => 'Fornecedor',
+                'plural_label' => 'Fornecedores',
+            ],
+            'inventory' => [
+                'label' => 'Item de inventário',
+                'plural_label' => 'Inventário',
+            ],
+            'coupons' => [
+                'label' => 'Cupom',
+                'plural_label' => 'Cupons',
+            ],
+            'reviews' => [
+                'label' => 'Avaliação',
+                'plural_label' => 'Avaliações',
+            ],
+            'users' => [
+                'label' => 'Cliente',
+                'plural_label' => 'Clientes',
+            ],
+            'warehouses' => [
+                'label' => 'Armazém',
+                'plural_label' => 'Armazéns',
+            ],
         ],
     ],
 
@@ -203,6 +244,77 @@ return [
     'inventory' => [
         'not_enough_stock' => 'Estoque insuficiente para o produto nº :product_id no depósito nº :warehouse_id.',
         'not_enough_reserved_stock' => 'Estoque reservado insuficiente para o produto nº :product_id no depósito nº :warehouse_id.',
+        'fields' => [
+            'quantity' => 'Quantidade',
+            'reserved' => 'Reservado',
+            'available' => 'Disponível',
+        ],
+        'filters' => [
+            'warehouse' => 'Armazém',
+        ],
+    ],
+
+    'warehouses' => [
+        'fields' => [
+            'code' => 'Código',
+            'name' => 'Nome',
+            'description' => 'Descrição',
+        ],
+        'columns' => [
+            'created' => 'Criado',
+            'updated' => 'Atualizado',
+        ],
+    ],
+
+    'coupons' => [
+        'fields' => [
+            'code' => 'Código',
+            'type' => 'Tipo',
+            'value' => 'Valor',
+            'min_cart' => 'Mínimo do carrinho',
+            'max_discount' => 'Desconto máximo',
+            'usage' => 'Uso',
+            'usage_limit' => 'Limite total de uso',
+            'per_user_limit' => 'Limite por usuário',
+            'starts_at' => 'Início',
+            'expires_at' => 'Expira em',
+            'is_active' => 'Ativo',
+        ],
+        'filters' => [
+            'is_active' => 'Ativo',
+        ],
+        'helpers' => [
+            'code_unique' => 'Código único que os clientes irão inserir.',
+        ],
+        'types' => [
+            'fixed' => 'Valor fixo',
+            'percent' => 'Percentual',
+        ],
+    ],
+
+    'reviews' => [
+        'fields' => [
+            'product' => 'Produto',
+            'user' => 'Usuário',
+            'rating' => 'Avaliação',
+            'status' => 'Status',
+            'text' => 'Texto da avaliação',
+            'created_at' => 'Criado',
+        ],
+        'filters' => [
+            'status' => 'Status',
+        ],
+        'statuses' => [
+            'pending' => 'Pendente',
+            'approved' => 'Aprovada',
+            'rejected' => 'Rejeitada',
+        ],
+    ],
+
+    'users' => [
+        'fields' => [
+            'points_balance' => 'Saldo de pontos',
+        ],
     ],
 
     'api' => [
@@ -254,6 +366,32 @@ return [
             'checkout_redeem' => 'Pontos resgatados no checkout',
             'shipped_bonus' => 'Bônus pelo pedido enviado :number',
             'cancellation_return' => 'Pontos devolvidos após cancelamento',
+        ],
+        'transactions' => [
+            'fields' => [
+                'type' => 'Tipo',
+                'points' => 'Pontos',
+                'amount' => 'Valor',
+            ],
+            'types' => [
+                'earn' => 'Acúmulo',
+                'redeem' => 'Resgate',
+                'adjustment' => 'Ajuste',
+            ],
+        ],
+    ],
+
+    'widgets' => [
+        'orders_stats' => [
+            'labels' => [
+                'new' => 'Novos',
+                'paid' => 'Pagos',
+                'shipped' => 'Enviados',
+                'cancelled' => 'Cancelados',
+            ],
+            'descriptions' => [
+                'new' => 'Aguardando',
+            ],
         ],
     ],
 

--- a/resources/lang/ru/shop.php
+++ b/resources/lang/ru/shop.php
@@ -7,11 +7,52 @@ return [
             'catalog' => 'Каталог',
             'sales' => 'Продажи',
             'inventory' => 'Запасы',
+            'marketing' => 'Маркетинг',
+            'content' => 'Контент',
+            'customers' => 'Клиенты',
             'settings' => 'Настройки',
         ],
         'language_switcher' => [
             'label' => 'Язык интерфейса',
             'help' => 'Изменяет язык панели после обновления страницы.',
+        ],
+        'resources' => [
+            'products' => [
+                'label' => 'Товар',
+                'plural_label' => 'Товары',
+            ],
+            'categories' => [
+                'label' => 'Категория',
+                'plural_label' => 'Категории',
+            ],
+            'orders' => [
+                'label' => 'Заказ',
+                'plural_label' => 'Заказы',
+            ],
+            'vendors' => [
+                'label' => 'Поставщик',
+                'plural_label' => 'Поставщики',
+            ],
+            'inventory' => [
+                'label' => 'Запас',
+                'plural_label' => 'Запасы',
+            ],
+            'coupons' => [
+                'label' => 'Купон',
+                'plural_label' => 'Купоны',
+            ],
+            'reviews' => [
+                'label' => 'Отзыв',
+                'plural_label' => 'Отзывы',
+            ],
+            'users' => [
+                'label' => 'Покупатель',
+                'plural_label' => 'Покупатели',
+            ],
+            'warehouses' => [
+                'label' => 'Склад',
+                'plural_label' => 'Склады',
+            ],
         ],
     ],
 
@@ -203,6 +244,77 @@ return [
     'inventory' => [
         'not_enough_stock' => 'Недостаточно товара для продукта №:product_id на складе №:warehouse_id.',
         'not_enough_reserved_stock' => 'Недостаточно зарезервированного товара для продукта №:product_id на складе №:warehouse_id.',
+        'fields' => [
+            'quantity' => 'Количество',
+            'reserved' => 'Зарезервировано',
+            'available' => 'Доступно',
+        ],
+        'filters' => [
+            'warehouse' => 'Склад',
+        ],
+    ],
+
+    'warehouses' => [
+        'fields' => [
+            'code' => 'Код',
+            'name' => 'Название',
+            'description' => 'Описание',
+        ],
+        'columns' => [
+            'created' => 'Создано',
+            'updated' => 'Обновлено',
+        ],
+    ],
+
+    'coupons' => [
+        'fields' => [
+            'code' => 'Код',
+            'type' => 'Тип',
+            'value' => 'Значение',
+            'min_cart' => 'Мин. сумма корзины',
+            'max_discount' => 'Макс. скидка',
+            'usage' => 'Использование',
+            'usage_limit' => 'Общий лимит использования',
+            'per_user_limit' => 'Лимит на пользователя',
+            'starts_at' => 'Начало действия',
+            'expires_at' => 'Окончание действия',
+            'is_active' => 'Активен',
+        ],
+        'filters' => [
+            'is_active' => 'Активность',
+        ],
+        'helpers' => [
+            'code_unique' => 'Уникальный код, который будут вводить покупатели.',
+        ],
+        'types' => [
+            'fixed' => 'Фиксированная сумма',
+            'percent' => 'Процент',
+        ],
+    ],
+
+    'reviews' => [
+        'fields' => [
+            'product' => 'Товар',
+            'user' => 'Пользователь',
+            'rating' => 'Рейтинг',
+            'status' => 'Статус',
+            'text' => 'Текст отзыва',
+            'created_at' => 'Создано',
+        ],
+        'filters' => [
+            'status' => 'Статус',
+        ],
+        'statuses' => [
+            'pending' => 'На модерации',
+            'approved' => 'Одобрен',
+            'rejected' => 'Отклонён',
+        ],
+    ],
+
+    'users' => [
+        'fields' => [
+            'points_balance' => 'Баланс баллов',
+        ],
     ],
 
     'api' => [
@@ -254,6 +366,32 @@ return [
             'checkout_redeem' => 'Баллы списаны при оформлении заказа',
             'shipped_bonus' => 'Бонус за отправленный заказ :number',
             'cancellation_return' => 'Баллы возвращены после отмены',
+        ],
+        'transactions' => [
+            'fields' => [
+                'type' => 'Тип',
+                'points' => 'Баллы',
+                'amount' => 'Сумма',
+            ],
+            'types' => [
+                'earn' => 'Начисление',
+                'redeem' => 'Списание',
+                'adjustment' => 'Корректировка',
+            ],
+        ],
+    ],
+
+    'widgets' => [
+        'orders_stats' => [
+            'labels' => [
+                'new' => 'Новые',
+                'paid' => 'Оплаченные',
+                'shipped' => 'Отправленные',
+                'cancelled' => 'Отменённые',
+            ],
+            'descriptions' => [
+                'new' => 'В ожидании',
+            ],
         ],
     ],
 


### PR DESCRIPTION
## Summary
- add Russian admin navigation labels and resource names for new management sections
- localize warehouse, coupon, review, user, inventory, widget, and loyalty strings in Russian
- mirror the updated structure and translations in the Portuguese language file

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd012f9308331a837446ab133352c