### PR TITLE
Convert translation columns to jsonb

### DIFF
--- a/database/migrations/2025_09_24_172038_convert_translation_columns_to_jsonb.php
+++ b/database/migrations/2025_09_24_172038_convert_translation_columns_to_jsonb.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * @var array<string, array<int, string>>
+     */
+    protected array $translationColumns = [
+        'categories' => ['name_translations'],
+        'products' => ['name_translations', 'description_translations'],
+        'vendors' => ['name_translations', 'description_translations'],
+        'warehouses' => ['name_translations', 'description_translations'],
+        'coupons' => ['name_translations', 'description_translations'],
+        'product_images' => ['alt_translations'],
+    ];
+
+    public function up(): void
+    {
+        $this->convertColumnsTo('jsonb');
+    }
+
+    public function down(): void
+    {
+        $this->convertColumnsTo('json');
+    }
+
+    protected function convertColumnsTo(string $type): void
+    {
+        foreach ($this->translationColumns as $table => $columns) {
+            if (! Schema::hasTable($table)) {
+                continue;
+            }
+
+            foreach ($columns as $column) {
+                if (! Schema::hasColumn($table, $column)) {
+                    continue;
+                }
+
+                DB::statement(sprintf(
+                    'ALTER TABLE "%s" ALTER COLUMN "%s" TYPE %s USING "%s"::%s',
+                    $table,
+                    $column,
+                    $type,
+                    $column,
+                    $type,
+                ));
+            }
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- convert translation columns for catalog-related tables from `json` to `jsonb` so PostgreSQL can evaluate DISTINCT queries
- guard the conversion for missing tables/columns and allow rolling back to the previous type

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d427fa826c83318895fb920f3b306f