### PR TITLE
Restrict product category selection and validation

### DIFF
--- a/app/Filament/Mine/Resources/Products/Pages/Concerns/ValidatesCategoryAccess.php
+++ b/app/Filament/Mine/Resources/Products/Pages/Concerns/ValidatesCategoryAccess.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Products\Pages\Concerns;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\ValidationException;
+
+trait ValidatesCategoryAccess
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function ensureCategoryIsPermitted(array $data): void
+    {
+        $user = Auth::user();
+
+        if ($user === null) {
+            return;
+        }
+
+        $permittedCategoryIds = $user->permittedCategoryIds();
+
+        if ($permittedCategoryIds->isEmpty()) {
+            return;
+        }
+
+        if (! array_key_exists('category_id', $data)) {
+            return;
+        }
+
+        $categoryId = $data['category_id'];
+
+        if ($categoryId === null) {
+            return;
+        }
+
+        if (! $permittedCategoryIds->contains((int) $categoryId)) {
+            throw ValidationException::withMessages([
+                'category_id' => __('validation.in', [
+                    'attribute' => __('shop.products.fields.category'),
+                ]),
+            ]);
+        }
+    }
+}

--- a/app/Filament/Mine/Resources/Products/Pages/CreateProduct.php
+++ b/app/Filament/Mine/Resources/Products/Pages/CreateProduct.php
@@ -2,16 +2,21 @@
 
 namespace App\Filament\Mine\Resources\Products\Pages;
 
+use App\Filament\Mine\Resources\Products\Pages\Concerns\ValidatesCategoryAccess;
 use App\Filament\Mine\Resources\Products\ProductResource;
 use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Support\Facades\Auth;
 
 class CreateProduct extends CreateRecord
 {
+    use ValidatesCategoryAccess;
+
     protected static string $resource = ProductResource::class;
 
     protected function mutateFormDataBeforeCreate(array $data): array
     {
+        $this->ensureCategoryIsPermitted($data);
+
         if ($vendor = Auth::user()?->vendor) {
             $data['vendor_id'] = $vendor->id;
         }

--- a/app/Filament/Mine/Resources/Products/Pages/EditProduct.php
+++ b/app/Filament/Mine/Resources/Products/Pages/EditProduct.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Mine\Resources\Products\Pages;
 
+use App\Filament\Mine\Resources\Products\Pages\Concerns\ValidatesCategoryAccess;
 use App\Filament\Mine\Resources\Products\ProductResource;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
@@ -9,6 +10,8 @@ use Illuminate\Support\Facades\Auth;
 
 class EditProduct extends EditRecord
 {
+    use ValidatesCategoryAccess;
+
     protected static string $resource = ProductResource::class;
 
     protected function getHeaderActions(): array
@@ -43,6 +46,8 @@ class EditProduct extends EditRecord
 
     protected function mutateFormDataBeforeSave(array $data): array
     {
+        $this->ensureCategoryIsPermitted($data);
+
         if ($vendor = Auth::user()?->vendor) {
             $data['vendor_id'] = $this->record->vendor_id ?? $vendor->id;
         }

--- a/app/Filament/Mine/Resources/Products/Schemas/ProductForm.php
+++ b/app/Filament/Mine/Resources/Products/Schemas/ProductForm.php
@@ -77,7 +77,25 @@ class ProductForm
                     ->required(),
                 Select::make('category_id')
                     ->label(__('shop.products.fields.category'))
-                    ->relationship('category', 'name')
+                    ->relationship(
+                        name: 'category',
+                        titleAttribute: 'name',
+                        modifyQueryUsing: function (Builder $query) {
+                            $user = Auth::user();
+
+                            if ($user === null) {
+                                return $query;
+                            }
+
+                            $permittedCategoryIds = $user->permittedCategoryIds();
+
+                            if ($permittedCategoryIds->isEmpty()) {
+                                return $query;
+                            }
+
+                            return $query->whereIn('id', $permittedCategoryIds);
+                        }
+                    )
                     ->searchable()
                     ->preload()
                     ->native(false)

--- a/tests/Feature/Filament/Mine/Products/ProductCategoryRestrictionTest.php
+++ b/tests/Feature/Filament/Mine/Products/ProductCategoryRestrictionTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Enums\Permission as PermissionEnum;
+use App\Filament\Mine\Resources\Products\Pages\CreateProduct;
+use App\Models\Category;
+use App\Models\User;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Permission;
+use Illuminate\Validation\ValidationException;
+use Spatie\Invade\Invader;
+
+it('restricts product categories to the permitted set for catalog managers', function (): void {
+    Permission::findOrCreate(PermissionEnum::ManageProducts->value, 'web');
+
+    $permittedCategory = Category::factory()->create();
+    $restrictedCategory = Category::factory()->create();
+    $user = User::factory()->create();
+    $user->givePermissionTo(PermissionEnum::ManageProducts->value);
+    $user->categories()->attach($permittedCategory);
+
+    $this->actingAs($user);
+
+    if (! file_exists(base_path('.env'))) {
+        file_put_contents(base_path('.env'), '');
+    }
+
+    $component = Livewire::test(CreateProduct::class);
+
+    $options = $component->instance()->form->getComponent('category_id')->getOptions();
+
+    expect($options)->toHaveKey($permittedCategory->getKey());
+    expect($options)->not->toHaveKey($restrictedCategory->getKey());
+
+    (new Invader($component->instance()))->ensureCategoryIsPermitted([
+        'category_id' => (string) $permittedCategory->getKey(),
+    ]);
+
+    $restrictedComponent = Livewire::test(CreateProduct::class);
+
+    expect(fn () => (new Invader($restrictedComponent->instance()))->ensureCategoryIsPermitted([
+        'category_id' => (string) $restrictedCategory->getKey(),
+    ]))->toThrow(ValidationException::class);
+});


### PR DESCRIPTION
## Summary
- limit the Mine product category picker to the authenticated user’s permitted categories
- reuse a shared validator to block creating or editing products with unauthorized categories
- cover the category restriction behaviour with a Mine panel feature test

## Testing
- `vendor/bin/pest tests/Feature/Filament/Mine/Products/ProductCategoryRestrictionTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68d0cb08b9d8833192a44d840fbeb960