### PR TITLE
Add consistent international phone formatting

### DIFF
--- a/app/Filament/Mine/Resources/Orders/Pages/CreateOrder.php
+++ b/app/Filament/Mine/Resources/Orders/Pages/CreateOrder.php
@@ -6,6 +6,7 @@ use App\Enums\ShipmentStatus;
 use App\Filament\Mine\Resources\Orders\OrderResource;
 use App\Models\Address;
 use App\Models\Order;
+use App\Support\Phone;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateOrder extends CreateRecord
@@ -73,7 +74,7 @@ class CreateOrder extends CreateRecord
             'city' => $address['city'] ?? null,
             'addr' => $address['addr'] ?? null,
             'postal_code' => $address['postal_code'] ?? null,
-            'phone' => $address['phone'] ?? null,
+            'phone' => Phone::normalize($address['phone'] ?? null),
         ];
     }
 

--- a/app/Filament/Mine/Resources/Orders/Pages/EditOrder.php
+++ b/app/Filament/Mine/Resources/Orders/Pages/EditOrder.php
@@ -6,6 +6,7 @@ use App\Enums\ShipmentStatus;
 use App\Filament\Mine\Resources\Orders\OrderResource;
 use App\Models\Address;
 use App\Models\Shipment;
+use App\Support\Phone;
 use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
@@ -145,7 +146,7 @@ class EditOrder extends EditRecord
             'city' => $address['city'] ?? null,
             'addr' => $address['addr'] ?? null,
             'postal_code' => $address['postal_code'] ?? null,
-            'phone' => $address['phone'] ?? null,
+            'phone' => Phone::normalize($address['phone'] ?? null),
         ];
     }
 

--- a/app/Filament/Mine/Resources/Orders/Schemas/OrderForm.php
+++ b/app/Filament/Mine/Resources/Orders/Schemas/OrderForm.php
@@ -6,6 +6,7 @@ use App\Enums\OrderStatus;
 use App\Enums\ShipmentStatus;
 use App\Models\Order;
 use App\Models\User;
+use App\Support\Phone;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
@@ -70,7 +71,15 @@ class OrderForm
                         TextInput::make('shipping_address.city')->label(__('shop.common.city')),
                         TextInput::make('shipping_address.addr')->label(__('shop.common.address')),
                         TextInput::make('shipping_address.postal_code')->label(__('shop.common.postal_code')),
-                        TextInput::make('shipping_address.phone')->label(__('shop.common.phone'))->tel(),
+                        TextInput::make('shipping_address.phone')
+                            ->label(__('shop.common.phone'))
+                            ->placeholder('+123 456 789 012')
+                            ->tel()
+                            ->live(onBlur: true)
+                            ->afterStateHydrated(fn (TextInput $component, $state) => $component->state(Phone::format($state)))
+                            ->afterStateUpdated(function (Set $set, $state): void {
+                                $set('shipping_address.phone', Phone::format($state));
+                            }),
                     ])->columns(2),
 
                     Fieldset::make(__('shop.orders.fieldsets.billing_address'))->schema([
@@ -78,7 +87,15 @@ class OrderForm
                         TextInput::make('billing_address.city')->label(__('shop.common.city')),
                         TextInput::make('billing_address.addr')->label(__('shop.common.address')),
                         TextInput::make('billing_address.postal_code')->label(__('shop.common.postal_code')),
-                        TextInput::make('billing_address.phone')->label(__('shop.common.phone'))->tel(),
+                        TextInput::make('billing_address.phone')
+                            ->label(__('shop.common.phone'))
+                            ->placeholder('+123 456 789 012')
+                            ->tel()
+                            ->live(onBlur: true)
+                            ->afterStateHydrated(fn (TextInput $component, $state) => $component->state(Phone::format($state)))
+                            ->afterStateUpdated(function (Set $set, $state): void {
+                                $set('billing_address.phone', Phone::format($state));
+                            }),
                     ])->columns(2),
                 ])->columns(1),
 

--- a/app/Filament/Mine/Resources/Vendors/Schemas/VendorForm.php
+++ b/app/Filament/Mine/Resources/Vendors/Schemas/VendorForm.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Mine\Resources\Vendors\Schemas;
 
+use App\Support\Phone;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
@@ -49,6 +50,13 @@ class VendorForm
                     ->maxLength(255),
                 TextInput::make('contact_phone')
                     ->label(__('shop.common.phone'))
