### PR TITLE
Add description label to loyalty transactions table

### DIFF
--- a/app/Filament/Mine/Resources/Users/RelationManagers/LoyaltyPointTransactionsRelationManager.php
+++ b/app/Filament/Mine/Resources/Users/RelationManagers/LoyaltyPointTransactionsRelationManager.php
@@ -33,6 +33,7 @@ class LoyaltyPointTransactionsRelationManager extends RelationManager
                     ->state(fn ($record) => formatCurrency($record->amount, $record->order?->currency))
                     ->toggleable(),
                 TextColumn::make('description')
+                    ->label(__('shop.loyalty.transactions.fields.description'))
                     ->formatStateUsing(fn ($state, $record) => $record->localized_description ?: $state)
                     ->wrap()
                     ->toggleable(),

--- a/resources/lang/en/shop.php
+++ b/resources/lang/en/shop.php
@@ -401,6 +401,7 @@ return [
                 'type' => 'Type',
                 'points' => 'Points',
                 'amount' => 'Amount',
+                'description' => 'Description',
             ],
             'types' => [
                 'earn' => 'Earned',

--- a/resources/lang/uk/shop.php
+++ b/resources/lang/uk/shop.php
@@ -401,6 +401,7 @@ return [
                 'type' => 'Тип',
                 'points' => 'Бали',
                 'amount' => 'Сума',
+                'description' => 'Опис',
             ],
             'types' => [
                 'earn' => 'Нарахування',


### PR DESCRIPTION
## Summary
- add a localized label to the loyalty transactions description column
- provide English and Ukrainian translation strings for the description field

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cfe0451dac8331ba514fb2f078a498