### PR TITLE
Ensure localization fallback updates translator

### DIFF
--- a/tests/Feature/LocalizationTest.php
+++ b/tests/Feature/LocalizationTest.php
@@ -16,9 +16,15 @@ it('returns localized order shipment subject for each supported locale', functio
 ]);
 
 it('falls back to english when locale has no translation', function () {
+    $originalFallback = App::getFallbackLocale();
+
     Config::set('app.fallback_locale', 'en');
+    App::setFallbackLocale('en');
     App::setLocale('fr');
 
     expect(__('shop.orders.shipped.subject'))
         ->toBe('Order on the way');
+
+    App::setFallbackLocale($originalFallback);
+    Config::set('app.fallback_locale', $originalFallback);
 });


### PR DESCRIPTION
## Summary
- ensure the localization fallback configuration also updates the translator fallback and restore the original value after the test

## Testing
- php artisan test --filter=Tests\\Feature\\LocalizationTest
- ./vendor/bin/pest tests/Feature/LocalizationTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d114771acc8331b62838c1e9733d3a