### PR TITLE
Use query builder for push campaign badge count

### DIFF
--- a/app/Filament/Mine/Resources/PushCampaigns/PushCampaignResource.php
+++ b/app/Filament/Mine/Resources/PushCampaigns/PushCampaignResource.php
@@ -90,7 +90,7 @@ class PushCampaignResource extends Resource
             return null;
         }
 
-        return (string) MarketingCampaign::push()->count();
+        return (string) MarketingCampaign::query()->push()->count();
     }
 
     public static function persistSchedule(MarketingCampaign $campaign, array $data): void


### PR DESCRIPTION
## Summary
- update the push campaign navigation badge to count campaigns via the query builder so the push scope is respected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0e1b864b483318760f996db265ec2