### PR TITLE
Prevent Slack alerts for non-customer order messages

### DIFF
--- a/app/Jobs/SendOrderMessageToSlack.php
+++ b/app/Jobs/SendOrderMessageToSlack.php
@@ -21,12 +21,23 @@ class SendOrderMessageToSlack
             return;
         }
 
-        $message = $event->message->loadMissing('order.user');
+        $message = $event->message->loadMissing('order.user', 'user');
         $order = $message->order;
 
         if ($order === null) {
             Log::warning('Cannot send Slack notification: message order is missing.', [
                 'message_id' => $message->getKey(),
+            ]);
+
+            return;
+        }
+
+        if ($order->user_id === null || $message->user_id !== $order->user_id) {
+            Log::info('Skipping Slack notification for order message: author is not the order customer.', [
+                'message_id' => $message->getKey(),
+                'order_id' => $order->getKey(),
+                'message_user_id' => $message->user_id,
+                'order_user_id' => $order->user_id,
             ]);
 
             return;

--- a/tests/Feature/OrderMessageSlackNotificationTest.php
+++ b/tests/Feature/OrderMessageSlackNotificationTest.php
@@ -47,4 +47,26 @@ class OrderMessageSlackNotificationTest extends TestCase
                 && str_contains($data['blocks'][0]['text']['text'] ?? '', $user->name);
         });
     }
+
+    public function test_slack_notification_is_not_sent_for_admin_messages(): void
+    {
+        Http::fake();
+
+        config([
+            'services.slack.order_messages' => [
+                'webhook_url' => 'https://hooks.slack.test/services/T000/B000/XXXX',
+            ],
+        ]);
+
+        $customer = User::factory()->create();
+        $order = Order::factory()->for($customer)->create();
+
+        $admin = User::factory()->create();
+
+        $service = app(OrderMessageService::class);
+
+        $service->create($order, $admin->getKey(), 'Адмінське повідомлення.');
+
+        Http::assertSentCount(0);
+    }
 }


### PR DESCRIPTION
## Summary
- guard the Slack notification job to only post customer-authored order messages and retain the existing admin link payload
- add a feature test ensuring admin-authored messages do not trigger Slack webhooks

## Testing
- php artisan test --testsuite=Feature *(fails: existing Tests\Feature\Auth\RegistrationTest > it sends verification and welcome mails when registering)*

------
https://chatgpt.com/codex/tasks/task_e_68d6874bdd308331986482a0e8ca9f85