+                    ->placeholder('+123 456 789 012')
+                    ->tel()
+                    ->live(onBlur: true)
+                    ->afterStateHydrated(fn (TextInput $component, $state) => $component->state(Phone::format($state)))
+                    ->afterStateUpdated(function (Set $set, $state): void {
+                        $set('contact_phone', Phone::format($state));
+                    })
                     ->maxLength(255),
                 Textarea::make('description')
                     ->label(__('shop.vendor.fields.description'))

--- a/app/Filament/Mine/Resources/Vendors/Tables/VendorsTable.php
+++ b/app/Filament/Mine/Resources/Vendors/Tables/VendorsTable.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Mine\Resources\Vendors\Tables;
 
 use App\Models\Vendor;
+use App\Support\Phone;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
@@ -41,6 +42,7 @@ class VendorsTable
                     ->toggleable(),
                 TextColumn::make('contact_phone')
                     ->label(__('shop.common.phone'))
+                    ->formatStateUsing(static fn (?string $state): ?string => Phone::format($state))
                     ->toggleable(),
                 TextColumn::make('created_at')
                     ->label(__('shop.vendor.fields.created_at'))

--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\{Address, Cart, Coupon, LoyaltyPointTransaction, Order, OrderItem, Warehouse};
+use App\Support\Phone;
 use App\Enums\ShipmentStatus;
 use App\Services\Carts\CartPricingService;
 use App\Services\Currency\CurrencyConverter;
@@ -146,7 +147,7 @@ class OrderController extends Controller
                 'city' => $data['shipping_address']['city'],
                 'addr' => $data['shipping_address']['addr'],
                 'postal_code' => $data['shipping_address']['postal_code'] ?? null,
-                'phone' => $data['shipping_address']['phone'] ?? null,
+                'phone' => Phone::normalize($data['shipping_address']['phone'] ?? null),
             ];
 
             $addressAttributes = array_merge([
@@ -175,7 +176,11 @@ class OrderController extends Controller
                 'total' => $totals->total,
                 'shipping_address' => $addressPayload,
                 'shipping_address_id' => $shippingAddress->id,
-                'billing_address' => $data['billing_address'] ?? null,
+                'billing_address' => isset($data['billing_address'])
+                    ? array_merge($data['billing_address'], [
+                        'phone' => Phone::normalize($data['billing_address']['phone'] ?? null),
+                    ])
+                    : null,
                 'note' => $data['note'] ?? null,
                 'inventory_committed_at' => now(),
                 'currency' => $this->converter->getBaseCurrency(),

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Support\Phone;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -33,5 +35,13 @@ class Address extends Model
     public function shipments(): HasMany
     {
         return $this->hasMany(Shipment::class);
+    }
+
+    protected function phone(): Attribute
+    {
+        return Attribute::make(
+            get: static fn (?string $value): ?string => Phone::format($value),
+            set: static fn (?string $value): ?string => Phone::normalize($value),
+        );
     }
 }

--- a/app/Models/Vendor.php
+++ b/app/Models/Vendor.php
@@ -3,11 +3,13 @@
 namespace App\Models;
 
 use App\Models\Concerns\HasTranslations;
+use App\Support\Phone;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Builder;
 
 class Vendor extends Model
 {
@@ -85,5 +87,13 @@ class Vendor extends Model
         }
 
         return $query->whereKey($user->vendor->id);
+    }
+
+    protected function contactPhone(): Attribute
+    {
+        return Attribute::make(
+            get: static fn (?string $value): ?string => Phone::format($value),
+            set: static fn (?string $value): ?string => Phone::normalize($value),
+        );
     }
 }

--- a/app/Support/Phone.php
+++ b/app/Support/Phone.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Support;
+
+final class Phone
+{
+    private const MAX_DIGITS = 15;
+
+    public static function format(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        if ($trimmed === '') {
+            return '';
+        }
+
+        $sanitized = preg_replace('/[^+\d]/', '', $trimmed) ?? '';
+        if ($sanitized === '') {
+            return '';
+        }
+
+        $sanitized = preg_replace('/(?!^)\+/', '', $sanitized) ?? '';
+        if ($sanitized === '') {
+            return '';
+        }
+
+        if (! str_starts_with($sanitized, '+')) {
+            $sanitized = '+' . ltrim($sanitized, '+');
+        }
+
+        $digits = substr(preg_replace('/\D/', '', $sanitized) ?? '', 0, self::MAX_DIGITS);
+
+        if ($digits === '') {
+            return '+';
+        }
+
+        $chunks = str_split($digits, 3);
+
+        return '+' . implode(' ', $chunks);
+    }
+
+    public static function normalize(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $formatted = self::format($value);
+
+        if ($formatted === null || $formatted === '') {
+            return null;
+        }
+
+        $digits = preg_replace('/\D/', '', $formatted) ?? '';
+
+        if ($digits === '') {
+            return null;
+        }
+
+        return '+' . substr($digits, 0, self::MAX_DIGITS);
+    }
+}

