### PR TITLE
Respect request locale for auth mails

### DIFF
--- a/app/Listeners/SendPasswordChangedMail.php
+++ b/app/Listeners/SendPasswordChangedMail.php
@@ -10,6 +10,10 @@ class SendPasswordChangedMail
 {
     public function handle(PasswordReset $event): void
     {
-        Mail::to($event->user)->queue(new PasswordChangedMail($event->user));
+        $locale = resolveMailLocale();
+
+        Mail::to($event->user)
+            ->locale($locale)
+            ->queue((new PasswordChangedMail($event->user))->locale($locale));
     }
 }

--- a/app/Mail/PasswordChangedMail.php
+++ b/app/Mail/PasswordChangedMail.php
@@ -18,13 +18,17 @@ class PasswordChangedMail extends Mailable implements ShouldQueue
 
     public function build(): self
     {
-        $appName = config('app.name', 'Shop');
+        $locale = $this->locale ?: app()->getLocale() ?: (string) config('app.fallback_locale', 'en');
 
-        return $this->subject(__('shop.auth.reset.changed_subject', ['app' => $appName]))
-            ->tag('auth-password-changed')
-            ->metadata(['type' => 'auth'])
-            ->view('emails.auth.password-changed', [
-                'user' => $this->user,
-            ]);
+        return $this->withLocale($locale, function () use ($locale) {
+            $appName = config('app.name', 'Shop');
+
+            return $this->subject(__('shop.auth.reset.changed_subject', ['app' => $appName], $locale))
+                ->tag('auth-password-changed')
+                ->metadata(['type' => 'auth'])
+                ->view('emails.auth.password-changed', [
+                    'user' => $this->user,
+                ]);
+        });
     }
 }

--- a/app/Mail/ResetPasswordMail.php
+++ b/app/Mail/ResetPasswordMail.php
@@ -24,16 +24,20 @@ class ResetPasswordMail extends Mailable implements ShouldQueue
 
     public function build(): self
     {
-        $appName = config('app.name', 'Shop');
+        $locale = $this->locale ?: app()->getLocale() ?: (string) config('app.fallback_locale', 'en');
 
-        return $this->subject(__('shop.auth.reset.subject', ['app' => $appName]))
-            ->tag('auth-password-reset')
-            ->metadata(['type' => 'auth'])
-            ->view('emails.auth.reset-password', [
-                'user' => $this->user,
-                'resetUrl' => $this->resetUrl,
-                'displayUrl' => $this->displayUrl,
-            ]);
+        return $this->withLocale($locale, function () use ($locale) {
+            $appName = config('app.name', 'Shop');
+
+            return $this->subject(__('shop.auth.reset.subject', ['app' => $appName], $locale))
+                ->tag('auth-password-reset')
+                ->metadata(['type' => 'auth'])
+                ->view('emails.auth.reset-password', [
+                    'user' => $this->user,
+                    'resetUrl' => $this->resetUrl,
+                    'displayUrl' => $this->displayUrl,
+                ]);
+        });
     }
 
     protected function makeResetUrl(): string

--- a/app/Mail/VerifyEmailMail.php
+++ b/app/Mail/VerifyEmailMail.php
@@ -21,16 +21,20 @@ class VerifyEmailMail extends Mailable implements ShouldQueue
 
     public function build(): self
     {
-        $appName = config('app.name', 'Shop');
+        $locale = $this->locale ?: app()->getLocale() ?: (string) config('app.fallback_locale', 'en');
 
-        return $this->subject(__('shop.auth.verify.subject', ['app' => $appName]))
-            ->tag('auth-verify-email')
-            ->metadata(['type' => 'auth'])
-            ->view('emails.auth.verify-email', [
-                'user' => $this->user,
-                'verificationUrl' => $this->verificationUrl,
-                'displayUrl' => $this->displayUrl,
-            ]);
+        return $this->withLocale($locale, function () use ($locale) {
+            $appName = config('app.name', 'Shop');
+
+            return $this->subject(__('shop.auth.verify.subject', ['app' => $appName], $locale))
+                ->tag('auth-verify-email')
+                ->metadata(['type' => 'auth'])
+                ->view('emails.auth.verify-email', [
+                    'user' => $this->user,
+                    'verificationUrl' => $this->verificationUrl,
+                    'displayUrl' => $this->displayUrl,
+                ]);
+        });
     }
 
     protected function makeDisplayUrl(string $url): string

