### PR TITLE
Allow order owners to post order messages

### DIFF
--- a/app/Policies/OrderPolicy.php
+++ b/app/Policies/OrderPolicy.php
@@ -62,6 +62,10 @@ class OrderPolicy
 
     public function createMessage(User $user, Order $order): bool
     {
+        if ($order->user_id === $user->id) {
+            return true;
+        }
+
         if (! $user->hasPermissionTo(Permission::ManageOrders->value)) {
             return false;
         }

--- a/tests/Feature/Api/OrderMessagesTest.php
+++ b/tests/Feature/Api/OrderMessagesTest.php
@@ -1,9 +1,12 @@
 <?php
 
+use App\Enums\Permission as PermissionEnum;
 use App\Models\Order;
 use App\Models\User;
 use Laravel\Sanctum\Sanctum;
 use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+use Spatie\Permission\Models\Permission;
 
 it('allows an order owner to view their order messages', function () {
     $owner = User::factory()->create();
@@ -29,4 +32,34 @@ it('forbids other customers from viewing order messages', function () {
 
     getJson("/api/orders/{$order->id}/messages")
         ->assertForbidden();
+});
+
+it('allows an order owner to post messages to their order', function () {
+    $owner = User::factory()->create();
+    $order = Order::factory()->create([
+        'user_id' => $owner->id,
+    ]);
+
+    Sanctum::actingAs($owner, [], 'sanctum');
+
+    postJson("/api/orders/{$order->id}/messages", [
+        'body' => 'Hello from the customer!',
+    ])->assertCreated();
+});
+
+it('forbids other customers from posting messages to an order', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+
+    $order = Order::factory()->create([
+        'user_id' => $owner->id,
+    ]);
+
+    Permission::findOrCreate(PermissionEnum::ManageOrders->value);
+
+    Sanctum::actingAs($other, [], 'sanctum');
+
+    postJson("/api/orders/{$order->id}/messages", [
+        'body' => 'I should not be able to post this.',
+    ])->assertForbidden();
 });


### PR DESCRIPTION
## Summary
- allow order owners to create order messages without requiring the ManageOrders permission
- keep staff permission checks intact and cover owner/non-owner message posting with API tests

## Testing
- php artisan test --filter=OrderMessagesTest

------
https://chatgpt.com/codex/tasks/task_e_68d16a9103c88331aa1d9fa15105f4a2