### PR TITLE
Fix product name hydration when base attribute blank

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Laravel\Scout\Searchable;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\DB;
@@ -71,6 +72,23 @@ class Product extends Model
                 $product->price_cents = (int) round($price * 100);
             } elseif ($product->isDirty('price_cents') && ! $product->isDirty('price')) {
                 $product->price = round(((int) $product->price_cents) / 100, 2);
+            }
+
+            $rawName = $product->getAttributes()['name'] ?? null;
+
+            if (blank($rawName)) {
+                $translations = array_filter((array) $product->name_translations, fn ($value) => filled($value));
+                $primaryLocale = config('app.locale');
+
+                if ($primaryLocale && isset($translations[$primaryLocale])) {
+                    $product->name = $translations[$primaryLocale];
+                } else {
+                    $fallback = Arr::first($translations, fn ($value) => filled($value));
+
+                    if ($fallback !== null) {
+                        $product->name = $fallback;
+                    }
+                }
             }
         });
 

--- a/tests/Feature/ProductTranslationsTest.php
+++ b/tests/Feature/ProductTranslationsTest.php
@@ -35,6 +35,24 @@ it('returns localized names with fallback to configured fallback locale', functi
     expect($product->fresh()->description)->toBe('Laptop description');
 });
 
+it('hydrates the legacy name column from available translations when blank', function () {
+    $product = Product::factory()->create([
+        'name' => null,
+        'name_translations' => [
+            'uk' => 'Ноутбук',
+            'en' => 'Laptop',
+        ],
+        'description' => 'Опис ноутбука',
+        'description_translations' => [
+            'uk' => 'Опис ноутбука',
+            'en' => 'Laptop description',
+        ],
+    ]);
+
+    expect($product->getRawOriginal('name'))->toBe('Ноутбук');
+    expect($product->fresh()->name)->toBe('Ноутбук');
+});
+
 it('falls back to legacy attribute when translations are missing', function () {
     $product = Product::factory()->create([
         'name' => 'Стара назва',


### PR DESCRIPTION
## Summary
- ensure the legacy `name` column hydrates from translations based on the raw attribute value
- add coverage to confirm blank legacy names are populated before persisting products

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d417aa06dc8331965f4e363403f0c0