### PR TITLE
Fix vendor translation persistence

### DIFF
--- a/app/Filament/Mine/Resources/Vendors/Pages/Concerns/NormalizesVendorTranslations.php
+++ b/app/Filament/Mine/Resources/Vendors/Pages/Concerns/NormalizesVendorTranslations.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Filament\Mine\Resources\Vendors\Pages\Concerns;
+
+use Illuminate\Support\Arr;
+
+trait NormalizesVendorTranslations
+{
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function normalizeVendorFormTranslations(array $data): array
+    {
+        $primaryLocale = config('app.locale');
+        $fallbackLocale = config('app.fallback_locale');
+        $supportedLocales = array_values(array_unique(array_filter(
+            config('app.supported_locales', [])
+        )));
+
+        if ($supportedLocales === []) {
+            $supportedLocales = [$primaryLocale];
+        } elseif (! in_array($primaryLocale, $supportedLocales, true)) {
+            $supportedLocales[] = $primaryLocale;
+        }
+
+        $translationAttributes = [
+            'name' => 'name_translations',
+            'description' => 'description_translations',
+        ];
+
+        foreach ($translationAttributes as $attribute => $translationsKey) {
+            $raw = $data[$translationsKey] ?? [];
+            $translations = [];
+
+            if (is_array($raw)) {
+                foreach ($raw as $locale => $value) {
+                    if ($value === null || $value === '') {
+                        continue;
+                    }
+
+                    $translations[$locale] = $value;
+                }
+            } elseif ($raw !== null && $raw !== '') {
+                $translations[$primaryLocale] = $raw;
+            }
+
+            $data[$translationsKey] = $translations;
+        }
+
+        foreach ($supportedLocales as $locale) {
+            if (! array_key_exists($locale, $data)) {
+                continue;
+            }
+
+            $localeState = $data[$locale];
+            unset($data[$locale]);
+
+            if (is_array($localeState)) {
+                foreach ($translationAttributes as $attribute => $translationsKey) {
+                    $value = $localeState[$attribute]
+                        ?? $localeState["{$attribute}_translations"]
+                        ?? null;
+
+                    if ($value === null || $value === '') {
+                        continue;
+                    }
+
+                    $data[$translationsKey][$locale] = $value;
+                }
+
+                continue;
+            }
+
+            if ($localeState === null || $localeState === '') {
+                continue;
+            }
+
+            $data['description_translations'][$locale] = $localeState;
+        }
+
+        foreach ($translationAttributes as $attribute => $translationsKey) {
+            if (isset($data[$translationsKey])) {
+                ksort($data[$translationsKey]);
+            }
+
+            if (! blank($data[$attribute] ?? null)) {
+                continue;
+            }
+
+            $translations = $data[$translationsKey] ?? [];
+
+            if (! is_array($translations) || $translations === []) {
+                continue;
+            }
+
+            $candidate = $translations[$primaryLocale]
+                ?? ($fallbackLocale ? ($translations[$fallbackLocale] ?? null) : null)
+                ?? Arr::first($translations);
+
+            if ($candidate !== null && $candidate !== '') {
+                $data[$attribute] = $candidate;
+            }
+        }
+
+        unset($data['translations']);
+
+        return $data;
+    }
+}

--- a/app/Filament/Mine/Resources/Vendors/Pages/CreateVendor.php
+++ b/app/Filament/Mine/Resources/Vendors/Pages/CreateVendor.php
@@ -2,16 +2,21 @@
 
 namespace App\Filament\Mine\Resources\Vendors\Pages;
 
