### PR TITLE
Add automatic invoice creation after marking orders paid

### DIFF
--- a/app/Filament/Mine/Resources/Orders/Tables/OrdersTable.php
+++ b/app/Filament/Mine/Resources/Orders/Tables/OrdersTable.php
@@ -93,7 +93,7 @@ class OrdersTable
                 Action::make('markPaid')
                     ->label(__('shop.orders.actions.mark_paid'))
                     ->icon('heroicon-o-banknotes')
-                    ->visible(fn (Order $record) => $record->status === OrderStatus::New->value)
+                    ->visible(fn (Order $record) => ($record->status instanceof OrderStatus ? $record->status->value : (string) $record->status) === OrderStatus::New->value)
                     ->requiresConfirmation()
                     ->action(function (Order $record) {
                         $record->markPaid();
@@ -102,7 +102,7 @@ class OrdersTable
                 Action::make('markShipped')
                     ->label(__('shop.orders.actions.mark_shipped'))
                     ->icon('heroicon-o-truck')
-                    ->visible(fn (Order $record) => $record->status === OrderStatus::Paid->value)
+                    ->visible(fn (Order $record) => ($record->status instanceof OrderStatus ? $record->status->value : (string) $record->status) === OrderStatus::Paid->value)
                     ->requiresConfirmation()
                     ->form([
                         TextInput::make('tracking_number')
@@ -129,7 +129,7 @@ class OrdersTable
                     ->label(__('shop.orders.actions.cancel'))
                     ->color('danger')
                     ->icon('heroicon-o-x-circle')
-                    ->visible(fn (Order $record) => in_array($record->status, [OrderStatus::New->value, OrderStatus::Paid->value], true))
+                    ->visible(fn (Order $record) => in_array($record->status instanceof OrderStatus ? $record->status->value : (string) $record->status, [OrderStatus::New->value, OrderStatus::Paid->value], true))
                     ->requiresConfirmation()
                     ->action(function (Order $record) {
                         $record->cancel();

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Jobs\SendOrderStatusMail;
+use App\Services\Invoices\CreateInvoiceFromOrder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -275,6 +276,8 @@ class Order extends Model
             }
             $this->reserveInventory();
             $this->update(['status' => OrderStatus::Paid]);
+
+            app(CreateInvoiceFromOrder::class)->handle($this->fresh());
         });
     }
 

--- a/app/Services/Invoices/CreateInvoiceFromOrder.php
+++ b/app/Services/Invoices/CreateInvoiceFromOrder.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Services\Invoices;
+
+use App\Models\Invoice;
+use App\Models\Order;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+class CreateInvoiceFromOrder
+{
+    public function handle(Order $order): Invoice
+    {
+        if (! $order->exists) {
+            throw new InvalidArgumentException('Cannot create an invoice for an unsaved order.');
+        }
+
+        return Invoice::firstOrCreate(
+            ['order_id' => $order->getKey()],
+            $this->buildPayload($order),
+        );
+    }
+
+    public function __invoke(Order $order): Invoice
+    {
+        return $this->handle($order);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function buildPayload(Order $order): array
+    {
+        $subtotal = $this->toMoney($order->subtotal);
+        $discount = $this->toMoney($order->discount_total);
+        $total = $this->toMoney($order->total);
+
+        return [
+            'number' => $this->makeInvoiceNumber($order),
+            'issued_at' => $order->paid_at ?? now(),
+            'status' => 'paid',
+            'currency' => $order->currency,
+            'subtotal' => $subtotal,
+            'tax_total' => $this->calculateTaxTotal($subtotal, $discount, $total),
+            'total' => $total,
+        ];
+    }
+
+    protected function makeInvoiceNumber(Order $order): string
+    {
+        $base = Str::of((string) ($order->number ?? $order->getKey()))
+            ->after('ORD-')
+            ->replaceMatches('/[^A-Za-z0-9]/', '')
+            ->upper();
+
+        if ($base->isEmpty()) {
+            $base = Str::of((string) $order->getKey())->padLeft(6, '0');
+        }
+
+        return 'INV-' . $base;
+    }
+
+    protected function calculateTaxTotal(float $subtotal, float $discount, float $total): float
+    {
+        $taxTotal = $total - ($subtotal - $discount);
+
+        return round(max($taxTotal, 0), 2);
+    }
+
+    protected function toMoney(mixed $value): float
+    {
+        return round((float) ($value ?? 0), 2);
+    }
+}

--- a/app/Services/Orders/OrderStateService.php
+++ b/app/Services/Orders/OrderStateService.php
@@ -6,6 +6,7 @@ use App\Enums\OrderStatus;
 use App\Models\Order;
 use Illuminate\Support\Facades\DB;
 use DomainException;
+use App\Services\Invoices\CreateInvoiceFromOrder;
 
 class OrderStateService
 {
@@ -24,6 +25,8 @@ class OrderStateService
         DB::transaction(function () use ($order) {
             $order->reserveInventory();
             $order->update(['status' => OrderStatus::Paid]);
+
+            app(CreateInvoiceFromOrder::class)->handle($order->fresh());
         });
     }
 

--- a/tests/Feature/InvoiceCreationTest.php
+++ b/tests/Feature/InvoiceCreationTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use App\Enums\OrderStatus;
+use App\Enums\Permission as PermissionEnum;
+use App\Filament\Mine\Resources\Orders\Pages\ListOrders;
+use App\Http\Controllers\StripeWebhookController;
+use App\Models\Invoice;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
+use App\Models\User;
+use Livewire\Livewire;
+use Illuminate\Http\Request;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+
+beforeEach(function (): void {
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+});
+
+afterEach(function (): void {
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+});
+
+it('creates a paid invoice when marking an order paid via filament', function () {
+    $user = User::factory()->create();
+    Permission::findOrCreate(PermissionEnum::ManageOrders->value, 'web');
+    $user->givePermissionTo(PermissionEnum::ManageOrders->value);
+
+    $this->actingAs($user);
+
+    $product = Product::factory()->create([
+        'stock' => 10,
+        'price' => 50,
+    ]);
+
+    $order = Order::factory()->create([
+        'status' => OrderStatus::New,
+        'currency' => 'USD',
+    ]);
+
+    OrderItem::factory()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'qty' => 2,
+        'price' => 50,
+    ]);
+
+    $order->recalculateTotal();
+    $order->refresh();
+
+    expect(Invoice::count())->toBe(0);
+
+    Livewire::test(ListOrders::class)
+        ->callTableAction('markPaid', $order->getKey());
+
+    $order->refresh();
+    $invoice = Invoice::where('order_id', $order->id)->first();
+
+    expect($invoice)->not->toBeNull();
+    expect($invoice->order_id)->toBe($order->id);
+    expect($invoice->status)->toBe('paid');
+    expect((float) $invoice->subtotal)->toBe((float) $order->subtotal);
+    expect((float) $invoice->tax_total)->toBe(0.0);
+    expect((float) $invoice->total)->toBe((float) $order->total);
+    expect($invoice->number)->toMatch('/^INV-/');
+});
+
+it('creates a paid invoice when a stripe payment intent succeeds', function () {
+    $product = Product::factory()->create([
+        'stock' => 5,
+        'price' => 25,
+    ]);
+
+    $order = Order::factory()->create([
+        'status' => OrderStatus::New,
+        'currency' => 'USD',
+        'payment_intent_id' => 'pi_test_123',
+    ]);
+
+    OrderItem::factory()->create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'qty' => 2,
+        'price' => 25,
+    ]);
+
+    $order->recalculateTotal();
+    $order->refresh();
+
+    $data = [
+        'id' => 'evt_test_123',
+        'object' => 'event',
+        'type' => 'payment_intent.succeeded',
+        'data' => [
+            'object' => [
+                'id' => 'pi_test_123',
+                'object' => 'payment_intent',
+                'status' => 'succeeded',
+                'metadata' => [
+                    'order_number' => null,
+                ],
+            ],
+        ],
+    ];
+
+    $payload = json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+
+    $secret = 'whsec_test';
+    $timestamp = (string) now()->timestamp;
+    $signature = hash_hmac('sha256', $timestamp . '.' . $payload, $secret);
+    $signatureHeader = 't=' . $timestamp . ',v1=' . $signature;
+
+    config(['services.stripe.webhook_secret' => $secret]);
+
+    $request = Request::create(
+        '/stripe/webhook',
+        'POST',
+        content: $payload,
+    );
+
+    $request->headers->set('Stripe-Signature', $signatureHeader);
+    $request->headers->set('Content-Type', 'application/json');
+
+    $response = app(StripeWebhookController::class)->handle($request);
+
+    expect($response->getStatusCode())->toBe(200);
+
+    $order->refresh();
+    $invoice = Invoice::where('order_id', $order->id)->first();
+
+    expect($invoice)->not->toBeNull();
+    expect($invoice->status)->toBe('paid');
+    expect((float) $invoice->subtotal)->toBe((float) $order->subtotal);
+    expect((float) $invoice->tax_total)->toBe(0.0);
+    expect((float) $invoice->total)->toBe((float) $order->total);
+});


### PR DESCRIPTION
## Summary
- add a CreateInvoiceFromOrder service that builds paid invoices from an order's totals and generates invoice numbers
- trigger invoice creation after markPaid transitions in the model, service layer, and Stripe webhook handler
- ensure Filament order actions handle enum-backed statuses and add feature tests covering the Filament action and Stripe webhook invoice creation

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d66a40000083318a6eb2505b1f638d