### PR TITLE
Ensure registration queues verification email

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -38,7 +38,7 @@ class AuthController extends Controller
 
         $user->loadMissing('twoFactorSecret');
 
-        $verificationUrl = $this->queueEmailVerification($user);
+        $verificationUrl = $this->queueEmailVerification($user, true);
 
         Mail::to($user)->queue(new WelcomeMail($user, $verificationUrl));
 


### PR DESCRIPTION
## Summary
- queue the registration verification email when registering a new user so the mailable is faked as expected

## Testing
- php artisan test --filter=Tests\\Feature\\Auth\\RegistrationTest

------
https://chatgpt.com/codex/tasks/task_e_68d11004462483319d1accee5b277cb3