### PR TITLE
Prevent auto-assigning admin as vendor owner

### DIFF
--- a/app/Filament/Mine/Resources/Vendors/Pages/CreateVendor.php
+++ b/app/Filament/Mine/Resources/Vendors/Pages/CreateVendor.php
@@ -21,8 +21,6 @@ class CreateVendor extends CreateRecord
 
         if ($user?->vendor) {
             $data['user_id'] = $user->id;
-        } elseif (! array_key_exists('user_id', $data) || ! $data['user_id']) {
-            $data['user_id'] = $user?->id;
         }
 
         return $data;


### PR DESCRIPTION
## Summary
- avoid overriding the selected owner when creating a vendor so administrators retain full vendor visibility

## Testing
- `composer test` *(fails: sqlite test database missing legacy `name` column in orders table)*

------
https://chatgpt.com/codex/tasks/task_e_68d4098ac84c83318c5634e75edaecd0