### PR TITLE
Show parent category name in admin list

### DIFF
--- a/app/Filament/Mine/Resources/Categories/Tables/CategoriesTable.php
+++ b/app/Filament/Mine/Resources/Categories/Tables/CategoriesTable.php
@@ -20,10 +20,10 @@ class CategoriesTable
                 TextColumn::make('slug')
                     ->label(__('shop.categories.fields.slug'))
                     ->searchable(),
-                TextColumn::make('parent_id')
+                TextColumn::make('parent.name')
                     ->label(__('shop.categories.fields.parent'))
-                    ->numeric()
-                    ->sortable(),
+                    ->sortable()
+                    ->searchable(),
                 TextColumn::make('deleted_at')
                     ->label(__('shop.categories.fields.deleted_at'))
                     ->dateTime()


### PR DESCRIPTION
## Summary
- display the parent category name instead of the raw parent id in the categories table
- enable searching and sorting against the parent category column

## Testing
- php artisan test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68d3bde731548331998cee4e496de84f