### PR TITLE
Adjust admin visibility filters for vendor users

### DIFF
--- a/app/Filament/Mine/Resources/Products/Tables/ProductsTable.php
+++ b/app/Filament/Mine/Resources/Products/Tables/ProductsTable.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Mine\Resources\Products\Tables;
 
+use App\Filament\Mine\Resources\Products\ProductResource;
 use App\Models\Product;
 use App\Models\Vendor;
 use Filament\Actions\BulkActionGroup;
@@ -25,8 +26,8 @@ class ProductsTable
             ->query(function (): Builder {
                 $query = Product::query()->with(['images', 'category', 'stocks']);
 
-                if ($vendor = Auth::user()?->vendor) {
-                    $query->where('vendor_id', $vendor->id);
+                if ($user = Auth::user()) {
+                    $query = ProductResource::applyVisibilityScopes($query, $user);
                 }
 
                 return $query;


### PR DESCRIPTION
## Summary
- reuse a shared visibility scope so product listings and navigation counts honour category and vendor restrictions
- prevent vendor scoping for users who can manage vendors so administrators keep access to the full catalog
- align order resource navigation counts with the updated vendor-aware visibility rules

## Testing
- not run (dependencies not installed in container)

------
https://chatgpt.com/codex/tasks/task_e_68d40b6a81ac8331bdba01e8219e1e50