### PR TITLE
Adjust items relation title translation

### DIFF
--- a/app/Filament/Mine/Resources/Orders/RelationManagers/ItemsRelationManager.php
+++ b/app/Filament/Mine/Resources/Orders/RelationManagers/ItemsRelationManager.php
@@ -27,7 +27,12 @@ use function formatCurrency;
 class ItemsRelationManager extends RelationManager
 {
     protected static string $relationship = 'items';
-    protected static ?string $title = __('shop.orders.items.title');
+    protected static ?string $title = null;
+
+    public static function getTitle(): ?string
+    {
+        return __('shop.orders.items.title');
+    }
 
     public function form(Schema $schema): Schema
     {


### PR DESCRIPTION
## Summary
- clear the items relation manager title property to avoid evaluating the translation early
- provide a getTitle() override that defers translation to runtime for the items relation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cfe5292c0c8331b0c67f08b0f467f3