--- a/app/Mail/WelcomeMail.php
+++ b/app/Mail/WelcomeMail.php
@@ -21,16 +21,20 @@ class WelcomeMail extends Mailable implements ShouldQueue
 
     public function build(): self
     {
-        $appName = config('app.name', 'Shop');
+        $locale = $this->locale ?: app()->getLocale() ?: (string) config('app.fallback_locale', 'en');
 
-        return $this->subject(__('shop.auth.welcome.subject', ['app' => $appName]))
-            ->tag('auth-welcome')
-            ->metadata(['type' => 'auth'])
-            ->view('emails.auth.welcome', [
-                'user' => $this->user,
-                'verificationUrl' => $this->verificationUrl,
-                'displayUrl' => $this->displayUrl,
-            ]);
+        return $this->withLocale($locale, function () use ($locale) {
+            $appName = config('app.name', 'Shop');
+
+            return $this->subject(__('shop.auth.welcome.subject', ['app' => $appName], $locale))
+                ->tag('auth-welcome')
+                ->metadata(['type' => 'auth'])
+                ->view('emails.auth.welcome', [
+                    'user' => $this->user,
+                    'verificationUrl' => $this->verificationUrl,
+                    'displayUrl' => $this->displayUrl,
+                ]);
+        });
     }
 
     protected function makeDisplayUrl(?string $url): ?string

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -149,6 +149,10 @@ class User extends Authenticatable implements FilamentUser, MustVerifyEmail
 
     public function sendPasswordResetNotification($token): void
     {
-        Mail::to($this)->queue(new ResetPasswordMail($this, $token));
+        $locale = resolveMailLocale();
+
+        Mail::to($this)
+            ->locale($locale)
+            ->queue((new ResetPasswordMail($this, $token))->locale($locale));
     }
 }

--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Support\CurrencyFormatter;
+use Illuminate\Http\Request;
 
 if (! function_exists('currencySymbol')) {
     function currencySymbol(?string $currency = null): string
@@ -20,5 +21,32 @@ if (! function_exists('formatCurrency')) {
     function formatCurrency(float|int|string|null $amount, ?string $currency = null, int $decimals = 2): string
     {
         return CurrencyFormatter::format($amount, $currency, $decimals);
+    }
+}
+
+if (! function_exists('resolveMailLocale')) {
+    function resolveMailLocale(?Request $request = null): string
+    {
+        $request ??= request();
+
+        $locale = null;
+
+        if ($request instanceof Request) {
+            $cookieLocale = $request->cookie('lang');
+
+            if (is_string($cookieLocale) && $cookieLocale !== '') {
+                $locale = $cookieLocale;
+            }
+        }
+
+        if (!is_string($locale) || $locale === '') {
+            $locale = app()->getLocale();
+        }
+
+        if (!is_string($locale) || $locale === '') {
+            $locale = (string) config('app.fallback_locale', 'en');
+        }
+
+        return $locale;
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -17,7 +17,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
+        $middleware->encryptCookies(except: ['appearance', 'sidebar_state', 'lang']);
 
         $middleware->api(prepend: [
             EncryptCookies::class,

--- a/tests/Feature/Auth/PasswordUpdateTest.php
+++ b/tests/Feature/Auth/PasswordUpdateTest.php
@@ -15,7 +15,7 @@ it('queues password changed email when password is updated', function () {
 
     Sanctum::actingAs($user, [], 'sanctum');
 
-    $response = $this->putJson('/api/auth/me', [
+    $response = $this->withUnencryptedCookie('lang', 'es')->withCredentials()->putJson('/api/auth/me', [
         'password' => 'new-secure-password',
         'password_confirmation' => 'new-secure-password',
     ]);
@@ -24,6 +24,7 @@ it('queues password changed email when password is updated', function () {
 
     Mail::assertQueued(PasswordChangedMail::class, function (PasswordChangedMail $mail) use ($user) {
         $mail->assertHasTag('auth-password-changed')->assertHasMetadata('type', 'auth');
+        expect($mail->locale)->toBe('es');
 
         return $mail->user->is($user);
     });

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -20,7 +20,7 @@ beforeEach(function () {
 it('sends verification and welcome mails when registering', function () {
     Mail::fake();
 
-    $response = $this->postJson('/api/auth/register', [
+    $response = $this->withUnencryptedCookie('lang', 'pt')->withCredentials()->postJson('/api/auth/register', [
         'name' => 'Jane Doe',
         'email' => 'jane@example.com',
         'password' => 'super-secret',
@@ -33,6 +33,7 @@ it('sends verification and welcome mails when registering', function () {
     Mail::assertQueued(VerifyEmailMail::class, function (VerifyEmailMail $mail) use ($user) {
         expect($mail->verificationUrl)->toBeString();
         expect($mail->displayUrl)->toBe(expectedDisplayUrl($mail->verificationUrl));
+        expect($mail->locale)->toBe('pt');
 
         $rendered = $mail->render();
         $escapedUrl = e($mail->verificationUrl);
@@ -47,6 +48,7 @@ it('sends verification and welcome mails when registering', function () {
     Mail::assertQueued(WelcomeMail::class, function (WelcomeMail $mail) use ($user) {
         expect($mail->verificationUrl)->toBeString();
         expect($mail->displayUrl)->toBe(expectedDisplayUrl($mail->verificationUrl));
+        expect($mail->locale)->toBe('pt');
 
         $rendered = $mail->render();
         $escapedUrl = e($mail->verificationUrl);


### PR DESCRIPTION
## Summary
- resolve the preferred locale from the current request (prioritising the `lang` cookie) when queueing auth-related mails and ensure the queue helper uses that locale for verification messages
- teach password change/reset listeners and user notifications to queue their mailables with the resolved locale and update each auth mailable to render with that locale
- treat the `lang` cookie as unencrypted and expand feature tests to assert queued mails honour the cookie-provided locale

## Testing
- php artisan test tests/Feature/Auth/RegistrationTest.php tests/Feature/Auth/PasswordResetTest.php tests/Feature/Auth/PasswordUpdateTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d15cfa6a1c8331834d02024552ff11