### PR TITLE
Update currency expectation in order mail test

### DIFF
--- a/tests/Feature/Mail/OrderEmailsTest.php
+++ b/tests/Feature/Mail/OrderEmailsTest.php
@@ -28,7 +28,7 @@ class OrderEmailsTest extends TestCase
 
         $this->assertStringContainsString('Оплату отримано', $html);
         $this->assertStringContainsString($order->number, $html);
-        $this->assertStringContainsString('грн', $html);
+        $this->assertStringContainsString('UAH', $html);
     }
 
     public function test_order_shipped_mail_highlights_shipment_status(): void


### PR DESCRIPTION
## Summary
- update the order paid mail feature test to expect the new formatted currency code

## Testing
- php artisan test --filter=Tests\\Feature\\Mail\\OrderEmailsTest

------
https://chatgpt.com/codex/tasks/task_e_68d11693855083318158913cae75d823