### PR TITLE
Adjust cart cookie flags

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -174,9 +174,11 @@ App\Enums\OrderStatus:
     → 200: { facets, nbHits, driver, error? }
 ```
 
-4.4 Кошик   
+4.4 Кошик
 (у нас hook useCart() — бекенд має мати типові REST-ендпоїнти: /api/cart GET/POST/PUT/DELETE).
 Фактичні назви/схема залежать від вашої реалізації (ми інтегрували «як було»).
+Бекенд виставляє cookie `cart_id` (SameSite=Lax, HttpOnly=true). Прапор `Secure` бере значення з `config('session.secure')`,
+а за його відсутності — з `app()->environment('production')`, тому для axios потрібно `withCredentials: true`.
 
 4.5 Замовлення  
 ```bash

--- a/app/Http/Controllers/Api/CartController.php
+++ b/app/Http/Controllers/Api/CartController.php
@@ -48,8 +48,13 @@ class CartController extends Controller
             $cart->load($relations);
         }
 
+        $secureCookie = config('session.secure');
+        if ($secureCookie === null) {
+            $secureCookie = app()->environment('production');
+        }
+
         return $this->cartResponse($cart)
-            ->cookie('cart_id', $cart->id, 60 * 24 * 30, '/', null, false, false, 'Lax');
+            ->cookie('cart_id', $cart->id, 60 * 24 * 30, '/', null, (bool) $secureCookie, true, 'Lax');
     }
 
     public function show(string $id): JsonResponse

--- a/tests/Feature/CartCookieTest.php
+++ b/tests/Feature/CartCookieTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Arr;
+use Tests\TestCase;
+
+class CartCookieTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function getCartCookie(array $cookies)
+    {
+        return Arr::first($cookies, fn ($cookie) => $cookie->getName() === 'cart_id');
+    }
+
+    public function test_cart_cookie_respects_session_secure_config(): void
+    {
+        config()->set('session.secure', true);
+
+        $response = $this->getJson('/api/cart');
+
+        $cartCookie = $this->getCartCookie($response->headers->getCookies());
+
+        $this->assertNotNull($cartCookie);
+        $this->assertTrue($cartCookie->isSecure());
+        $this->assertTrue($cartCookie->isHttpOnly());
+        $this->assertSame('lax', strtolower($cartCookie->getSameSite()));
+    }
+
+    public function test_cart_cookie_falls_back_to_environment(): void
+    {
+        config()->set('session.secure', null);
+
+        $response = $this->getJson('/api/cart');
+
+        $cartCookie = $this->getCartCookie($response->headers->getCookies());
+
+        $this->assertNotNull($cartCookie);
+        $this->assertSame(app()->environment('production'), $cartCookie->isSecure());
+        $this->assertTrue($cartCookie->isHttpOnly());
+        $this->assertSame('lax', strtolower($cartCookie->getSameSite()));
+    }
+}


### PR DESCRIPTION
## Summary
- make the cart cookie honor the session secure configuration (fallback to production env) and force HttpOnly
- cover the cart cookie behaviour with feature tests for secure/httpOnly/SameSite flags
- document the cart cookie requirements, including axios withCredentials

## Testing
- php artisan test --filter=CartCookieTest

------
https://chatgpt.com/codex/tasks/task_e_68d13d42d05c8331b7bf371bdad665cf