### PR TITLE
Keep guest carts active after login merge

### DIFF
--- a/app/Listeners/MergeGuestCart.php
+++ b/app/Listeners/MergeGuestCart.php
@@ -42,6 +42,11 @@ class MergeGuestCart
                 return;
             }
 
+            if ($guest->user_id && (string) $guest->user_id === (string) $user->id) {
+                Cookie::queue(Cookie::forget('cart_id'));
+                return;
+            }
+
             /** @var Cart|null $userCart */
             $userCart = Cart::query()
                 ->where('user_id', $user->id)
@@ -52,8 +57,8 @@ class MergeGuestCart
 // 1) Немає активного кошика у користувача — просто “прикріплюємо” guest.
             if (! $userCart) {
                 $guest->forceFill([
-                    'status'  => 'merged',      // ← новий статус
-                    'user_id' => $user->id,     // для аудиту хто «власник» архівованого кошика
+                    'status'  => 'active',      // залишаємо кошик активним для подальших запитів
+                    'user_id' => $user->id,     // фіксуємо власника активного кошика
                 ])->saveQuietly();
                 Cookie::queue(Cookie::forget('cart_id'));
                 return; // критично, щоб не дійти до видалення guest

--- a/tests/Feature/MergeGuestCartTest.php
+++ b/tests/Feature/MergeGuestCartTest.php
@@ -2,8 +2,6 @@
 
 use App\Models\{User, Product, Cart, CartItem};
 use Illuminate\Auth\Events\Login;
-use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Cookie;
 
 it('attaches guest cart to user when user has no active cart', function () {
     $user = User::factory()->create();
@@ -37,4 +35,34 @@ it('merges guest items into existing user cart with stock clamp', function () {
 
     $mergedItem = $userCart->items()->where('product_id', $product->id)->first();
     expect($mergedItem->qty)->toBe(5);
+});
+
+it('keeps reassigned guest cart active and retrievable via getOrCreate', function () {
+    $user = User::factory()->create();
+    $product = Product::factory()->create(['stock' => 10, 'price' => 99]);
+
+    $guest = Cart::factory()->create(['user_id' => null, 'status' => 'active']);
+    CartItem::factory()->for($guest)->create([
+        'product_id' => $product->id,
+        'qty' => 3,
+        'price' => 99,
+    ]);
+
+    $this->app['request']->cookies->set('cart_id', $guest->id);
+
+    event(new Login('web', $user, false));
+
+    $guest->refresh();
+    expect($guest->status)->toBe('active');
+    expect($guest->user_id)->toBe($user->id);
+
+    $this->actingAs($user);
+
+    $response = $this->getJson('/api/cart')->assertOk();
+
+    $response->assertJsonPath('id', $guest->id);
+    $response->assertJsonPath('status', 'active');
+    $response->assertJsonCount(1, 'items');
+    $response->assertJsonPath('items.0.product_id', $product->id);
+    $response->assertJsonPath('items.0.qty', 3);
 });


### PR DESCRIPTION
## Summary
- ensure the MergeGuestCart listener retains the guest cart as active when it is reassigned and skip repeat processing once attached to the user
- add a regression feature test covering CartController::getOrCreate returning the reassigned cart items for an authenticated user

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d648251e848331abc668d6c7ec3c5d