### PR TITLE
Adjust Livewire component test setup

### DIFF
--- a/tests/Feature/Filament/Mine/Inventory/CreateInventoryTest.php
+++ b/tests/Feature/Filament/Mine/Inventory/CreateInventoryTest.php
@@ -14,18 +14,16 @@ it('validates unique product and warehouse combination when creating inventory',
 
     $this->actingAs($user);
 
-    $component = null;
+    $component = Livewire::test(CreateInventory::class)
+        ->fillForm([
+            'product_id' => $product->getKey(),
+            'warehouse_id' => $warehouse->getKey(),
+            'qty' => 5,
+            'reserved' => 0,
+        ]);
 
-    expect(function () use (&$component, $product, $warehouse) {
-        $component = Livewire::test(CreateInventory::class)
-            ->fillForm([
-                'product_id' => $product->getKey(),
-                'warehouse_id' => $warehouse->getKey(),
-                'qty' => 5,
-                'reserved' => 0,
-            ])
-            ->call('create');
-    })->not->toThrow(UniqueConstraintViolationException::class);
+    expect(fn () => $component->call('create'))
+        ->not->toThrow(UniqueConstraintViolationException::class);
 
     $component->assertHasErrors(['data.product_id']);
 


### PR DESCRIPTION
## Summary
- initialize the Livewire test component before invoking the create action
- call the create action separately to keep the component instance available for assertions
- ensure the uniqueness validation assertion runs on the TestableLivewire instance

## Testing
- php artisan test --filter=Tests\\Feature\\Filament\\Mine\\Inventory\\CreateInventoryTest *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1135ee8608331a99a2d9f5d9912b1