### PR TITLE
Add currency resource labels and translations

### DIFF
--- a/app/Filament/Mine/Resources/Currencies/CurrencyResource.php
+++ b/app/Filament/Mine/Resources/Currencies/CurrencyResource.php
@@ -30,6 +30,21 @@ class CurrencyResource extends Resource
 
     protected static bool $shouldRegisterNavigation = true;
 
+    public static function getModelLabel(): string
+    {
+        return __('shop.admin.resources.currencies.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('shop.admin.resources.currencies.plural_label');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('shop.admin.resources.currencies.plural_label');
+    }
+
     public static function form(Schema $schema): Schema
     {
         return $schema->components([

--- a/resources/lang/en/shop.php
+++ b/resources/lang/en/shop.php
@@ -53,6 +53,10 @@ return [
                 'label' => 'Warehouse',
                 'plural_label' => 'Warehouses',
             ],
+            'currencies' => [
+                'label' => 'Currency',
+                'plural_label' => 'Currencies',
+            ],
         ],
     ],
 

--- a/resources/lang/uk/shop.php
+++ b/resources/lang/uk/shop.php
@@ -53,6 +53,10 @@ return [
                 'label' => 'Склад',
                 'plural_label' => 'Склади',
             ],
+            'currencies' => [
+                'label' => 'Валюта',
+                'plural_label' => 'Валюти',
+            ],
         ],
     ],
 


### PR DESCRIPTION
## Summary
- localize the currency resource labels used in navigation and headings
- add English and Ukrainian translations for the currency resource labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfda8c03c08331848af5b051d04cd5