### PR TITLE
Fix Filament product visibility and navigation badges

### DIFF
--- a/app/Filament/Mine/Resources/Orders/OrderResource.php
+++ b/app/Filament/Mine/Resources/Orders/OrderResource.php
@@ -100,6 +100,6 @@ class OrderResource extends Resource
             return null;
         }
 
-        return (string) Order::count();
+        return (string) static::getEloquentQuery()->count();
     }
 }

--- a/app/Filament/Mine/Resources/Products/ProductResource.php
+++ b/app/Filament/Mine/Resources/Products/ProductResource.php
@@ -110,7 +110,7 @@ class ProductResource extends Resource
             return null;
         }
 
-        return (string) Product::count();
+        return (string) static::getEloquentQuery()->count();
     }
 
     public static function getRelations(): array

--- a/app/Filament/Mine/Resources/Products/Tables/ProductsTable.php
+++ b/app/Filament/Mine/Resources/Products/Tables/ProductsTable.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Mine\Resources\Products\Tables;
 
+use App\Filament\Mine\Resources\Products\ProductResource;
 use App\Models\Product;
 use App\Models\Vendor;
 use Filament\Actions\BulkActionGroup;
@@ -23,13 +24,9 @@ class ProductsTable
     {
         return $table
             ->query(function (): Builder {
-                $query = Product::query()->with(['images', 'category', 'stocks']);
+                $query = ProductResource::getEloquentQuery();
 
-                if ($vendor = Auth::user()?->vendor) {
-                    $query->where('vendor_id', $vendor->id);
-                }
-
-                return $query;
+                return $query->with(['category', 'stocks']);
             })
             ->columns([
                 ImageColumn::make('preview')

--- a/tests/Feature/Filament/Mine/Orders/OrderNavigationBadgeTest.php
+++ b/tests/Feature/Filament/Mine/Orders/OrderNavigationBadgeTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use App\Enums\Permission as PermissionEnum;
+use App\Filament\Mine\Resources\Orders\OrderResource;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
+use App\Models\User;
+use App\Models\Vendor;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Spatie\Permission\Models\Permission;
+
+it('counts only orders involving the current vendor user in the navigation badge', function (): void {
+    Permission::findOrCreate(PermissionEnum::ViewOrders->value, 'web');
+    Permission::findOrCreate(PermissionEnum::ManageOrders->value, 'web');
+
+    $user = User::factory()->create();
+    $user->givePermissionTo([
+        PermissionEnum::ViewOrders->value,
+        PermissionEnum::ManageOrders->value,
+    ]);
+
+    $vendor = Vendor::factory()->for($user)->create();
+
+    $visibleProduct = Product::factory()->for($vendor)->create();
+    $hiddenProduct = Product::factory()->create();
+
+    $now = now();
+
+    $visibleOrderId = DB::table('orders')->insertGetId([
+        'user_id' => null,
+        'email' => 'visible@example.com',
+        'status' => 'new',
+        'total' => 0,
+        'subtotal' => 0,
+        'discount_total' => 0,
+        'coupon_id' => null,
+        'coupon_code' => null,
+        'coupon_discount' => 0,
+        'loyalty_points_used' => 0,
+        'loyalty_points_value' => 0,
+        'loyalty_points_earned' => 0,
+        'shipping_address' => json_encode([
+            'name' => 'Visible Buyer',
+            'city' => 'Visible City',
+            'addr' => 'Visible Street',
+            'postal_code' => '00001',
+            'phone' => '+380000000001',
+        ], JSON_THROW_ON_ERROR),
+        'billing_address' => null,
+        'note' => null,
+        'number' => 'ORD-' . Str::upper(Str::random(16)),
+        'shipping_address_id' => null,
+        'currency' => 'EUR',
+        'payment_intent_id' => null,
+        'payment_status' => 'pending',
+        'paid_at' => null,
+        'shipped_at' => null,
+        'cancelled_at' => null,
+        'inventory_committed_at' => null,
+        'locale' => 'en',
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $hiddenOrderId = DB::table('orders')->insertGetId([
+        'user_id' => null,
+        'email' => 'hidden@example.com',
+        'status' => 'new',
+        'total' => 0,
+        'subtotal' => 0,
+        'discount_total' => 0,
+        'coupon_id' => null,
+        'coupon_code' => null,
+        'coupon_discount' => 0,
+        'loyalty_points_used' => 0,
+        'loyalty_points_value' => 0,
+        'loyalty_points_earned' => 0,
+        'shipping_address' => json_encode([
+            'name' => 'Hidden Buyer',
+            'city' => 'Hidden City',
+            'addr' => 'Hidden Street',
+            'postal_code' => '00002',
+            'phone' => '+380000000002',
+        ], JSON_THROW_ON_ERROR),
+        'billing_address' => null,
+        'note' => null,
+        'number' => 'ORD-' . Str::upper(Str::random(16)),
+        'shipping_address_id' => null,
+        'currency' => 'EUR',
+        'payment_intent_id' => null,
+        'payment_status' => 'pending',
+        'paid_at' => null,
+        'shipped_at' => null,
+        'cancelled_at' => null,
+        'inventory_committed_at' => null,
+        'locale' => 'en',
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $visibleOrder = Order::findOrFail($visibleOrderId);
+    $hiddenOrder = Order::findOrFail($hiddenOrderId);
+
+    OrderItem::factory()->for($visibleOrder)->for($visibleProduct)->create();
+    OrderItem::factory()->for($hiddenOrder)->for($hiddenProduct)->create();
+
+    $this->actingAs($user);
+
+    expect(OrderResource::getNavigationBadge())->toBe('1');
+
+    $table = $visibleOrder->getTable();
+
+    $visibleIds = OrderResource::getEloquentQuery()->pluck("{$table}.id")->all();
+
+    expect($visibleIds)->toBe([$visibleOrder->getKey()]);
+});

--- a/tests/Feature/Filament/Mine/Products/ProductNavigationBadgeTest.php
+++ b/tests/Feature/Filament/Mine/Products/ProductNavigationBadgeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Enums\Permission as PermissionEnum;
+use App\Filament\Mine\Resources\Products\ProductResource;
+use App\Models\Product;
+use App\Models\User;
+use App\Models\Vendor;
+use Spatie\Permission\Models\Permission;
+
+it('counts only products visible to the current vendor user in the navigation badge', function (): void {
+    Permission::findOrCreate(PermissionEnum::ViewProducts->value, 'web');
+    Permission::findOrCreate(PermissionEnum::ManageProducts->value, 'web');
+
+    $user = User::factory()->create();
+    $user->givePermissionTo([
+        PermissionEnum::ViewProducts->value,
+        PermissionEnum::ManageProducts->value,
+    ]);
+
+    $vendor = Vendor::factory()->for($user)->create();
+
+    $visibleProduct = Product::factory()->for($vendor)->create();
+    Product::factory()->create();
+
+    $this->actingAs($user);
+
+    expect(ProductResource::getNavigationBadge())->toBe('1');
+
+    $table = $visibleProduct->getTable();
+
+    $visibleIds = ProductResource::getEloquentQuery()->pluck("{$table}.id")->all();
+
+    expect($visibleIds)->toBe([$visibleProduct->getKey()]);
+});


### PR DESCRIPTION
## Summary
- reuse the Product resource query inside the table configuration so scoped users see the same records across the list and navigation badge
- calculate product and order navigation badges from the scoped resource queries
- add coverage to ensure vendor users only see their own products and orders counted in the badge

## Testing
- php artisan test tests/Feature/Filament/Mine/Products/ProductNavigationBadgeTest.php tests/Feature/Filament/Mine/Orders/OrderNavigationBadgeTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d40b6a81ac8331bdba01e8219e1e50