### PR TITLE
Ensure warehouse translations hydrate base attributes

### DIFF
--- a/app/Filament/Mine/Resources/Warehouses/Pages/CreateWarehouse.php
+++ b/app/Filament/Mine/Resources/Warehouses/Pages/CreateWarehouse.php
@@ -8,4 +8,37 @@ use Filament\Resources\Pages\CreateRecord;
 class CreateWarehouse extends CreateRecord
 {
     protected static string $resource = WarehouseResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $primaryLocale = config('app.locale');
+
+        if (blank($data['name_translations'][$primaryLocale] ?? null)) {
+            $fallbackName = collect($data['name_translations'] ?? [])
+                ->first(fn ($value) => filled($value));
+
+            if (filled($fallbackName)) {
+                $data['name_translations'][$primaryLocale] = $fallbackName;
+            }
+        }
+
+        if (blank($data['name'] ?? null)) {
+            $data['name'] = $data['name_translations'][$primaryLocale] ?? null;
+        }
+
+        if (array_key_exists('description_translations', $data) && blank($data['description_translations'][$primaryLocale] ?? null)) {
+            $fallbackDescription = collect($data['description_translations'] ?? [])
+                ->first(fn ($value) => filled($value));
+
+            if (filled($fallbackDescription)) {
+                $data['description_translations'][$primaryLocale] = $fallbackDescription;
+            }
+        }
+
+        if (blank($data['description'] ?? null)) {
+            $data['description'] = $data['description_translations'][$primaryLocale] ?? null;
+        }
+
+        return $data;
+    }
 }

--- a/app/Filament/Mine/Resources/Warehouses/Pages/EditWarehouse.php
+++ b/app/Filament/Mine/Resources/Warehouses/Pages/EditWarehouse.php
@@ -39,4 +39,39 @@ class EditWarehouse extends EditRecord
 
         return $data;
     }
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $primaryLocale = config('app.locale');
+
+        if (blank($data['name_translations'][$primaryLocale] ?? null)) {
+            $fallbackName = collect($data['name_translations'] ?? [])
+                ->first(fn ($value) => filled($value));
+
+            if (filled($fallbackName)) {
+                $data['name_translations'][$primaryLocale] = $fallbackName;
+            }
+        }
+
+        if (blank($data['name'] ?? null)) {
+            $data['name'] = $data['name_translations'][$primaryLocale]
+                ?? $this->record?->getRawOriginal('name');
+        }
+
+        if (array_key_exists('description_translations', $data) && blank($data['description_translations'][$primaryLocale] ?? null)) {
+            $fallbackDescription = collect($data['description_translations'] ?? [])
+                ->first(fn ($value) => filled($value));
+
+            if (filled($fallbackDescription)) {
+                $data['description_translations'][$primaryLocale] = $fallbackDescription;
+            }
+        }
+
+        if (blank($data['description'] ?? null)) {
+            $data['description'] = $data['description_translations'][$primaryLocale]
+                ?? $this->record?->getRawOriginal('description');
+        }
+
+        return $data;
+    }
 }


### PR DESCRIPTION
## Summary
- ensure warehouse creation copies a fallback translation into the primary locale and base columns
- ensure warehouse updates hydrate the legacy name and description columns from translations

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d4dec2bdfc8331af51f9bd562db32e