--- a/resources/js/shop/__tests__/SellerPage.test.tsx
+++ b/resources/js/shop/__tests__/SellerPage.test.tsx
@@ -121,7 +121,7 @@ describe('SellerPage localization', () => {
         expect(lastSeoCallUk).toBeDefined();
         expect(lastSeoCallUk?.title).toBe('ACME Studio — Продавець — 3D-Print Shop');
         expect(lastSeoCallUk?.description).toBe(
-            'Handmade miniatures and accessories. Email: acme@example.com Телефон: +380501234567',
+            'Handmade miniatures and accessories. Email: acme@example.com Телефон: +380 501 234 567',
         );
 
         await act(async () => {
@@ -141,7 +141,7 @@ describe('SellerPage localization', () => {
         expect(lastSeoCallEn).toBeDefined();
         expect(lastSeoCallEn?.title).toBe('ACME Studio — Seller — 3D-Print Shop');
         expect(lastSeoCallEn?.description).toBe(
-            'Handmade miniatures and accessories. Email: acme@example.com Phone: +380501234567',
+            'Handmade miniatures and accessories. Email: acme@example.com Phone: +380 501 234 567',
         );
     });
 });

--- a/resources/js/shop/lib/phone.ts
+++ b/resources/js/shop/lib/phone.ts
@@ -1,0 +1,54 @@
+const NON_DIGIT_PLUS = /[^\d+]/g;
+const NON_DIGIT = /[^\d]/g;
+const MAX_PHONE_DIGITS = 15;
+
+const splitIntoGroups = (digits: string): string[] => {
+    const groups: string[] = [];
+    for (let index = 0; index < digits.length; index += 3) {
+        groups.push(digits.slice(index, index + 3));
+    }
+    return groups;
+};
+
+export const formatInternationalPhoneInput = (value: string): string => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return '';
+    }
+
+    const sanitized = trimmed.replace(NON_DIGIT_PLUS, '');
+    if (!sanitized) {
+        return '';
+    }
+
+    if (sanitized === '+') {
+        return '+';
+    }
+
+    const digits = sanitized.replace(NON_DIGIT, '').slice(0, MAX_PHONE_DIGITS);
+    if (!digits) {
+        return '+';
+    }
+
+    const groups = splitIntoGroups(digits);
+    return `+${groups.join(' ')}`;
+};
+
+export const normalizeInternationalPhone = (value: string): string | null => {
+    const formatted = formatInternationalPhoneInput(value);
+    const digits = formatted.replace(NON_DIGIT, '');
+
+    if (!digits) {
+        return null;
+    }
+
+    return `+${digits}`;
+};
+
+export const formatPhoneForDisplay = (value?: string | null): string => {
+    if (typeof value !== 'string' || value.trim() === '') {
+        return '';
+    }
+
+    return formatInternationalPhoneInput(value);
+};

--- a/resources/js/shop/pages/OrderConfirmation.tsx
+++ b/resources/js/shop/pages/OrderConfirmation.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import {useParams, Link, useSearchParams} from 'react-router-dom';
 import { OrdersApi, refreshOrderStatus, type Product } from '../api';
+import { formatPhoneForDisplay } from '../lib/phone';
 import { formatPrice } from '../ui/format';
 import SeoHead from '../components/SeoHead';
 import { GA } from '../ui/ga';
@@ -205,7 +206,9 @@ export default function OrderConfirmation() {
                         {order.shipping_address.city && <div>{order.shipping_address.city}</div>}
                         {order.shipping_address.addr && <div>{order.shipping_address.addr}</div>}
                         {order.shipping_address.postal_code && <div>{order.shipping_address.postal_code}</div>}
-                        {order.shipping_address.phone && <div>{order.shipping_address.phone}</div>}
+                        {order.shipping_address.phone && (
+                            <div>{formatPhoneForDisplay(order.shipping_address.phone)}</div>
+                        )}
                     </div>
                 )}
             </div>
