### PR TITLE
Adjust period filter query for top products widget

### DIFF
--- a/app/Filament/Mine/Widgets/TopProductsTable.php
+++ b/app/Filament/Mine/Widgets/TopProductsTable.php
@@ -60,6 +60,13 @@ class TopProductsTable extends TableWidget
                     ->label(__('shop.admin.dashboard.filters.period'))
                     ->options(DashboardPeriod::options())
                     ->default(DashboardPeriod::ThirtyDays->value)
+                    ->query(function (Builder $query, array $data) use ($metrics) {
+                        $period = DashboardPeriod::tryFromFilter($data['value'] ?? null);
+
+                        $metrics->applyPeriodConstraint($query, $period, 'orders.created_at');
+
+                        return $query;
+                    })
                     ->native(false),
             ]);
     }


### PR DESCRIPTION
## Summary
- ensure the top products period filter applies the metrics service constraint directly on the query

## Testing
- ./vendor/bin/phpunit *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f47cc55c83319344771a2a242f46