### PR TITLE
Fix category name saving from translations

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -36,6 +36,31 @@ class Category extends Model
 
     protected static function booted(): void
     {
+        static::saving(function (self $category): void {
+            if ($category->isDirty('name')) {
+                return;
+            }
+
+            $translations = $category->getAttribute('name_translations');
+
+            if (! is_array($translations)) {
+                return;
+            }
+
+            $primaryLocale = config('app.locale');
+            $fallbackLocale = config('app.fallback_locale');
+
+            $name = $translations[$primaryLocale] ?? null;
+
+            if ($name === null && $fallbackLocale) {
+                $name = $translations[$fallbackLocale] ?? null;
+            }
+
+            if ($name !== null) {
+                $category->setAttribute('name', $name);
+            }
+        });
+
         $clear = fn () => static::clearCache();
 
         static::created($clear);


### PR DESCRIPTION
## Summary
- ensure the category `name` attribute is populated from available translations when saving
- keep cache clearing hooks while preventing null `name` values in the database

## Testing
- ⚠️ `composer test` *(fails: vendor directory is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3bb898e588331b6799766573d9209