@@ -223,7 +226,9 @@ export default function OrderConfirmation() {
                         {billingAddress.city && <div>{billingAddress.city}</div>}
                         {billingAddress.addr && <div>{billingAddress.addr}</div>}
                         {billingAddress.postal_code && <div>{billingAddress.postal_code}</div>}
-                        {billingAddress.phone && <div>{billingAddress.phone}</div>}
+                        {billingAddress.phone && (
+                            <div>{formatPhoneForDisplay(billingAddress.phone)}</div>
+                        )}
                     </div>
                 </div>
             )}

--- a/resources/js/shop/pages/ProfileAddresses.tsx
+++ b/resources/js/shop/pages/ProfileAddresses.tsx
@@ -5,6 +5,7 @@ import ProfileNavigation from '../components/ProfileNavigation';
 import useAuth from '../hooks/useAuth';
 import { useLocale } from '../i18n/LocaleProvider';
 import { resolveErrorMessage } from '../lib/errors';
+import { formatPhoneForDisplay } from '../lib/phone';
 
 export default function ProfileAddressesPage() {
     const { t } = useLocale();
@@ -100,7 +101,7 @@ export default function ProfileAddressesPage() {
                                     {address.phone && (
                                         <div>
                                             <dt className="font-medium text-gray-900">{t('profile.addresses.list.fields.phone')}</dt>
-                                            <dd>{address.phone}</dd>
+                                            <dd>{formatPhoneForDisplay(address.phone)}</dd>
                                         </div>
                                     )}
                                 </dl>

--- a/resources/js/shop/pages/SellerPage.tsx
+++ b/resources/js/shop/pages/SellerPage.tsx
@@ -7,6 +7,7 @@ import SeoHead from '../components/SeoHead';
 import WishlistButton from '../components/WishlistButton';
 import { fetchSellerProducts, type Product, type SellerProductsResponse, type Vendor } from '../api';
 import { resolveErrorMessage } from '../lib/errors';
+import { formatPhoneForDisplay, normalizeInternationalPhone } from '../lib/phone';
 import { formatPrice } from '../ui/format';
 import { GA } from '../ui/ga';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
@@ -92,10 +93,11 @@ export default function SellerPage() {
     useDocumentTitle(documentTitle);
 
     const seoTitle = t('sellerPage.seo.title', { name: vendor?.name, brand });
+    const formattedVendorPhone = formatPhoneForDisplay(vendor?.contact_phone);
     const seoDescription = t('sellerPage.seo.description', {
         description: vendor?.description ?? '',
         email: vendor?.contact_email ?? '',
-        phone: vendor?.contact_phone ?? '',
+        phone: formattedVendorPhone,
     });
 
     const canPrev = page > 1;
@@ -110,8 +112,9 @@ export default function SellerPage() {
     const emailLabel = vendor?.contact_email
         ? t('sellerPage.contact.email', { email: vendor.contact_email })
         : null;
-    const phoneLabel = vendor?.contact_phone
-        ? t('sellerPage.contact.phone', { phone: vendor.contact_phone })
+    const phoneHref = vendor?.contact_phone ? normalizeInternationalPhone(vendor.contact_phone) : null;
+    const phoneLabel = vendor?.contact_phone && formattedVendorPhone
+        ? t('sellerPage.contact.phone', { phone: formattedVendorPhone })
         : null;
 
     const paginationStatus = t('sellerPage.pagination.status', { page, lastPage });
@@ -137,9 +140,9 @@ export default function SellerPage() {
                                     {emailLabel}
                                 </a>
                             )}
-                            {vendor.contact_phone && phoneLabel && (
+                            {vendor.contact_phone && phoneLabel && phoneHref && (
                                 <a
-                                    href={`tel:${vendor.contact_phone}`}
+                                    href={`tel:${phoneHref}`}
                                     className="text-blue-600 hover:text-blue-800 hover:underline"
                                 >
                                     {phoneLabel}


### PR DESCRIPTION
## Summary
- add shared helpers to normalize and format international phone numbers on the storefront and in Filament admin forms
- normalize phone storage across addresses, orders, and vendors while formatting phone values for display in the API and UI
- update checkout, profile, seller, and confirmation views to show formatted phones and adjust related tests

## Testing
- npm run test *(fails: suite expects mocked providers and Playwright runner in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ccba80608331a4743612e2e58b0b