### PR TITLE
Fix phone formatter for non-string values

### DIFF
--- a/app/Support/Phone.php
+++ b/app/Support/Phone.php
@@ -2,13 +2,29 @@
 
 namespace App\Support;
 
+use Stringable;
+
 final class Phone
 {
     private const MAX_DIGITS = 15;
 
-    public static function format(?string $value): ?string
+    public static function format(null|string|int|float|Stringable $value): ?string
     {
         if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof Stringable) {
+            $value = (string) $value;
+        }
+
+        if (is_int($value)) {
+            $value = (string) $value;
+        } elseif (is_float($value)) {
+            $value = rtrim(rtrim(sprintf('%.0f', $value), '0'), '.');
+        }
+
+        if (! is_string($value)) {
             return null;
         }
 
@@ -43,7 +59,7 @@ final class Phone
         return '+' . implode(' ', $chunks);
     }
 
-    public static function normalize(?string $value): ?string
+    public static function normalize(null|string|int|float|Stringable $value): ?string
     {
         if ($value === null) {
             return null;


### PR DESCRIPTION
## Summary
- allow the phone formatting helper to accept numeric and Stringable inputs
- normalize floats and reject unsupported value types before formatting

## Testing
- composer test *(fails: sqlite test database schema lacks the `name` column on `orders`)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e9b4e3c08331ba8f34c70454f6b0