+use App\Filament\Mine\Resources\Vendors\Pages\Concerns\NormalizesVendorTranslations;
 use App\Filament\Mine\Resources\Vendors\VendorResource;
 use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Support\Facades\Auth;
 
 class CreateVendor extends CreateRecord
 {
+    use NormalizesVendorTranslations;
+
     protected static string $resource = VendorResource::class;
 
     protected function mutateFormDataBeforeCreate(array $data): array
     {
+        $data = $this->normalizeVendorFormTranslations($data);
+
         $user = Auth::user();
 
         if ($user?->vendor) {

--- a/app/Filament/Mine/Resources/Vendors/Pages/EditVendor.php
+++ b/app/Filament/Mine/Resources/Vendors/Pages/EditVendor.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Mine\Resources\Vendors\Pages;
 
+use App\Filament\Mine\Resources\Vendors\Pages\Concerns\NormalizesVendorTranslations;
 use App\Filament\Mine\Resources\Vendors\VendorResource;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
@@ -9,6 +10,8 @@ use Illuminate\Support\Facades\Auth;
 
 class EditVendor extends EditRecord
 {
+    use NormalizesVendorTranslations;
+
     protected static string $resource = VendorResource::class;
 
     protected function getHeaderActions(): array
@@ -44,6 +47,8 @@ class EditVendor extends EditRecord
 
     protected function mutateFormDataBeforeSave(array $data): array
     {
+        $data = $this->normalizeVendorFormTranslations($data);
+
         if ($user = Auth::user()) {
             if ($user->vendor && $this->record->user_id === $user->vendor->user_id) {
                 $data['user_id'] = $user->id;

--- a/app/Models/Vendor.php
+++ b/app/Models/Vendor.php
@@ -46,7 +46,7 @@ class Vendor extends Model
     protected function nameTranslations(): Attribute
     {
         return Attribute::make(
-            set: function (?array $value): ?array {
+            set: function (?array $value): array {
                 $translations = collect($value)
                     ->map(fn ($translation) => filled($translation) ? $translation : null)
                     ->filter()
@@ -58,7 +58,11 @@ class Vendor extends Model
                     ?? reset($translations)
                     ?? null;
 
-                return $translations;
+                return [
+                    'name_translations' => $translations === []
+                        ? null
+                        : json_encode($translations, JSON_UNESCAPED_UNICODE),
+                ];
             },
         );
     }
@@ -66,7 +70,7 @@ class Vendor extends Model
     protected function descriptionTranslations(): Attribute
     {
         return Attribute::make(
-            set: function (?array $value): ?array {
+            set: function (?array $value): array {
                 $translations = collect($value)
                     ->map(fn ($translation) => filled($translation) ? $translation : null)
                     ->filter()
@@ -78,7 +82,11 @@ class Vendor extends Model
                     ?? reset($translations)
                     ?? null;
 
-                return $translations;
+                return [
+                    'description_translations' => $translations === []
+                        ? null
+                        : json_encode($translations, JSON_UNESCAPED_UNICODE),
+                ];
             },
         );
     }

--- a/tests/Feature/Filament/Mine/Vendors/VendorFormTranslationsTest.php
+++ b/tests/Feature/Filament/Mine/Vendors/VendorFormTranslationsTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use App\Enums\Role as RoleEnum;
+use App\Filament\Mine\Resources\Vendors\Pages\CreateVendor;
+use App\Filament\Mine\Resources\Vendors\Pages\EditVendor;
+use App\Models\User;
+use App\Models\Vendor;
+use Illuminate\Support\Facades\Config;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+
+beforeEach(function (): void {
+    Config::set('app.locale', 'uk');
+    Config::set('app.fallback_locale', 'en');
+    Config::set('app.supported_locales', ['uk', 'en']);
+
+    Role::findOrCreate(RoleEnum::Administrator->value, 'web');
+});
+
+function createVendorManager(): User
+{
+    $user = User::factory()->create();
+    $user->assignRole(RoleEnum::Administrator->value);
+
+    return $user;
+}
+
+it('creates vendors when translations are keyed by locale', function (): void {
+    $user = createVendorManager();
+
+    $component = Livewire::actingAs($user)
+        ->test(CreateVendor::class);
+
+    $component->set('data.user_id', $user->id)
+        ->set('data.slug', 'locale-vendor')
+        ->set('data.contact_email', 'vendor@example.test')
+        ->set('data.contact_phone', '+380950000000')
+        ->set('data.name_translations.uk', 'Постачальник')
+        ->set('data.name_translations.en', 'Vendor')
+        ->set('data.description_translations.uk', 'Опис українською')
+        ->set('data.description_translations.en', 'Description')
+        ->set('data.uk.name', 'Постачальник')
+        ->set('data.uk.description', 'Опис українською')
+        ->set('data.en.name', 'Vendor')
+        ->set('data.en.description', 'Description')
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $vendor = Vendor::first();
+
+    expect($vendor)->not()->toBeNull();
+    expect($vendor->name_translations)
+        ->toMatchArray([
+            'en' => 'Vendor',
+            'uk' => 'Постачальник',
+        ]);
+    expect($vendor->description_translations)
+        ->toMatchArray([
+            'en' => 'Description',
+            'uk' => 'Опис українською',
+        ]);
+    expect($vendor->name)->toBe('Постачальник');
+    expect($vendor->description)->toBe('Опис українською');
+});
+
+it('updates vendors when translations are keyed by locale', function (): void {
+    $user = createVendorManager();
+
+    $vendor = Vendor::factory()
+        ->for($user)
+        ->create([
+            'slug' => 'existing-vendor',
+            'contact_email' => 'existing@example.test',
+            'contact_phone' => '+380950000001',
+        ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(EditVendor::class, ['record' => $vendor->getKey()]);
+
+    $component->set('data.user_id', $user->id)
+        ->set('data.slug', $vendor->slug)
+        ->set('data.contact_email', $vendor->contact_email)
+        ->set('data.contact_phone', '+380950000002')
+        ->set('data.name_translations.uk', 'Оновлений постачальник')
+        ->set('data.name_translations.en', 'Updated Vendor')
+        ->set('data.description_translations.uk', 'Оновлений опис')
+        ->set('data.description_translations.en', 'Updated description')
+        ->set('data.uk.name', 'Оновлений постачальник')
+        ->set('data.uk.description', 'Оновлений опис')
+        ->set('data.en.name', 'Updated Vendor')
+        ->set('data.en.description', 'Updated description')
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $vendor->refresh();
+
+    expect($vendor->name_translations)
+        ->toMatchArray([
+            'en' => 'Updated Vendor',
+            'uk' => 'Оновлений постачальник',
+        ]);
+    expect($vendor->description_translations)
+        ->toMatchArray([
+            'en' => 'Updated description',
+            'uk' => 'Оновлений опис',
+        ]);
+    expect($vendor->name)->toBe('Оновлений постачальник');
+    expect($vendor->description)->toBe('Оновлений опис');
+});


### PR DESCRIPTION
## Summary
- normalize vendor form data to build translation arrays and strip stray locale keys before saving
- ensure vendor model stores translation arrays as JSON while keeping base columns in sync
- add feature tests covering Filament vendor create and update workflows with locale-keyed input

## Testing
- php artisan test tests/Feature/FormTranslationsTest.php
- php artisan test tests/Feature/Filament/Mine/Vendors/VendorFormTranslationsTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d3f5ab6da083319707fb35da5e2eb7