### PR TITLE
Fix push campaign segments select query

### DIFF
--- a/app/Filament/Mine/Resources/PushCampaigns/Schemas/PushCampaignForm.php
+++ b/app/Filament/Mine/Resources/PushCampaigns/Schemas/PushCampaignForm.php
@@ -53,7 +53,11 @@ class PushCampaignForm
                     DateTimePicker::make('scheduled_for')
                         ->label(__('Scheduled for')),
                     Select::make('segments')
-                        ->relationship('segments', 'name')
+                        ->relationship(
+                            'segments',
+                            'name',
+                            fn ($query) => $query->select(['customer_segments.id', 'customer_segments.name'])
+                        )
                         ->multiple()
                         ->preload()
                         ->searchable()


### PR DESCRIPTION
## Summary
- ensure the push campaign segment relationship only selects id and name columns to avoid DISTINCT on JSON columns

## Testing
- php artisan test *(fails: vendor directory missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d43a546ec08331bda4a8330e7c5a35