### PR TITLE
Ensure vendor creation captures primary locale fields

### DIFF
--- a/app/Filament/Mine/Resources/Vendors/Pages/CreateVendor.php
+++ b/app/Filament/Mine/Resources/Vendors/Pages/CreateVendor.php
@@ -12,6 +12,34 @@ class CreateVendor extends CreateRecord
 
     protected function mutateFormDataBeforeCreate(array $data): array
     {
+        $primaryLocale = config('app.locale');
+
+        if (blank($data['name_translations'][$primaryLocale] ?? null)) {
+            $fallbackName = collect($data['name_translations'] ?? [])
+                ->first(fn ($value) => filled($value));
+
+            if (filled($fallbackName)) {
+                $data['name_translations'][$primaryLocale] = $fallbackName;
+            }
+        }
+
+        if (blank($data['name'] ?? null)) {
+            $data['name'] = $data['name_translations'][$primaryLocale] ?? null;
+        }
+
+        if (array_key_exists('description_translations', $data) && blank($data['description_translations'][$primaryLocale] ?? null)) {
+            $fallbackDescription = collect($data['description_translations'] ?? [])
+                ->first(fn ($value) => filled($value));
+
+            if (filled($fallbackDescription)) {
+                $data['description_translations'][$primaryLocale] = $fallbackDescription;
+            }
+        }
+
+        if (blank($data['description'] ?? null)) {
+            $data['description'] = $data['description_translations'][$primaryLocale] ?? null;
+        }
+
         $user = Auth::user();
 
         if ($user?->vendor) {


### PR DESCRIPTION
## Summary
- ensure the vendor create page hydrates the primary-locale name and description fields from the provided translations
- fall back to the first non-empty translation so required database columns are populated during creation
- keep existing user assignment logic while extending the form data mutation

## Testing
- `php artisan test --filter=FormTranslationsTest` *(fails: vendor autoload missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d442b296d483319acbd12f6d7fd546