### PR TITLE
Remove attach/detach actions from order items relation

### DIFF
--- a/app/Filament/Mine/Resources/Orders/RelationManagers/ItemsRelationManager.php
+++ b/app/Filament/Mine/Resources/Orders/RelationManagers/ItemsRelationManager.php
@@ -6,13 +6,10 @@ use App\Enums\OrderStatus;
 use App\Models\OrderItem;
 use App\Models\Product;
 use App\Filament\Mine\Resources\Orders\Pages\EditOrder;
-use Filament\Actions\AttachAction;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
-use Filament\Actions\DetachAction;
-use Filament\Actions\DetachBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -94,12 +91,6 @@ class ItemsRelationManager extends RelationManager
                         $livewire->dispatch('order-items-updated')
                             ->to(EditOrder::class);
                     }),
-                AttachAction::make()->after(function (RelationManager $livewire) {
-                    $order = $livewire->getOwnerRecord();
-                    $order->recalculateTotal();
-                    $livewire->dispatch('order-items-updated')
-                        ->to(EditOrder::class);
-                }),
             ])
             ->recordActions([
                 EditAction::make()
@@ -121,7 +112,6 @@ class ItemsRelationManager extends RelationManager
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DetachBulkAction::make(),
                     DeleteBulkAction::make(),
                 ]),
             ])


### PR DESCRIPTION
## Summary
- remove the attach header action so order items cannot be reassigned through the relation manager
- drop the detach bulk action from the toolbar, leaving delete as the only bulk option

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d63333eda88331a75e64b16d49f49e