### PR TITLE
Convert translation columns to jsonb after seeding

### DIFF
--- a/database/migrations/2025_10_09_000000_convert_translation_columns_to_jsonb.php
+++ b/database/migrations/2025_10_09_000000_convert_translation_columns_to_jsonb.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * @var array<string, array<int, string>>
+     */
+    protected array $translationColumns = [
+        'categories' => ['name_translations'],
+        'products' => ['name_translations', 'description_translations'],
+        'vendors' => ['name_translations', 'description_translations'],
+        'warehouses' => ['name_translations', 'description_translations'],
+        'coupons' => ['name_translations', 'description_translations'],
+        'product_images' => ['alt_translations'],
+    ];
+
+    public function up(): void
+    {
+        $this->convertColumnsTo('jsonb');
+    }
+
+    public function down(): void
+    {
+        $this->convertColumnsTo('json');
+    }
+
+    protected function convertColumnsTo(string $type): void
+    {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        foreach ($this->translationColumns as $table => $columns) {
+            if (! Schema::hasTable($table)) {
+                continue;
+            }
+
+            foreach ($columns as $column) {
+                if (! Schema::hasColumn($table, $column)) {
+                    continue;
+                }
+
+                DB::statement(sprintf(
+                    'ALTER TABLE "%s" ALTER COLUMN "%s" TYPE %s USING "%s"::%s',
+                    $table,
+                    $column,
+                    $type,
+                    $column,
+                    $type,
+                ));
+            }
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- add a dedicated migration to cast translation columns to jsonb for PostgreSQL installs
- skip the conversion on non-PostgreSQL drivers to keep sqlite-based tests working

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d42a57412c8331b430e80362ff9c95