### PR TITLE
Add label to product name column

### DIFF
--- a/app/Filament/Mine/Resources/Products/Tables/ProductsTable.php
+++ b/app/Filament/Mine/Resources/Products/Tables/ProductsTable.php
@@ -84,6 +84,7 @@ class ProductsTable
 //                    ->getStateUsing(fn ($record) => $record->preview_url ?: asset('images/no-image.svg'))
 //                    ->circular(),
                 TextColumn::make('name')
+                    ->label(__('shop.products.fields.name'))
                     ->searchable(),
 
 //                TextColumn::make('slug')


### PR DESCRIPTION
## Summary
- add a translated label to the products table name column so it displays the correct heading

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfdb6335dc8331901b658c79825e90